### PR TITLE
fix(ci): remove unsupported nextest JUnit report generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,12 +58,11 @@ jobs:
     - name: Install nextest
       if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable' && matrix.features == ''
       uses: taiki-e/install-action@nextest
-    - name: Run tests (nextest + junit for test-truth binding)
+    - name: Run tests (nextest)
       if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable' && matrix.features == ''
       run: |
         cargo nextest run --workspace --profile ci --failure-output=immediate --status-level=fail
         cargo nextest archive --workspace --profile ci --archive-file target/nextest/partial-archive.tar.zst
-        cargo nextest r junit --archive-file target/nextest/partial-archive.tar.zst --output-file target/nextest/junit.xml
     - name: Sync test status to docs
       if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable' && matrix.features == ''
       run: cargo run -p xtask -- docs sync-tests


### PR DESCRIPTION
### **User description**
## Summary

Fixes the Test Suite (ubuntu-latest, stable) failure caused by attempting to use unsupported nextest commands.

## Problem

PR #137 attempted to fix the nextest command by changing `nextest report junit` to `nextest r junit`, but this was incorrect because:

1. The `r` alias is for `run`, not for "report"
2. This nextest version doesn't have a `report` subcommand at all
3. The `--output-file` flag is not recognized

Error observed in CI run #19256099054:
```
error: unexpected argument '--output-file' found
```

## Solution

Remove the unsupported JUnit report generation line:

```yaml
# REMOVED:
cargo nextest r junit --archive-file target/nextest/partial-archive.tar.zst --output-file target/nextest/junit.xml
```

**Rationale:**
- Tests already run successfully and pass (639 passed, 58 skipped in last run)
- JUnit report generation is optional, not required for test execution
- Archive step retained for potential future nextest features
- Sync/verify test status steps remain unchanged and functional

## Test Plan

- [ ] CI Quick workflow passes
- [ ] Full CI workflow passes on main, specifically:
  - [ ] Code Coverage job completes successfully (from PR #137 fix)
  - [ ] Test Suite (ubuntu-latest, stable) completes successfully (this fix)
  - [ ] All 639 tests pass

## Impact

- **No functional changes** to test execution
- **No impact** on test quality gates or coverage
- **Removes optional feature** (JUnit export) that isn't supported by current nextest version
- **Unblocks** CI on main branch

---

Follow-up to #137
Resolves Test Suite failure in CI run #19256099054


___

### **PR Type**
Bug fix


___

### **Description**
- Remove unsupported nextest JUnit report generation command

- Fixes CI Test Suite job failure with '--output-file' flag error

- Simplifies workflow step by removing optional JUnit export feature

- Tests continue running successfully via nextest without report generation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI Workflow"] --> B["Install nextest"]
  B --> C["Run nextest tests"]
  C --> D["Archive test results"]
  D --> E["Sync test status"]
  E --> F["Verify test status"]
  style A fill:#f9f,stroke:#333
  style D fill:#bbf,stroke:#333
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Remove unsupported nextest JUnit report generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Removed unsupported <code>cargo nextest r junit</code> command that was causing CI <br>failures<br> <li> Updated step name from "Run tests (nextest + junit for test-truth <br>binding)" to "Run tests (nextest)"<br> <li> Retained <code>cargo nextest run</code> and <code>cargo nextest archive</code> commands which <br>work correctly<br> <li> Removed <code>--output-file target/nextest/junit.xml</code> flag that is not <br>supported by current nextest version</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/copybook-rs/pull/138/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).