### PR TITLE
fix(ci): correct nextest JUnit configuration syntax

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,6 +3,4 @@ failure-output = "immediate-final"
 status-level   = "all"
 retries        = 0
 slow-timeout   = "120s"
-
-[[profile.ci.junit]]
-path = "junit.xml"
+junit = { path = "junit.xml" }


### PR DESCRIPTION
### **User description**
## Issue

PR #146 introduced a nextest JUnit configuration, but used incorrect TOML syntax causing CI failure:

```
error: failed to parse nextest config at `.config/nextest.toml`
Caused by:
  invalid type: map, expected path string
```

## Solution

Change from TOML array syntax (`[[profile.ci.junit]]`) to inline table syntax (`junit = { path = "junit.xml" }`), which is the correct format for nextest 0.9.11.

## Changes

- Fix `.config/nextest.toml` JUnit configuration to use inline table format

## Testing

This PR resolves the nextest configuration parsing error and allows the test suite to generate JUnit XML output.

## Related

- Fixes CI failure introduced in #146
- Unblocks v0.3.2 release


___

### **PR Type**
Bug fix


___

### **Description**
- Fix nextest JUnit configuration TOML syntax error

- Change from array syntax to inline table format

- Resolves CI parsing failure in nextest 0.9.11


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Invalid array syntax<br/>[[profile.ci.junit]]"] -- "Fix to inline table" --> B["Valid inline table<br/>junit = { path }"]
  B --> C["CI passes<br/>JUnit XML generated"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nextest.toml</strong><dd><code>Correct nextest JUnit configuration syntax</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.config/nextest.toml

<ul><li>Replaced TOML array syntax <code>[[profile.ci.junit]]</code> with inline table <br>syntax <code>junit = { path = "junit.xml" }</code><br> <li> Fixes parsing error "invalid type: map, expected path string" in <br>nextest 0.9.11<br> <li> Allows CI to successfully generate JUnit XML output</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/copybook-rs/pull/147/files#diff-3e429424057e0b2a83fafc6e8942f4c05b63f4d977548e51535f8d86be8f9613">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).