### PR TITLE
fix(ci): configure nextest JUnit output for xtask docs sync

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,3 +3,6 @@ failure-output = "immediate-final"
 status-level   = "all"
 retries        = 0
 slow-timeout   = "120s"
+
+[[profile.ci.junit]]
+path = "junit.xml"


### PR DESCRIPTION
### **User description**
## Issue

After PR #145 removed the `nextest archive` command, the CI is now failing at the `Sync test status to docs` step:

```
Error: No junit.xml found (run nextest with junit output)
```

The `xtask docs sync-tests` command expects `target/nextest/junit.xml` to be generated by nextest.

## Solution

Configure the nextest `ci` profile to generate JUnit XML output at the expected location.

## Changes

- Add `[[profile.ci.junit]]` configuration to `.config/nextest.toml`
- Configures `path = "junit.xml"` which will output to `target/nextest/junit.xml`

## Testing

This PR enables the `Sync test status to docs` step to complete successfully by providing the required JUnit XML file.

## Related

- Fixes CI failure introduced in #145
- Unblocks v0.3.2 release


___

### **PR Type**
Bug fix


___

### **Description**
- Configure nextest JUnit output in CI profile

- Fixes missing junit.xml file for xtask docs sync

- Enables test status documentation synchronization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["nextest CI profile"] -- "add JUnit config" --> B["junit.xml output"]
  B -- "enables" --> C["xtask docs sync"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nextest.toml</strong><dd><code>Add JUnit output configuration to nextest CI profile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.config/nextest.toml

<ul><li>Added <code>[[profile.ci.junit]]</code> section to nextest configuration<br> <li> Configured <code>path = "junit.xml"</code> to output JUnit XML to <br><code>target/nextest/junit.xml</code><br> <li> Enables xtask docs sync to read test results from expected location</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/copybook-rs/pull/146/files#diff-3e429424057e0b2a83fafc6e8942f4c05b63f4d977548e51535f8d86be8f9613">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).