### PR TITLE
Lower workspace MSRV to Rust 1.89

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,7 @@ name = "copybook-codec"
 version = "0.3.1"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "base64",
  "clap",
  "copybook-core",
@@ -449,6 +450,7 @@ dependencies = [
  "hex",
  "indexmap",
  "metrics",
+ "predicates",
  "proptest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 [workspace.package]
 version = "0.3.1"
 edition = "2024"
-rust-version = "1.90"  # MSRV aligned with CI test matrix (see .github/workflows/ci.yml line 44)
+rust-version = "1.89"  # MSRV aligned with CI test matrix (see .github/workflows/ci.yml line 44)
 license = "AGPL-3.0-or-later"
 authors = ["copybook-rs contributors"]
 repository = "https://github.com/EffortlessMetrics/copybook-rs"


### PR DESCRIPTION
### **User description**
## Summary
- update the workspace rust-version to 1.89 to match the requested MSRV
- refresh the lockfile so copybook-codec records assert_cmd/predicates dependencies

## Testing
- cargo test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69145230c9e48333bc1d5c532592ba36)


___

### **PR Type**
Enhancement


___

### **Description**
- Lower workspace MSRV from Rust 1.90 to 1.89

- Aligns with CI test matrix configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cargo.toml<br/>rust-version"] -- "downgrade from 1.90" --> B["rust-version = 1.89"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Lower workspace MSRV to 1.89</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

<ul><li>Updated workspace <code>rust-version</code> from "1.90" to "1.89"<br> <li> Aligns MSRV with CI test matrix configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/copybook-rs/pull/153/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).