### PR TITLE
Fix doctest example for RecordIterator

### DIFF
--- a/copybook-codec/src/iterator.rs
+++ b/copybook-codec/src/iterator.rs
@@ -21,13 +21,16 @@ const FIXED_FORMAT_LRECL_MISSING: &str = "Fixed format requires a fixed record l
 /// ```rust,no_run
 /// use copybook_codec::{RecordIterator, DecodeOptions};
 /// use copybook_core::parse_copybook;
-/// use std::fs::File;
+/// # use std::io::Cursor;
 ///
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let copybook_text = "01 RECORD.\n   05 ID PIC 9(5).\n   05 NAME PIC X(20).";
-/// let schema = parse_copybook(copybook_text)?;
-/// let file = File::open("data.bin")?;
+/// let mut schema = parse_copybook(copybook_text)?;
+/// schema.lrecl_fixed = Some(25);
 /// let options = DecodeOptions::default();
+/// # let record_bytes = b"00001ALICE               ";
+/// # let file = Cursor::new(&record_bytes[..]);
+/// // let file = std::fs::File::open("data.bin")?;
 ///
 /// let mut iterator = RecordIterator::new(file, &schema, &options)?;
 ///


### PR DESCRIPTION
### **User description**
## Summary
- fix the `RecordIterator` documentation example by using an in-memory reader and setting the fixed record length so the doctest builds

## Testing
- cargo test -p copybook-codec --doc

------
https://chatgpt.com/codex/tasks/task_e_68f141887d04833395a7343c265e16c7


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fixed RecordIterator doctest by using in-memory Cursor reader

- Set required fixed record length (LRECL) in schema

- Replaced file I/O with embedded test data for reproducibility

- Made schema mutable to allow LRECL configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["File-based example"] -->|"Replace with in-memory"| B["Cursor reader"]
  C["Missing LRECL"] -->|"Set schema.lrecl_fixed"| D["Fixed record length"]
  E["External file dependency"] -->|"Use embedded bytes"| F["Self-contained test"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>iterator.rs</strong><dd><code>Update doctest to use in-memory reader and fixed LRECL</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

copybook-codec/src/iterator.rs

<ul><li>Replaced <code>std::fs::File</code> import with <code>std::io::Cursor</code> for in-memory <br>testing<br> <li> Made schema mutable to allow setting <code>lrecl_fixed</code> property<br> <li> Added embedded test record bytes instead of relying on external file<br> <li> Set <code>schema.lrecl_fixed = Some(25)</code> to satisfy fixed format requirement<br> <li> Commented out original file-based example for reference</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/copybook-rs/pull/108/files#diff-e4138a6824ecc30eed2b15f58caccdc9f6700aa1bf8e739699e2096c0e635e32">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

