### PR TITLE
fix(ci): remove unsupported nextest archive command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,16 +86,12 @@ jobs:
         export LC_ALL=C
         file=".github/workflows/ci.yml"
 
-        # Check that all four test commands include --exclude copybook-bench
+        # Check that all test commands include --exclude copybook-bench
         missing=0
 
         # nextest run
         grep -Eq '^[[:space:]]+cargo nextest run.*--exclude[[:space:]]+copybook-bench([[:space:]]|$)' "$file" || {
           echo "::error::Missing --exclude copybook-bench in 'cargo nextest run'"; missing=1; }
-
-        # nextest archive
-        grep -Eq '^[[:space:]]+cargo nextest archive.*--exclude[[:space:]]+copybook-bench([[:space:]]|$)' "$file" || {
-          echo "::error::Missing --exclude copybook-bench in 'cargo nextest archive'"; missing=1; }
 
         # cargo test: require ≥2 invocations with --exclude
         ct_count=$(grep -Ec 'run:[[:space:]]+cargo test .*--exclude[[:space:]]+copybook-bench' "$file" || echo 0)
@@ -113,7 +109,6 @@ jobs:
       if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable' && matrix.features == ''
       run: |
         cargo nextest run --workspace --exclude copybook-bench --profile ci --failure-output=immediate --status-level=fail
-        cargo nextest archive --workspace --exclude copybook-bench --profile ci --archive-file target/nextest/partial-archive.tar.zst
     - name: Sync test status to docs
       if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable' && matrix.features == ''
       run: cargo run -p xtask -- docs sync-tests


### PR DESCRIPTION
### **User description**
## Issue

CI is failing on main because nextest 0.9.11 doesn't support the `archive` subcommand:

```
error: Found argument 'archive' which wasn't expected, or isn't valid in this context
```

The archive command was added in PR #140/#141 but the pinned nextest version (0.9.11) doesn't support it.

## Solution

Remove the unused `cargo nextest archive` command and its corresponding guard check. The archive file wasn't being used by any subsequent CI steps.

## Changes

- Remove `cargo nextest archive` command from Test Suite job
- Remove archive guard check from bench exclusion validation

## Testing

This PR unblocks main CI. Once merged, the Test Suite job will complete successfully with only the `nextest run` command.

## Related

- Fixes CI failure introduced in #140/#141
- Unblocks v0.3.2 release


___

### **PR Type**
Bug fix


___

### **Description**
- Remove unsupported `cargo nextest archive` command from CI workflow

- Delete corresponding guard check validating archive command exclusions

- Unblock CI pipeline failing on nextest 0.9.11 incompatibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI Workflow"] -->|Remove archive command| B["nextest run only"]
  A -->|Remove guard check| C["Simplified validation"]
  B --> D["CI unblocked"]
  C --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Remove nextest archive command and validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Removed <code>cargo nextest archive</code> command from Run tests job (unsupported <br>in nextest 0.9.11)<br> <li> Deleted guard check validation for archive command bench exclusions<br> <li> Updated guard check comment from "four test commands" to "all test <br>commands"<br> <li> Retained <code>cargo nextest run</code> command with proper exclusions</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/copybook-rs/pull/145/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+1/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).