### PR TITLE
ci: durable fixes for docs-only PRs and perf workflow

### DIFF
--- a/.github/workflows/ci-quick.yml
+++ b/.github/workflows/ci-quick.yml
@@ -39,7 +39,6 @@ jobs:
               - 'scripts/ci/**'
 
   test:
-    if: needs.changes.outputs.rust == 'true'
     needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -47,6 +46,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Short-circuit when no Rust changed
+        if: needs.changes.outputs.rust != 'true'
+        run: |
+          echo "No Rust changes detected; CI Quick gate success (policy: path-filter)"
+          exit 0
 
       - name: Fetch PR base for security diff
         if: ${{ github.event_name == 'pull_request' }}
@@ -58,16 +63,20 @@ jobs:
           echo "HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 
       - uses: dtolnay/rust-toolchain@stable
+        if: needs.changes.outputs.rust == 'true'
         with:
           components: rustfmt, clippy
 
       - uses: taiki-e/install-action@v2
+        if: needs.changes.outputs.rust == 'true'
         with:
           tool: cargo-nextest,cargo-deny
 
       - uses: Swatinem/rust-cache@v2
+        if: needs.changes.outputs.rust == 'true'
 
       - name: Quick gates (fmt→clippy→build→nextest→doctests)
+        if: needs.changes.outputs.rust == 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || 'HEAD~1' }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || 'HEAD' }}
@@ -75,6 +84,7 @@ jobs:
           bash scripts/ci/quick.sh
 
       - name: Security (deny; audit only if Cargo.lock changed)
+        if: needs.changes.outputs.rust == 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || 'HEAD~1' }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || 'HEAD' }}

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,6 +1,7 @@
 name: Perf Receipts
 on:
-  pull_request:
+  push:
+    branches: [main]
     paths:
       - "copybook-bench/**"
       - "copybook-codec/**"
@@ -8,6 +9,7 @@ on:
       - "scripts/bench.bat"
       - "scripts/guard-hotpaths.sh"
       - "justfile"
+  workflow_dispatch:
 
 concurrency:
   group: perf-${{ github.ref }}


### PR DESCRIPTION
### **User description**
## Summary

Establishes durable patterns for CI Quick on docs-only PRs and disables legacy perf workflow on PRs.

### Changes

1. **CI Quick: Always run test job**
   - Removes job-level `if: needs.changes.outputs.rust == 'true'` condition
   - Adds short-circuit step that exits with success when no Rust changes detected
   - Ensures required check "CI Quick / test" always succeeds (not skipped) on docs-only PRs
   - Satisfies branch protection requirements without manual intervention

2. **Perf Receipts: Main-only + workflow_dispatch**
   - Disables `pull_request` trigger (was firing on all PRs matching path filters)
   - Restricts to `push: branches: [main]` + `workflow_dispatch`
   - Removes PR noise from non-required perf checks
   - Maintains 90d receipt retention on main for baseline tracking

### Rationale

- **Unblocks docs-only PRs**: Future docs PRs won't need manual Rust nudges (#121)
- **Reduces CI noise**: Legacy perf workflow failures distracted from actual issues
- **Cost controls**: Perf benchmarks run on-demand (`perf:run` label) or on main
- **Accuracy-first**: Maintains CI Quick as single blocking gate with clean UX

### Testing

- [x] CI Quick will pass on this PR (validates short-circuit logic)
- [x] Perf workflow won't fire on this PR (validates main-only restriction)
- [ ] Manual smoke test: Create docs-only PR, verify CI Quick succeeds

### Refs

- Closes #121 (provides durable fix)
- Relates to Phase-0 sign-off (PR #117, Issue #75)

## Test Plan

- [ ] Verify CI Quick passes on this PR
- [ ] Verify Perf Receipts does not run on this PR
- [ ] Create test docs-only PR to confirm CI Quick succeeds (not skipped)


___

### **PR Type**
Enhancement, Other


___

### **Description**
- Remove job-level condition from CI Quick test job, add short-circuit step

- Ensures required check always succeeds on docs-only PRs without skipping

- Add conditional guards to individual steps to skip Rust work when unneeded

- Restrict Perf Receipts workflow to main branch and manual dispatch only

- Eliminates PR noise from legacy perf checks, reduces CI cost


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI Quick Job"] -->|"Remove job-level if"| B["Always Runs"]
  B -->|"No Rust changes"| C["Short-circuit Step"]
  C -->|"Exit 0"| D["Success Status"]
  E["Perf Receipts"] -->|"Remove pull_request"| F["Main + Dispatch Only"]
  F -->|"Reduce PR noise"| G["Cost Control"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-quick.yml</strong><dd><code>CI Quick job always runs with short-circuit logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-quick.yml

<ul><li>Removed job-level <code>if: needs.changes.outputs.rust == 'true'</code> condition <br>from test job<br> <li> Added short-circuit step that exits with success when no Rust changes <br>detected<br> <li> Added conditional guards (<code>if: needs.changes.outputs.rust == 'true'</code>) to <br>individual steps (toolchain, install-action, rust-cache, quick gates, <br>security)<br> <li> Ensures required check "CI Quick / test" always succeeds on docs-only <br>PRs</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/copybook-rs/pull/126/files#diff-17c59c5b9a2e5f0809cf26b132a08b32cd3624d71a6e162fb81d0be4b78f9177">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>perf.yml</strong><dd><code>Perf Receipts restricted to main and manual dispatch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/perf.yml

<ul><li>Changed trigger from <code>pull_request</code> to <code>push: branches: [main]</code><br> <li> Added <code>workflow_dispatch</code> for manual trigger capability<br> <li> Maintains path filters for perf-related files<br> <li> Restricts perf workflow to main branch and on-demand execution</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/copybook-rs/pull/126/files#diff-82c5d303a285e8cb2370945e1bb58c7f6c6d57b09ac32ed9b69ac619591b1030">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).