### PR TITLE
Ensure filler fields use real offsets for unique naming

### DIFF
--- a/copybook-core/src/layout.rs
+++ b/copybook-core/src/layout.rs
@@ -94,9 +94,6 @@ pub fn resolve_layout(schema: &mut Schema) -> Result<()> {
         ));
     }
     
-    // Update FILLER field names with actual offsets
-    update_filler_names(&mut schema.fields);
-    
     Ok(())
 }
 
@@ -479,18 +476,6 @@ fn detect_tail_odo(schema: &mut Schema, context: &LayoutContext) {
 }
 
 /// Update FILLER field names with actual byte offsets
-fn update_filler_names(fields: &mut [Field]) {
-    for field in fields {
-        if field.name.starts_with("_filler_") && field.name.ends_with('0') {
-            // Update FILLER name with actual offset
-            field.name = format!("_filler_{:08}", field.offset);
-        }
-        
-        // Recursively update children
-        update_filler_names(&mut field.children);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/copybook-core/src/lib.rs
+++ b/copybook-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod schema;
 pub use error::{Error, ErrorCode, ErrorContext, Result};
 pub use error_reporter::{ErrorReporter, ErrorMode, ErrorSeverity, ErrorSummary, ErrorReport};
 pub use schema::{Field, FieldKind, Occurs, Schema, TailODO};
+pub use parser::{ParseOptions, parse_with_options};
 
 /// Parse a COBOL copybook into a structured schema
 /// 

--- a/copybook-core/tests/comprehensive_parser_tests.rs
+++ b/copybook-core/tests/comprehensive_parser_tests.rs
@@ -3,7 +3,7 @@
 //! This test suite validates the parser's handling of various COBOL copybook formats
 //! according to the normative grammar rules specified in the design document.
 
-use copybook_core::{parse_copybook, ErrorCode, FieldKind, Occurs};
+use copybook_core::{parse_copybook, parse_with_options, ParseOptions, ErrorCode, FieldKind, Occurs};
 
 #[test]
 fn test_fixed_form_vs_free_form_detection() {
@@ -230,8 +230,9 @@ fn test_filler_field_naming_normative() {
    05 FIELD2 PIC X(5).
    05 FILLER PIC X(2).
 "#;
-    
-    let schema = parse_copybook(with_filler).unwrap();
+
+    let opts = ParseOptions { emit_filler: true, ..Default::default() };
+    let schema = parse_with_options(with_filler, opts).unwrap();
     assert_eq!(schema.fields.len(), 1);
     
     let root = &schema.fields[0];
@@ -239,9 +240,26 @@ fn test_filler_field_naming_normative() {
     
     // Check FILLER naming (offset-based)
     assert_eq!(root.children[0].name, "FIELD1");
-    assert_eq!(root.children[1].name, "_filler_5"); // Offset 5
+    assert_eq!(root.children[1].name, "_filler_00000005"); // Offset 5
     assert_eq!(root.children[2].name, "FIELD2");
-    assert_eq!(root.children[3].name, "_filler_13"); // Offset 13
+    assert_eq!(root.children[3].name, "_filler_00000013"); // Offset 13
+}
+
+#[test]
+fn test_multiple_filler_fields_distinct() {
+    let copybook = r#"
+01 RECORD.
+   05 FILLER PIC X(1).
+   05 FILLER PIC X(2).
+   05 FILLER PIC X(3).
+"#;
+
+    let opts = ParseOptions { emit_filler: true, ..Default::default() };
+    let schema = parse_with_options(copybook, opts).unwrap();
+
+    let root = &schema.fields[0];
+    let names: Vec<&str> = root.children.iter().map(|f| f.name.as_str()).collect();
+    assert_eq!(names, vec!["_filler_00000000", "_filler_00000001", "_filler_00000003"]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- compute offsets for all fields during layout resolution
- finalize FILLER names with their byte offsets and skip duplicate handling
- add parser options helper and tests to ensure multiple FILLER fields get unique names

## Testing
- `cargo test -q -p copybook-core test_filler_field_naming_normative -- --exact`
- `cargo test -q -p copybook-core test_multiple_filler_fields_distinct -- --exact`


------
https://chatgpt.com/codex/tasks/task_e_68b6ed4a4800833396ad124a876153f0