### PR TITLE
style: apply cargo fmt to merged code

### DIFF
--- a/copybook-cli/src/commands/support.rs
+++ b/copybook-cli/src/commands/support.rs
@@ -93,7 +93,9 @@ pub fn run(args: &SupportArgs) -> anyhow::Result<ExitCode> {
                 }
 
                 println!();
-                println!("Use 'copybook support --check <feature-id>' to check a specific feature.");
+                println!(
+                    "Use 'copybook support --check <feature-id>' to check a specific feature."
+                );
                 println!("Use 'copybook support --format json' for machine-readable output.");
             }
             OutputFormat::Json => {

--- a/xtask/src/perf.rs
+++ b/xtask/src/perf.rs
@@ -363,12 +363,16 @@ mod tests {
     #[test]
     fn test_delta_percentage_calculation() {
         let snapshot = PerfSnapshot {
-            display_mibps: 88.0,  // +10% over 80
-            comp3_mibps: 36.0,    // -10% under 40
+            display_mibps: 88.0, // +10% over 80
+            comp3_mibps: 36.0,   // -10% under 40
         };
-        
+
         let status = evaluate_slo(&snapshot);
-        if let SloStatus::Fail { display_delta_pct, comp3_delta_pct } = status {
+        if let SloStatus::Fail {
+            display_delta_pct,
+            comp3_delta_pct,
+        } = status
+        {
             assert!((display_delta_pct - 10.0).abs() < 0.01);
             assert!((comp3_delta_pct + 10.0).abs() < 0.01);
         } else {
@@ -384,7 +388,7 @@ mod tests {
         };
         let status = evaluate_slo(&snapshot);
         let summary = format_slo_summary(&snapshot, &status);
-        
+
         assert!(summary.contains("200.0 MiB/s"));
         assert!(summary.contains("100.0 MiB/s"));
         assert!(summary.contains("✓ All SLOs met"));
@@ -398,7 +402,7 @@ mod tests {
         };
         let status = evaluate_slo(&snapshot);
         let summary = format_slo_summary(&snapshot, &status);
-        
+
         assert!(summary.contains("70.0 MiB/s"));
         assert!(summary.contains("30.0 MiB/s"));
         assert!(summary.contains("⚠ SLOs not met"));


### PR DESCRIPTION
### **User description**
Quick formatting fixes after merging PRs #154, #155, #152, #151


___

### **PR Type**
Documentation


___

### **Description**
- Apply cargo fmt formatting to merged code

- Fix line wrapping in println! macro calls

- Align struct field comments and spacing

- Clean up whitespace in test functions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Merged PRs<br/>#154, #155, #152, #151"] -- "formatting issues" --> B["cargo fmt<br/>applied"]
  B --> C["copybook-cli<br/>support.rs"]
  B --> D["xtask<br/>perf.rs"]
  C --> E["println! wrapping"]
  D --> F["struct alignment<br/>& whitespace"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>support.rs</strong><dd><code>Format println macro call wrapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

copybook-cli/src/commands/support.rs

<ul><li>Wrapped long <code>println!</code> statement across multiple lines for better <br>readability<br> <li> Maintained consistent formatting with cargo fmt standards</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/copybook-rs/pull/156/files#diff-a53ffe889a8846d1b7afc45a97ed4e04cca4cb0917fd5db2a3529c6a3610bf1b">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>perf.rs</strong><dd><code>Format struct fields and test code alignment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

xtask/src/perf.rs

<ul><li>Aligned struct field comments to consistent spacing<br> <li> Reformatted pattern matching destructuring across multiple lines<br> <li> Removed trailing whitespace and normalized blank lines in test <br>functions<br> <li> Applied cargo fmt line length and indentation rules</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/copybook-rs/pull/156/files#diff-eb08cb3df431a3dd15da7d06dee275a106ddc6930c4884fa5f7f79d9baa34ee9">+10/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).