### PR TITLE
fix: pass schema through encoder helpers

### DIFF
--- a/copybook-core/src/schema.rs
+++ b/copybook-core/src/schema.rs
@@ -295,6 +295,25 @@ impl Schema {
         None
     }
 
+    /// Find all fields that redefine the field at the given path
+    #[must_use]
+    pub fn find_redefining_fields(&self, path: &str) -> Vec<&Field> {
+        let mut result = Vec::new();
+        Self::collect_redefining_fields(&self.fields, path, &mut result);
+        result
+    }
+
+    fn collect_redefining_fields<'a>(fields: &'a [Field], path: &str, result: &mut Vec<&'a Field>) {
+        for field in fields {
+            if let Some(ref redefines_of) = field.redefines_of
+                && redefines_of == path
+            {
+                result.push(field);
+            }
+            Self::collect_redefining_fields(&field.children, path, result);
+        }
+    }
+
     /// Get all fields in a flat list (pre-order traversal)
     #[must_use]
     pub fn all_fields(&self) -> Vec<&Field> {


### PR DESCRIPTION
## Summary
- propagate `Schema` through JsonEncoder helpers instead of referencing nonexistent `self.schema`
- add `Schema::find_redefining_fields` to support REDEFINES lookups

## Testing
- `cargo +nightly clippy -p copybook-core`
- `cargo +nightly clippy -p copybook-codec`
- `cargo +nightly clippy -p copybook-cli`
- `cargo +nightly test -p copybook-cli`
- `cargo +nightly test -p copybook-codec`


------
https://chatgpt.com/codex/tasks/task_e_68ba243e8f2c8333a94674eabf06a125