### PR TITLE
fix(test): make audit error handling test cross-platform

### DIFF
--- a/copybook-cli/tests/audit_cli_comprehensive.rs
+++ b/copybook-cli/tests/audit_cli_comprehensive.rs
@@ -399,12 +399,10 @@ fn test_audit_command_error_handling() -> TestResult<()> {
     // Platform-agnostic file not found error check
     // Unix: "No such file"
     // Windows: "The system cannot find the file specified"
-    cmd.assert()
-        .failure()
-        .stderr(
-            predicate::str::contains("No such file")
-                .or(predicate::str::contains("cannot find the file"))
-        );
+    cmd.assert().failure().stderr(
+        predicate::str::contains("No such file")
+            .or(predicate::str::contains("cannot find the file")),
+    );
     Ok(())
 }
 


### PR DESCRIPTION
### **User description**
## Issue

The `test_audit_command_error_handling` test in `audit_cli_comprehensive.rs` was failing on Windows because it expected Unix-specific error messages:

```
Expected: "No such file"
Actual (Windows): "The system cannot find the file specified."
```

This was blocking CI completion on the Windows test matrix.

## Solution

Use a platform-agnostic predicate that accepts both Unix and Windows file-not-found error messages:

- **Unix**: "No such file"
- **Windows**: "cannot find the file specified"

## Changes

- Update the error message assertion to use `.or()` predicate combinator
- Add explanatory comment documenting platform differences

## Testing

- ✅ Passes on Unix (existing behavior preserved)
- ✅ Will pass on Windows (accepts Windows error message)

## Related

- Discovered after PR #148 made CI proceed past docs sync step
- Final blocker for v0.3.2 release


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Make audit error handling test cross-platform compatible

- Accept both Unix and Windows file-not-found error messages

- Use predicate combinator to handle platform differences

- Add explanatory comments documenting error message variations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test assertion"] --> B["Platform-agnostic predicate"]
  B --> C["Unix: 'No such file'"]
  B --> D["Windows: 'cannot find the file'"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audit_cli_comprehensive.rs</strong><dd><code>Make file-not-found error check cross-platform</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

copybook-cli/tests/audit_cli_comprehensive.rs

<ul><li>Updated error message assertion to use <code>.or()</code> predicate combinator<br> <li> Added platform-agnostic check for file-not-found errors<br> <li> Added explanatory comment documenting Unix vs Windows error messages<br> <li> Maintains backward compatibility with Unix error messages</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/copybook-rs/pull/149/files#diff-aa246a59ec019e47dec3fb1002b5a5134616acfefea8b7a0a24af6bd20056f94">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).