### PR TITLE
chore(ci): harden Test Suite with nextest pin and bench exclusion guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,47 +62,46 @@ jobs:
         tool: nextest@0.9.11
         checksum: true
     - name: Guard nextest pin
-      if: runner.os == 'Linux' && matrix.rust == 'stable' && matrix.features == ''
+      if: ${{ runner.os == 'Linux' && matrix.rust == 'stable' && matrix.features == '' }}
       shell: bash
       run: |
         set -euo pipefail
-        grep -qE '^\s+tool:\s*nextest@0\.9\.11\s*$' .github/workflows/ci.yml || {
-          echo "::error::Expected nextest to be pinned to '0.9.11' in ci.yml Install step"
+        export LC_ALL=C
+        file=".github/workflows/ci.yml"
+        # Require explicit semver pin (e.g., nextest@0.9.11), disallow floating tags.
+        if ! grep -Eq '^[[:space:]]*tool:[[:space:]]*nextest@[0-9]+\.[0-9]+\.[0-9]+[[:space:]]*$' "$file"; then
+          echo "::error::nextest must be pinned to an explicit semver (e.g., nextest@0.9.11) in $file"
           exit 1
-        }
-        echo "✅ Nextest pinned to 0.9.11"
+        fi
+        echo "✅ nextest uses an explicit semver pin"
     - name: Guard bench exclusion in Test Suite
-      if: runner.os == 'Linux' && matrix.rust == 'stable' && matrix.features == ''
+      if: ${{ runner.os == 'Linux' && matrix.rust == 'stable' && matrix.features == '' }}
       shell: bash
       run: |
         set -euo pipefail
+        export LC_ALL=C
+        file=".github/workflows/ci.yml"
 
-        # Check that all three test commands include --exclude copybook-bench
-        # (nextest run, nextest archive, and two cargo test variants)
+        # Check that all four test commands include --exclude copybook-bench
         missing=0
 
-        # Check nextest run command
-        grep -qE '^\s+cargo nextest run.*--exclude copybook-bench' .github/workflows/ci.yml || {
-          echo "::error::Missing --exclude copybook-bench in 'cargo nextest run' command"
-          missing=1
-        }
+        # nextest run
+        grep -Eq '^[[:space:]]+cargo nextest run.*--exclude[[:space:]]+copybook-bench([[:space:]]|$)' "$file" || {
+          echo "::error::Missing --exclude copybook-bench in 'cargo nextest run'"; missing=1; }
 
-        # Check nextest archive command
-        grep -qE '^\s+cargo nextest archive.*--exclude copybook-bench' .github/workflows/ci.yml || {
-          echo "::error::Missing --exclude copybook-bench in 'cargo nextest archive' command"
-          missing=1
-        }
+        # nextest archive
+        grep -Eq '^[[:space:]]+cargo nextest archive.*--exclude[[:space:]]+copybook-bench([[:space:]]|$)' "$file" || {
+          echo "::error::Missing --exclude copybook-bench in 'cargo nextest archive'"; missing=1; }
 
-        # Check cargo test commands (should have at least 2 occurrences)
-        count=$(grep -cE '^\s+run: cargo test.*--exclude copybook-bench' .github/workflows/ci.yml || echo 0)
-        if [ "$count" -lt 2 ]; then
-          echo "::error::Expected at least 2 'cargo test' commands with --exclude copybook-bench, found $count"
+        # cargo test: require ≥2 invocations with --exclude
+        ct_count=$(grep -Ec 'run:[[:space:]]+cargo test .*--exclude[[:space:]]+copybook-bench' "$file" || echo 0)
+        if [ "$ct_count" -lt 2 ]; then
+          echo "::error::Expected at least two 'cargo test' commands with --exclude copybook-bench (found $ct_count)"
           missing=1
         fi
 
-        if [ "$missing" -eq 1 ]; then
-          echo "::error::Bench exclusion guard failed. Ensure all Test Suite commands exclude copybook-bench."
-          exit 1
+        if [ "$missing" -ne 0 ]; then
+          echo "::error::Bench exclusion guard failed"; exit 1
         fi
 
         echo "✅ All Test Suite commands properly exclude copybook-bench"


### PR DESCRIPTION
### **User description**
## Summary
Adds two defensive measures to lock in CI stability after PR #139:

1. **Pin nextest version** to prevent CLI drift
2. **Guard bench exclusion** to prevent accidental removal

Both are low-cost, high-value preventative measures with minimal overhead.

## Changes

### 1. Pin nextest to v0.9.11 (lines 58-63)
```yaml
- name: Install nextest (pinned)
  if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable' && matrix.features == ''
  uses: taiki-e/install-action@v2
  with:
    tool: nextest@0.9.11
    checksum: true
```

**Why:**
- Prevents future CLI changes from breaking CI
- Adds checksum verification for supply chain security
- Uses explicit version instead of `@nextest` shorthand

### 2. Guard bench exclusion (lines 64-68)
```yaml
- name: Guard bench exclusion in Test Suite
  if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable' && matrix.features == ''
  run: |
    grep -q -- '--exclude copybook-bench' .github/workflows/ci.yml \
      || (echo "::error::Bench exclusion missing in Test Suite"; exit 1)
```

**Why:**
- Validates `--exclude copybook-bench` flags exist in workflow
- Fails fast with clear error message if exclusion is removed
- Prevents regression of macOS timing flake from PR #139
- Runs only on ubuntu/stable (minimal overhead)

## Rationale

After PR #139 fixed the macOS timing flake by excluding `copybook-bench` from the Test Suite matrix, these guards ensure:

- **Stability**: Nextest CLI won't change unexpectedly
- **Policy enforcement**: Bench exclusion can't be accidentally removed
- **Fast feedback**: Clear error messages if guard violations occur
- **Low cost**: Single conditional check, no performance impact

## Test Plan
- [x] YAML syntax validated
- [x] Guard check verifies current exclusions
- [x] Nextest pin uses documented taiki-e/install-action@v2 API
- [ ] CI confirms guard passes on ubuntu/stable
- [ ] Test Suite continues to exclude bench tests

## Follow-up from
PR #139 - fix(ci): exclude copybook-bench from blocking Test Suite matrix


___

### **PR Type**
Enhancement


___

### **Description**
- Pin nextest to v0.9.11 with checksum verification for CLI stability

- Add guard check to prevent accidental bench exclusion removal

- Implement defensive measures to lock in PR #139 stability gains


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI Workflow"] --> B["Install nextest v0.9.11"]
  B --> C["Verify checksum"]
  A --> D["Guard bench exclusion"]
  D --> E["Validate --exclude flag"]
  E --> F["Fail if missing"]
  B --> G["Run tests with exclusion"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Pin nextest version and add bench exclusion guard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Changed nextest installation from <code>@nextest</code> shorthand to explicit <code>v2</code> <br>action with <code>nextest@0.9.11</code> version pinning<br> <li> Added checksum verification to the nextest installation step for <br>supply chain security<br> <li> Added new guard step that validates <code>--exclude copybook-bench</code> flag <br>exists in workflow file<br> <li> Guard step fails with clear error message if bench exclusion is <br>accidentally removed<br> <li> All changes conditional on ubuntu-latest, stable Rust, and empty <br>features matrix</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/copybook-rs/pull/140/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).