### PR TITLE
fix(ci): exclude copybook-bench from blocking Test Suite matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,8 @@ jobs:
     - name: Run tests (nextest)
       if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable' && matrix.features == ''
       run: |
-        cargo nextest run --workspace --profile ci --failure-output=immediate --status-level=fail
-        cargo nextest archive --workspace --profile ci --archive-file target/nextest/partial-archive.tar.zst
+        cargo nextest run --workspace --exclude copybook-bench --profile ci --failure-output=immediate --status-level=fail
+        cargo nextest archive --workspace --exclude copybook-bench --profile ci --archive-file target/nextest/partial-archive.tar.zst
     - name: Sync test status to docs
       if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable' && matrix.features == ''
       run: cargo run -p xtask -- docs sync-tests
@@ -71,10 +71,10 @@ jobs:
       run: cargo run -p xtask -- docs verify-tests
     - name: Run tests (no features)
       if: matrix.features == '' && !(matrix.os == 'ubuntu-latest' && matrix.rust == 'stable')
-      run: cargo test --workspace
+      run: cargo test --workspace --exclude copybook-bench
     - name: Run tests (with features)
       if: matrix.features != ''
-      run: cargo test --workspace --features ${{ matrix.features }}
+      run: cargo test --workspace --exclude copybook-bench --features ${{ matrix.features }}
 
   rdw-iterator-tests:
     name: RDW iterator tests


### PR DESCRIPTION
### **User description**
## Summary
- Fixes macOS timing flake in `test_diagnostic_benchmarks` by excluding `copybook-bench` from cross-platform Test Suite job
- Timing-sensitive bench tests now run exclusively in dedicated Bench/Perf workflows
- Mirrors existing coverage exclusion pattern (line 235)

## Changes
- **Line 64-65**: Nextest run + archive → `--exclude copybook-bench` (ubuntu/stable)
- **Line 74**: Standard tests → `--exclude copybook-bench` (all other OS/rust, no features)
- **Line 77**: Feature tests → `--exclude copybook-bench` (comp3_fast, audit)

## Rationale
- **Policy consistency**: Coverage already excludes bench; Test Suite now matches
- **Signal clarity**: Timing asserts (`<1ms` JSON parse) stay in non-blocking performance lanes where they're meaningful
- **macOS stability**: Shared GH runners show variance; this keeps blocking matrix stable

## Bench Tests Still Run In
- ✅ `.github/workflows/benchmark.yml` (PERF=1 cargo bench)
- ✅ `.github/workflows/perf.yml` (performance validation)

## Test Plan
- [x] YAML formatting validated (no line wraps, consistent flags)
- [x] Nextest archive has flag parity
- [x] All three Test Suite variants updated
- [ ] CI run confirms macOS Test Suite → green
- [ ] Bench/Perf workflows still execute copybook-bench


___

### **PR Type**
Bug fix


___

### **Description**
- Exclude `copybook-bench` from Test Suite matrix to prevent macOS timing flakes

- Apply exclusion to nextest, standard tests, and feature tests consistently

- Keep benchmark tests in dedicated Bench/Perf workflows only

- Maintain policy consistency with existing coverage exclusion pattern


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI Test Suite"] -->|exclude copybook-bench| B["Nextest Run"]
  A -->|exclude copybook-bench| C["Cargo Test"]
  A -->|exclude copybook-bench| D["Feature Tests"]
  E["Benchmark Tests"] -->|run in| F["benchmark.yml"]
  E -->|run in| G["perf.yml"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Exclude copybook-bench from all test suite runs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Added <code>--exclude copybook-bench</code> flag to nextest run command (line 64)<br> <li> Added <code>--exclude copybook-bench</code> flag to nextest archive command (line <br>65)<br> <li> Added <code>--exclude copybook-bench</code> flag to standard cargo test command <br>(line 74)<br> <li> Added <code>--exclude copybook-bench</code> flag to feature cargo test command <br>(line 77)</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/copybook-rs/pull/139/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).