### PR TITLE
fix: skip offset-based filler fields

### DIFF
--- a/copybook-codec/src/json.rs
+++ b/copybook-codec/src/json.rs
@@ -447,6 +447,13 @@ impl<W: Write> JsonWriter<W> {
         record_index: u64,
         byte_offset: u64,
     ) -> Result<()> {
+        // Skip FILLER fields unless explicitly requested
+        if (field.name.eq_ignore_ascii_case("FILLER") || field.name.starts_with("_filler_"))
+            && !self.options.emit_filler
+        {
+            return Ok(());
+        }
+
         // Handle REDEFINES: emit all views in declaration order
         if field.redefines_of.is_some() {
             // This is a redefining field - process it normally
@@ -715,11 +722,15 @@ impl<W: Write> JsonWriter<W> {
 
     /// Get field name with duplicate disambiguation
     fn get_field_name(&self, field: &Field) -> String {
-        // Handle FILLER fields
-        if field.name.eq_ignore_ascii_case("FILLER") {
+        // Handle FILLER fields (original or offset-based)
+        if field.name.eq_ignore_ascii_case("FILLER") || field.name.starts_with("_filler_") {
             if self.options.emit_filler {
-                // _filler_<offset> - NORMATIVE
-                format!("_filler_{:08}", field.offset)
+                if field.name.eq_ignore_ascii_case("FILLER") {
+                    // _filler_<offset> - NORMATIVE
+                    format!("_filler_{:08}", field.offset)
+                } else {
+                    field.name.clone()
+                }
             } else {
                 // Skip FILLER fields by default
                 String::new()


### PR DESCRIPTION
## Summary
- ignore filler fields that are named using byte offsets when `emit_filler` is disabled
- treat `_filler_` names as fillers when resolving JSON field names

## Testing
- `cargo test`
- `cargo clippy`


------
https://chatgpt.com/codex/tasks/task_e_68ba2445978c8333a593d361ca76d615