### PR TITLE
Clean up test helpers for pedantic clippy

### DIFF
--- a/copybook-core/tests/integration_layout.rs
+++ b/copybook-core/tests/integration_layout.rs
@@ -5,21 +5,23 @@ use copybook_core::{FieldKind, Occurs, parse_copybook};
 #[test]
 fn test_comp3_parsing_debug() {
     let input = "01 BALANCE PIC S9(7)V99 COMP-3.";
-    println!("Testing input: {}", input);
+    println!("Testing input: {input}");
 
     let mut lexer = copybook_core::lexer::Lexer::new(input);
     let tokens = lexer.tokenize();
 
     println!("Tokens:");
     for (i, token_pos) in tokens.iter().enumerate() {
-        println!("  {}: {:?}", i, token_pos.token);
+        println!("  {i}: {:?}", token_pos.token);
     }
 
     let schema = parse_copybook(input).unwrap();
     let field = &schema.fields[0];
     println!(
-        "Field: name={}, kind={:?}, len={}",
-        field.name, field.kind, field.len
+        "Field: name={name}, kind={kind:?}, len={len}",
+        name = field.name,
+        kind = field.kind,
+        len = field.len
     );
 
     // Should be PackedDecimal, not ZonedDecimal
@@ -28,7 +30,7 @@ fn test_comp3_parsing_debug() {
 
 #[test]
 fn test_complex_layout_resolution() {
-    let copybook = r#"
+    let copybook = r"
 01 CUSTOMER-RECORD.
    05 CUSTOMER-ID PIC X(10).
    05 CUSTOMER-NAME.
@@ -37,7 +39,7 @@ fn test_complex_layout_resolution() {
    05 BALANCE PIC S9(7)V99 COMP-3.
    05 ACCOUNT-COUNT PIC 9(3).
    05 ACCOUNTS PIC X(15) OCCURS 5 TIMES DEPENDING ON ACCOUNT-COUNT.
-"#;
+";
 
     let schema = parse_copybook(copybook).unwrap();
 
@@ -120,13 +122,13 @@ fn test_complex_layout_resolution() {
 
 #[test]
 fn test_synchronized_binary_alignment() {
-    let copybook = r#"
+    let copybook = r"
 01 RECORD-WITH-ALIGNMENT.
    05 CHAR-FIELD PIC X(1).
    05 BINARY-FIELD PIC 9(5) USAGE COMP SYNCHRONIZED.
    05 ANOTHER-CHAR PIC X(3).
    05 ANOTHER-BINARY PIC 9(9) USAGE COMP SYNCHRONIZED.
-"#;
+";
 
     let schema = parse_copybook(copybook).unwrap();
 
@@ -164,12 +166,12 @@ fn test_synchronized_binary_alignment() {
 
 #[test]
 fn test_redefines_with_different_sizes() {
-    let copybook = r#"
+    let copybook = r"
 01 ORIGINAL-FIELD PIC X(20).
 01 SHORT-REDEFINES REDEFINES ORIGINAL-FIELD PIC 9(10).
 01 LONG-REDEFINES REDEFINES ORIGINAL-FIELD PIC X(30).
 01 NEXT-FIELD PIC X(5).
-"#;
+";
 
     let schema = parse_copybook(copybook).unwrap();
 

--- a/copybook-gen/examples/generate_test_suite.rs
+++ b/copybook-gen/examples/generate_test_suite.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("\nTest breakdown by tag:");
     for (tag, count) in &stats.tests_by_tag {
-        println!("  {}: {} tests", tag, count);
+        println!("  {tag}: {count} tests");
     }
 
     // Example: Create a custom test suite


### PR DESCRIPTION
## Summary
- Simplify metadata test writer to avoid precision-loss casts and remove unused `Result`
- Switch raw string literals to `r""` and use captured format args in tests/examples

## Testing
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings -W clippy::pedantic`


------
https://chatgpt.com/codex/tasks/task_e_68ba0667e1348333bbbe59497b43a6e9