### PR TITLE
ci: add SBOM workflow + clarify private distribution

### DIFF
--- a/.github/workflows/ci-sbom.yml
+++ b/.github/workflows/ci-sbom.yml
@@ -1,0 +1,40 @@
+name: SBOM Generation
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-cyclonedx
+        run: cargo install --locked cargo-cyclonedx --version 0.5.7
+
+      - name: Generate SBOM (CycloneDX JSON)
+        run: cargo cyclonedx --manifest-path copybook-cli/Cargo.toml --format json
+
+      - name: Rename and verify SBOM
+        run: |
+          mv copybook-cli/copybook-cli.cdx.json sbom.cdx.json
+          echo "SBOM generated:"
+          head -50 sbom.cdx.json
+          echo "..."
+          echo "Component count: $(jq '.components | length' sbom.cdx.json)"
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-cyclonedx
+          path: sbom.cdx.json
+          retention-days: 90
+          if-no-files-found: error

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -80,6 +80,30 @@ The repository publish workflow (`.github/workflows/publish.yml`) follows this o
 
 ---
 
+## Distribution Truth
+
+**crates.io publish makes the crate public.** Once published:
+- The published crate tarball (packaged sources) is public
+- Download statistics are public
+- Crate metadata (dependencies, features) is indexed
+
+**Private distribution options:**
+- Git tags on private repositories
+- Private cargo registries (Cloudsmith, Artifactory, etc.)
+- Vendored dependencies via `cargo vendor`
+
+**SBOM generation** (for enterprise compliance):
+```bash
+# Generate CycloneDX SBOM locally
+cargo cyclonedx --manifest-path copybook-cli/Cargo.toml --format json
+mv copybook-cli/copybook-cli.cdx.json sbom.cdx.json
+
+# Or trigger the workflow (workflow_dispatch)
+# Artifact: sbom-cyclonedx/sbom.cdx.json
+```
+
+---
+
 ## Rollback (If Needed)
 
 If you published a bad release:


### PR DESCRIPTION
## Summary
- Add workflow_dispatch SBOM generator using cargo-cyclonedx (v0.5.7 pinned)
- Document that crates.io publish makes packaged sources public; note private distribution options
- Dispatch-only trigger (no release hook until CI is restored)

## Changes
- `.github/workflows/ci-sbom.yml`: New workflow with artifact upload (`if-no-files-found: error`)
- `docs/RELEASE_RUNBOOK.md`: Distribution truth section + corrected SBOM example

## Local validation
```bash
cargo fmt --all --check       # ✓
cargo clippy --workspace -- -D warnings -W clippy::pedantic  # ✓
cargo test --workspace -j 2   # (skipped - no code changes)
```