### PR TITLE
Implement full field decoding and propagate schema fingerprint

### DIFF
--- a/copybook-cli/src/utils.rs
+++ b/copybook-cli/src/utils.rs
@@ -1,6 +1,5 @@
 //! Utility functions for CLI operations
 
-use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
@@ -40,25 +39,8 @@ where
     Ok(())
 }
 
-/// Create a temporary file path for atomic operations
-/// 
-/// This generates a temporary file name in the same directory as the target file
-/// with a .tmp suffix and random component.
-pub fn temp_path_for(target: &Path) -> PathBuf {
-    let mut temp_name = target.file_name()
-        .unwrap_or_else(|| std::ffi::OsStr::new("output"))
-        .to_os_string();
-    temp_name.push(".tmp");
-    
-    if let Some(parent) = target.parent() {
-        parent.join(temp_name)
-    } else {
-        PathBuf::from(temp_name)
-    }
-}
-
 /// Determine exit code based on processing results
-/// 
+///
 /// According to the normative specification:
 /// - warnings → 0 (success with warnings)
 /// - any errors → 1 (completed with errors) 

--- a/copybook-codec/src/json.rs
+++ b/copybook-codec/src/json.rs
@@ -317,7 +317,7 @@ impl<W: Write> JsonWriter<W> {
         
         self.json_buffer.push_str("\"__schema_id\":\"");
         // TODO: Implement schema fingerprinting
-        self.json_buffer.push_str("placeholder_fingerprint");
+        self.json_buffer.push_str(&schema.fingerprint);
         self.json_buffer.push('"');
 
         // Add record index

--- a/copybook-codec/src/lib.rs
+++ b/copybook-codec/src/lib.rs
@@ -7,6 +7,11 @@
 pub mod lib_api;
 pub mod options;
 
+// Additional modules required for full decoding implementation
+pub mod charset;
+pub mod numeric;
+pub mod memory;
+
 pub use options::{
     Codepage, DecodeOptions, EncodeOptions, JsonNumberMode, RawMode, RecordFormat, UnmappablePolicy,
 };

--- a/copybook-codec/src/lib_api.rs
+++ b/copybook-codec/src/lib_api.rs
@@ -8,7 +8,7 @@
 //! - encode_jsonl_to_file
 //! - RecordIterator (for programmatic access)
 
-use copybook_core::{Schema, Error, ErrorCode, Result};
+use copybook_core::{Schema, Field, FieldKind, Occurs, Error, ErrorCode, Result};
 use crate::options::{DecodeOptions, EncodeOptions};
 use serde_json::Value;
 use std::io::{Read, Write, BufRead, BufReader};
@@ -157,24 +157,252 @@ impl fmt::Display for RunSummary {
 /// 
 /// * `schema` - The parsed copybook schema
 /// * `data` - The binary record data
-/// * `options` - Decoding options
-/// 
+/// * `options` - Decoding options controlling filler emission, metadata and number handling
+///
 /// # Errors
-/// 
+///
 /// Returns an error if the data cannot be decoded according to the schema
-pub fn decode_record(schema: &Schema, data: &[u8], _options: &DecodeOptions) -> Result<Value> {
-    // For now, return a minimal JSON object
-    // In a full implementation, this would decode all fields according to the schema
-    let mut json_obj = serde_json::Map::new();
-    
-    // Add basic metadata
-    json_obj.insert("__record_length".to_string(), Value::Number(serde_json::Number::from(data.len())));
-    json_obj.insert("__schema_fields".to_string(), Value::Number(serde_json::Number::from(schema.fields.len())));
-    
-    // Add placeholder for actual field decoding
-    json_obj.insert("__status".to_string(), Value::String("decoded".to_string()));
-    
+pub fn decode_record(schema: &Schema, data: &[u8], options: &DecodeOptions) -> Result<Value> {
+    use base64::{engine::general_purpose, Engine as _};
+    use serde_json::{Map, Value};
+
+    // Helper to decode a scalar field
+    fn decode_scalar(field: &Field, data: &[u8], options: &DecodeOptions, offset: usize) -> Result<Value> {
+        let end = offset + field.len as usize;
+        if end > data.len() {
+            return Err(Error::new(
+                ErrorCode::CBKD301_RECORD_TOO_SHORT,
+                format!("Field {} extends beyond record boundary", field.path),
+            ));
+        }
+        let field_data = &data[offset..end];
+
+        match &field.kind {
+            FieldKind::Alphanum { .. } => {
+                let text = crate::charset::ebcdic_to_utf8(
+                    field_data,
+                    options.codepage,
+                    options.on_decode_unmappable,
+                )?;
+                Ok(Value::String(text))
+            }
+            FieldKind::ZonedDecimal { digits, scale, signed } => {
+                let decimal = crate::numeric::decode_zoned_decimal(
+                    field_data,
+                    *digits,
+                    *scale,
+                    *signed,
+                    options.codepage,
+                    field.blank_when_zero,
+                )?;
+                let dec_str = decimal.to_fixed_scale_string(*scale);
+                match options.json_number_mode {
+                    crate::options::JsonNumberMode::Lossless => Ok(Value::String(dec_str)),
+                    crate::options::JsonNumberMode::Native => {
+                        if let Ok(num) = dec_str.parse::<f64>() {
+                            if let Some(n) = serde_json::Number::from_f64(num) {
+                                return Ok(Value::Number(n));
+                            }
+                        }
+                        Ok(Value::String(dec_str))
+                    }
+                }
+            }
+            FieldKind::PackedDecimal { digits, scale, signed } => {
+                let decimal = crate::numeric::decode_packed_decimal(field_data, *digits, *scale, *signed)?;
+                let dec_str = decimal.to_fixed_scale_string(*scale);
+                match options.json_number_mode {
+                    crate::options::JsonNumberMode::Lossless => Ok(Value::String(dec_str)),
+                    crate::options::JsonNumberMode::Native => {
+                        if let Ok(num) = dec_str.parse::<f64>() {
+                            if let Some(n) = serde_json::Number::from_f64(num) {
+                                return Ok(Value::Number(n));
+                            }
+                        }
+                        Ok(Value::String(dec_str))
+                    }
+                }
+            }
+            FieldKind::BinaryInt { bits, signed } => {
+                let int_value = crate::numeric::decode_binary_int(field_data, *bits, *signed)?;
+                match options.json_number_mode {
+                    crate::options::JsonNumberMode::Native if *bits <= 64 => {
+                        Ok(Value::Number(serde_json::Number::from(int_value)))
+                    }
+                    _ => Ok(Value::String(int_value.to_string())),
+                }
+            }
+            FieldKind::Group => Err(Error::new(
+                ErrorCode::CBKD101_INVALID_FIELD_TYPE,
+                format!("Group field {} processed as scalar", field.path),
+            )),
+        }
+    }
+
+    // Process fields recursively
+    fn process_fields(
+        fields: &[Field],
+        data: &[u8],
+        options: &DecodeOptions,
+        delta: usize,
+        json_obj: &mut Map<String, Value>,
+    ) -> Result<()> {
+        for field in fields {
+            // Handle FILLER fields
+            if field.name.eq_ignore_ascii_case("FILLER") && !options.emit_filler {
+                continue;
+            }
+
+            let key = if field.name.eq_ignore_ascii_case("FILLER") {
+                format!("_filler_{:08}", field.offset + delta as u32)
+            } else {
+                field.name.clone()
+            };
+
+            match &field.kind {
+                FieldKind::Group => {
+                    if let Some(occurs) = &field.occurs {
+                        let count = match occurs {
+                            Occurs::Fixed { count } => *count as usize,
+                            Occurs::ODO { max, .. } => *max as usize,
+                        };
+                        let mut array = Vec::new();
+                        for i in 0..count {
+                            let mut element_obj = Map::new();
+                            let new_delta = delta + i * field.len as usize;
+                            process_fields(&field.children, data, options, new_delta, &mut element_obj)?;
+                            array.push(Value::Object(element_obj));
+                        }
+                        json_obj.insert(key, Value::Array(array));
+                    } else if field.level <= 1 {
+                        process_fields(&field.children, data, options, delta, json_obj)?;
+                    } else {
+                        let mut group_obj = Map::new();
+                        process_fields(&field.children, data, options, delta, &mut group_obj)?;
+                        json_obj.insert(key, Value::Object(group_obj));
+                    }
+                }
+                _ => {
+                    if let Some(occurs) = &field.occurs {
+                        let count = match occurs {
+                            Occurs::Fixed { count } => *count as usize,
+                            Occurs::ODO { max, .. } => *max as usize,
+                        };
+                        let element_size = field.len as usize / count.max(1);
+                        let mut array = Vec::new();
+                        for i in 0..count {
+                            let offset = field.offset as usize + delta + i * element_size;
+                            let mut element_field = field.clone();
+                            element_field.len = element_size as u32;
+                            element_field.occurs = None;
+                            let value = decode_scalar(&element_field, data, options, offset)?;
+                            array.push(value);
+                        }
+                        json_obj.insert(key, Value::Array(array));
+                    } else {
+                        let offset = field.offset as usize + delta;
+                        let value = decode_scalar(field, data, options, offset)?;
+                        json_obj.insert(key.clone(), value);
+
+                        // Add raw field data if requested
+                        if matches!(options.emit_raw, crate::options::RawMode::Field) {
+                            let end = offset + field.len as usize;
+                            if end <= data.len() {
+                                let encoded = general_purpose::STANDARD.encode(&data[offset..end]);
+                                json_obj.insert(format!("{}_raw_b64", key), Value::String(encoded));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+
+    let mut json_obj = Map::new();
+    process_fields(&schema.fields, data, options, 0, &mut json_obj)?;
+
+    if options.emit_meta {
+        json_obj.insert("__schema_id".to_string(), Value::String(schema.fingerprint.clone()));
+        json_obj.insert("__record_index".to_string(), Value::Number(1.into()));
+        json_obj.insert("__offset".to_string(), Value::Number(0.into()));
+        json_obj.insert("__length".to_string(), Value::Number(data.len().into()));
+    }
+
+    if matches!(options.emit_raw, crate::options::RawMode::Record | crate::options::RawMode::RecordRDW) {
+        let encoded = general_purpose::STANDARD.encode(data);
+        json_obj.insert("__raw_b64".to_string(), Value::String(encoded));
+    }
+
     Ok(Value::Object(json_obj))
+}
+
+fn count_bwz_warnings(
+    fields: &[Field],
+    data: &[u8],
+    options: &DecodeOptions,
+    delta: usize,
+) -> u64 {
+    fn check(field: &Field, slice: &[u8], options: &DecodeOptions) -> u64 {
+        if field.blank_when_zero {
+            let is_all_spaces = slice.iter().all(|&b| match options.codepage {
+                crate::Codepage::ASCII => b == b' ',
+                _ => b == 0x40,
+            });
+            if is_all_spaces {
+                return 1;
+            }
+        }
+        0
+    }
+
+    let mut warnings = 0;
+    for field in fields {
+        match &field.kind {
+            FieldKind::Group => {
+                if let Some(occurs) = &field.occurs {
+                    let count = match occurs {
+                        Occurs::Fixed { count } => *count as usize,
+                        Occurs::ODO { max, .. } => *max as usize,
+                    };
+                    for i in 0..count {
+                        warnings += count_bwz_warnings(
+                            &field.children,
+                            data,
+                            options,
+                            delta + i * field.len as usize,
+                        );
+                    }
+                } else {
+                    warnings += count_bwz_warnings(&field.children, data, options, delta);
+                }
+            }
+            _ => {
+                if let Some(occurs) = &field.occurs {
+                    let count = match occurs {
+                        Occurs::Fixed { count } => *count as usize,
+                        Occurs::ODO { max, .. } => *max as usize,
+                    };
+                    let element_size = field.len as usize / count.max(1);
+                    for i in 0..count {
+                        let offset = field.offset as usize + delta + i * element_size;
+                        if offset + element_size <= data.len() {
+                            warnings +=
+                                check(field, &data[offset..offset + element_size], options);
+                        }
+                    }
+                } else {
+                    let offset = field.offset as usize + delta;
+                    if offset + field.len as usize <= data.len() {
+                        warnings +=
+                            check(field, &data[offset..offset + field.len as usize], options);
+                    }
+                }
+            }
+        }
+    }
+    warnings
 }
 
 /// Encode JSON data to binary using the provided schema
@@ -230,47 +458,68 @@ pub fn decode_file_to_jsonl(
     let record_length = schema.lrecl_fixed.unwrap_or(1024) as usize;
     let mut buffer = vec![0u8; record_length];
     let mut record_count = 0u64;
-    
-    loop {
-        // Try to read a record
-        match input.read_exact(&mut buffer) {
-            Ok(()) => {
-                record_count += 1;
-                summary.bytes_processed += record_length as u64;
-                
-                // Decode the record
-                match decode_record(schema, &buffer, options) {
-                    Ok(json_value) => {
-                        // Write as JSONL
-                        serde_json::to_writer(&mut output, &json_value)
-                            .map_err(|e| Error::new(ErrorCode::CBKC201_JSON_WRITE_ERROR, e.to_string()))?;
-                        writeln!(output)
-                            .map_err(|e| Error::new(ErrorCode::CBKC201_JSON_WRITE_ERROR, e.to_string()))?;
+
+    'outer: loop {
+        let mut read = 0;
+        while read < record_length {
+            match input.read(&mut buffer[read..record_length]) {
+                Ok(0) => {
+                    if read == 0 {
+                        break 'outer;
+                    } else if record_count == 0 {
+                        return Err(Error::new(
+                            ErrorCode::CBKD301_RECORD_TOO_SHORT,
+                            "Record shorter than expected".to_string(),
+                        ));
+                    } else {
+                        break 'outer;
                     }
-                    Err(_) => {
-                        summary.records_with_errors += 1;
-                        // In lenient mode, continue processing
-                        if options.strict_mode {
-                            break;
+                }
+                Ok(n) => read += n,
+                Err(e) => {
+                    if e.kind() == std::io::ErrorKind::UnexpectedEof {
+                        if read == 0 {
+                            break 'outer;
+                        } else if record_count == 0 {
+                            return Err(Error::new(
+                                ErrorCode::CBKD301_RECORD_TOO_SHORT,
+                                e.to_string(),
+                            ));
+                        } else {
+                            break 'outer;
                         }
+                    } else {
+                        return Err(Error::new(ErrorCode::CBKD301_RECORD_TOO_SHORT, e.to_string()));
                     }
                 }
             }
-            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
-                // End of file
-                break;
+        }
+
+        record_count += 1;
+        summary.bytes_processed += record_length as u64;
+
+        match decode_record(schema, &buffer, options) {
+            Ok(json_value) => {
+                serde_json::to_writer(&mut output, &json_value)
+                    .map_err(|e| Error::new(ErrorCode::CBKC201_JSON_WRITE_ERROR, e.to_string()))?;
+                writeln!(output)
+                    .map_err(|e| Error::new(ErrorCode::CBKC201_JSON_WRITE_ERROR, e.to_string()))?;
+                summary.warnings += count_bwz_warnings(&schema.fields, &buffer, options, 0);
             }
             Err(e) => {
-                return Err(Error::new(ErrorCode::CBKD301_RECORD_TOO_SHORT, e.to_string()));
+                summary.records_with_errors += 1;
+                if options.strict_mode {
+                    return Err(e);
+                }
             }
         }
     }
-    
+
     summary.records_processed = record_count;
     summary.processing_time_ms = start_time.elapsed().as_millis() as u64;
     summary.calculate_throughput();
-    summary.schema_fingerprint = "placeholder_fingerprint".to_string();
-    
+    summary.schema_fingerprint = schema.fingerprint.clone();
+
     Ok(summary)
 }
 
@@ -331,7 +580,7 @@ pub fn encode_jsonl_to_file(
     summary.records_processed = record_count;
     summary.processing_time_ms = start_time.elapsed().as_millis() as u64;
     summary.calculate_throughput();
-    summary.schema_fingerprint = "placeholder_fingerprint".to_string();
+    summary.schema_fingerprint = schema.fingerprint.clone();
     
     Ok(summary)
 }
@@ -439,23 +688,38 @@ pub fn iter_records<R: Read>(
 mod tests {
     use super::*;
     use copybook_core::parse_copybook;
+    use crate::Codepage;
     use std::io::Cursor;
 
     #[test]
     fn test_decode_record() {
         let copybook_text = r#"
             01 RECORD.
-               05 ID PIC 9(3).
-               05 NAME PIC X(5).
+               05 ID      PIC 9(3).
+               05 AMOUNT  PIC S9(3) COMP-3.
+               05 COUNT   PIC 9(4) COMP.
+               05 NAME    PIC X(5).
         "#;
-        
+
         let schema = parse_copybook(copybook_text).unwrap();
-        let options = DecodeOptions::default();
-        let data = b"001ALICE";
-        
-        let result = decode_record(&schema, data, &options).unwrap();
-        assert!(result.is_object());
-        assert!(result.get("__record_length").is_some());
+        let options = DecodeOptions::new()
+            .with_codepage(Codepage::ASCII)
+            .with_emit_meta(true);
+
+        // Build record data
+        let mut data = Vec::new();
+        data.extend_from_slice(b"123"); // ID
+        let packed = crate::numeric::encode_packed_decimal("123", 3, 0, true).unwrap();
+        data.extend_from_slice(&packed); // AMOUNT
+        data.extend_from_slice(&42u16.to_be_bytes()); // COUNT
+        data.extend_from_slice(b"ALICE"); // NAME
+
+        let result = decode_record(&schema, &data, &options).unwrap();
+        assert_eq!(result["ID"], "123");
+        assert_eq!(result["AMOUNT"], "123");
+        assert_eq!(result["COUNT"], "42");
+        assert_eq!(result["NAME"], "ALICE");
+        assert_eq!(result["__schema_id"], schema.fingerprint);
     }
 
     #[test]
@@ -502,22 +766,33 @@ mod tests {
     fn test_decode_file_to_jsonl() {
         let copybook_text = r#"
             01 RECORD.
-               05 ID PIC 9(3).
-               05 NAME PIC X(5).
+               05 ID      PIC 9(3).
+               05 AMOUNT  PIC S9(3) COMP-3.
+               05 COUNT   PIC 9(4) COMP.
+               05 NAME    PIC X(5).
         "#;
-        
+
         let schema = parse_copybook(copybook_text).unwrap();
-        let options = DecodeOptions::default();
-        
-        // Create test input
-        let input_data = vec![0u8; 16]; // Two 8-byte records
+        let options = DecodeOptions::new().with_codepage(Codepage::ASCII);
+
+        // Build test record
+        let mut record = Vec::new();
+        record.extend_from_slice(b"123");
+        let packed = crate::numeric::encode_packed_decimal("123", 3, 0, true).unwrap();
+        record.extend_from_slice(&packed);
+        record.extend_from_slice(&42u16.to_be_bytes());
+        record.extend_from_slice(b"ALICE");
+
+        // Two records input
+        let input_data = [record.clone(), record.clone()].concat();
         let input = Cursor::new(input_data);
-        
+
         // Create output buffer
         let mut output = Vec::new();
-        
+
         let summary = decode_file_to_jsonl(&schema, input, &mut output, &options).unwrap();
-        assert!(summary.records_processed > 0);
+        assert_eq!(summary.schema_fingerprint, schema.fingerprint);
+        assert_eq!(summary.records_processed, 2);
         assert!(!output.is_empty());
     }
 
@@ -542,6 +817,7 @@ mod tests {
         
         let summary = encode_jsonl_to_file(&schema, input, &mut output, &options).unwrap();
         assert_eq!(summary.records_processed, 2);
+        assert_eq!(summary.schema_fingerprint, schema.fingerprint);
         assert!(!output.is_empty());
     }
 }

--- a/copybook-codec/src/memory.rs
+++ b/copybook-codec/src/memory.rs
@@ -509,7 +509,7 @@ mod tests {
         assert!(!processor.is_memory_pressure());
         
         // Simulate memory usage
-        processor.update_memory_usage(800 * 1024); // 800 KB
+        processor.update_memory_usage(900 * 1024); // 900 KB
         assert!(processor.is_memory_pressure()); // Should be over 80% threshold
         
         // Record processing

--- a/copybook-codec/src/processor.rs
+++ b/copybook-codec/src/processor.rs
@@ -248,7 +248,7 @@ impl DecodeProcessor {
             warnings: 0, // TODO: Get from error_reporter
             processing_time_ms,
             bytes_processed: self.bytes_processed,
-            schema_fingerprint: "placeholder".to_string(), // TODO: Implement fingerprinting
+            schema_fingerprint: String::new(), // TODO: Implement fingerprinting
             input_file_hash: None,
             throughput_mbps: 0.0,
             error_summary: None, // TODO: Get from error_reporter

--- a/copybook-codec/tests/comprehensive_numeric_tests.rs
+++ b/copybook-codec/tests/comprehensive_numeric_tests.rs
@@ -273,14 +273,14 @@ fn test_fixed_scale_rendering_normative() {
    05 SCALE-0 PIC 9(5) COMP-3.
    05 SCALE-2 PIC 9(5)V99 COMP-3.
    05 SCALE-4 PIC 9(3)V9999 COMP-3.
-   05 NEGATIVE-SCALE PIC 9(3)V99 COMP-3.
+   05 NEGATIVE-SCALE PIC S9(3)V99 COMP-3.
 "#;
     
     let schema = parse_copybook(copybook).unwrap();
     let options = create_test_decode_options(Codepage::ASCII, false);
     
     // Test data representing: 12345, 123.45, 1.2345, -12.34
-    let test_data = b"\x01\x23\x45\x0C\x01\x23\x45\x0C\x12\x34\x50\x0C\x01\x23\x4D";
+    let test_data = b"\x12\x34\x5C\x12\x34\x50\x0C\x00\x12\x34\x5C\x01\x23\x4D";
     let input = Cursor::new(test_data);
     let mut output = Vec::new();
     

--- a/copybook-core/src/parser.rs
+++ b/copybook-core/src/parser.rs
@@ -786,8 +786,8 @@ impl Parser {
             FieldKind::ZonedDecimal { digits, signed, .. } => {
                 let bits = match digits {
                     1..=4 => 16,
-                    5..=8 => 32,
-                    9..=18 => 64,
+                    5..=9 => 32,
+                    10..=18 => 64,
                     _ => {
                         return Err(Error::new(
                             ErrorCode::CBKP001_SYNTAX,

--- a/copybook-core/src/pic.rs
+++ b/copybook-core/src/pic.rs
@@ -167,7 +167,7 @@ impl PicClause {
             ));
         }
 
-        if digits > 38 {
+        if kind == PicKind::NumericDisplay && digits > 38 {
             return Err(Error::new(
                 ErrorCode::CBKP001_SYNTAX,
                 format!("PIC clause too long: {} digits (max 38)", digits),

--- a/docs/LIBRARY_API.md
+++ b/docs/LIBRARY_API.md
@@ -629,14 +629,15 @@ mod tests {
         "#;
         
         let schema = parse_copybook(copybook).unwrap();
-        let opts = DecodeOptions::default();
+        let opts = DecodeOptions::default().with_emit_meta(true);
         let mut decoder = RecordDecoder::new(&schema, &opts).unwrap();
-        
+
         let data = b"1234JOHN      ";
         let json = decoder.decode_record(data).unwrap();
-        
+
         assert_eq!(json["ID"], "1234");
         assert_eq!(json["NAME"], "JOHN      ");
+        assert_eq!(json["__schema_id"], schema.fingerprint);
     }
 }
 ```


### PR DESCRIPTION
## Summary
- refine binary width mapping and relax PIC length checks for alphanumeric fields
- improve ASCII zoned-decimal handling, packed decimal sign acceptance, and include BLANK WHEN ZERO warnings
- flatten top-level groups and enhance record reading with strict/lenient behaviors and warning accounting
- correct packed-decimal byte sizing and adjust tests for fixed-scale rendering and flattened records

## Dependencies
⚠️ **This PR depends on PR #4** - "Use schema fingerprint in JSON metadata" must be merged first.

## Testing
- `cargo test -p copybook-codec --test comprehensive_numeric_tests`
- `cargo test -p copybook-codec --lib`

------
https://chatgpt.com/codex/tasks/task_e_68b7052e294c8333830b2fbe940bcca1