### PR TITLE
test: use assert for ODO validation

### DIFF
--- a/copybook-core/src/parser.rs
+++ b/copybook-core/src/parser.rs
@@ -1316,14 +1316,17 @@ mod tests {
 
         // Check ODO field
         let odo_field = &schema.fields[1];
+        assert!(
+            matches!(&odo_field.occurs, Some(Occurs::ODO { .. })),
+            "Expected ODO occurs, got {:?}",
+            odo_field.occurs
+        );
         if let Some(Occurs::ODO {
             max, counter_path, ..
         }) = &odo_field.occurs
         {
             assert_eq!(*max, 5);
             assert_eq!(counter_path, "COUNTER");
-        } else {
-            panic!("Expected ODO occurs, got {:?}", odo_field.occurs);
         }
     }
 


### PR DESCRIPTION
## Summary
- replace manual panic in ODO validation test with assertion

## Testing
- `cargo test -p copybook-core`


------
https://chatgpt.com/codex/tasks/task_e_68ba652ff0ac8333b1c005e7db38afe2