### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to copybook-rs are documented here. This root file is the ca
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] — 2025-12-22
+
+> Patch release with receipt integrity fixes and documentation cleanup.
+
+### Fixed
+
+- **Receipt Integrity**: Fixed hash mismatch between generator and validator
+  - Compute percentiles BEFORE hashing (no post-write mutations)
+  - Use jq-based hash computation for consistent canonicalization
+  - Removed soak-aggregate.sh post-write call that caused integrity failures
+- **Doc Comments**: Fixed backtick usage in CLI utils for clippy pedantic compliance
+- **Historical Docs**: Cleaned merge conflict markers from archived roadmap files
+- **CI Stability**: Constrained parallelism (`-j 2`) to prevent linker/resource exhaustion
+
+### Changed
+
+- **Merge with main**: Synchronized release/v0.4.0 branch with main after PR #178
+
 ## [0.4.0] — 2025-12-18
 
 > Minor release with projection support and edited PIC decode.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.90" # MSRV (validated in .github/workflows/ci.yml)
 license = "AGPL-3.0-or-later"
@@ -23,8 +23,8 @@ categories = ["parsing", "encoding", "command-line-utilities"]
 
 [workspace.dependencies]
 # Internal workspace crates (pin exact versions for publish)
-copybook-core = { version = "=0.4.0", path = "copybook-core" }
-copybook-codec = { version = "=0.4.0", path = "copybook-codec" }
+copybook-core = { version = "=0.4.1", path = "copybook-core" }
+copybook-codec = { version = "=0.4.1", path = "copybook-codec" }
 
 # Core dependencies
 serde = { version = "1.0.228", features = ["derive"] }


### PR DESCRIPTION
## Summary

Version bump for v0.4.1 patch release.

- Update workspace version: 0.4.0 → 0.4.1
- Update internal dependency pins: =0.4.0 → =0.4.1
- Add CHANGELOG entry for v0.4.1 release

## Context

This follows the merge of PR #179 which fixed receipt integrity issues and removed conflict markers.