### PR TITLE
fix(codec): CBKE510/515 correctness + tests

### DIFF
--- a/copybook-codec/src/edited_pic.rs
+++ b/copybook-codec/src/edited_pic.rs
@@ -681,7 +681,7 @@ pub fn encode_edited_numeric(
             | PicToken::Comma
             | PicToken::Slash
             | PicToken::Currency => {}
-            _ => {
+            PicToken::Space => {
                 return Err(Error::new(
                     ErrorCode::CBKD302_EDITED_PIC_NOT_IMPLEMENTED,
                     format!("Edited PIC token not supported in E3.6: {token:?}"),
@@ -930,7 +930,7 @@ pub fn encode_edited_numeric(
                     }
                 }
             }
-            _ => {
+            PicToken::Space => {
                 // Should have been caught by unsupported check
                 return Err(Error::new(
                     ErrorCode::CBKD302_EDITED_PIC_NOT_IMPLEMENTED,

--- a/copybook-codec/src/json.rs
+++ b/copybook-codec/src/json.rs
@@ -1668,8 +1668,8 @@ impl JsonEncoder {
                     // Validate string length doesn't exceed field capacity
                     if text.len() > field.len as usize {
                         return Err(Error::new(
-                            ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
-                            format!("String length {} exceeds field capacity {} for alphanumeric field {}", 
+                            ErrorCode::CBKE515_STRING_LENGTH_VIOLATION,
+                            format!("String length {} exceeds field capacity {} for alphanumeric field {}",
                                 text.len(), field.len, field.path),
                         ).with_field(field.path.clone()));
                     }
@@ -1842,7 +1842,7 @@ impl JsonEncoder {
             // Validate string length doesn't exceed field capacity
             if text.len() > field.len as usize {
                 return Err(Error::new(
-                    ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
+                    ErrorCode::CBKE515_STRING_LENGTH_VIOLATION,
                     format!(
                         "String length {} exceeds field capacity {} for alphanumeric field {}",
                         text.len(),

--- a/copybook-codec/src/numeric.rs
+++ b/copybook-codec/src/numeric.rs
@@ -438,7 +438,7 @@ impl SmallDecimal {
             .and_then(|v| v.checked_add(fractional_value))
             .ok_or_else(|| {
                 Error::new(
-                    ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
+                    ErrorCode::CBKE510_NUMERIC_OVERFLOW,
                     "Numeric value too large - would cause overflow",
                 )
             })
@@ -1477,7 +1477,7 @@ pub fn encode_zoned_decimal_with_format_and_policy(
 
     if digit_str.len() > width {
         return Err(Error::new(
-            ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
+            ErrorCode::CBKE510_NUMERIC_OVERFLOW,
             format!("Value too large for {digits} digits"),
         ));
     }
@@ -1589,7 +1589,7 @@ pub fn encode_packed_decimal(
     let digits_usize = usize::from(digits);
     if unlikely(digit_count > digits_usize) {
         return Err(Error::new(
-            ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
+            ErrorCode::CBKE510_NUMERIC_OVERFLOW,
             format!("Value too large for {digits} digits"),
         ));
     }

--- a/copybook-codec/tests/error_code_tests.rs
+++ b/copybook-codec/tests/error_code_tests.rs
@@ -1,0 +1,275 @@
+//! Tests for specific error codes in the codec layer
+//!
+//! This module tests error conditions that are difficult to trigger through
+//! normal parsing but are important for robustness.
+
+use copybook_codec::record::FixedRecordReader;
+use copybook_codec::{Codepage, EncodeOptions, encode_record};
+use copybook_core::ErrorCode;
+use copybook_core::schema::{Field, FieldKind, Schema};
+use serde_json::json;
+use std::io::Cursor;
+
+/// Test CBKI001_INVALID_STATE: FixedRecordReader requires LRECL
+#[test]
+fn test_cbki001_fixed_reader_requires_lrecl() {
+    let data = Cursor::new(b"test data");
+
+    // Attempt to create reader without LRECL
+    let result = FixedRecordReader::new(data, None);
+
+    assert!(result.is_err(), "Expected CBKI001 error for missing LRECL");
+    if let Err(err) = result {
+        assert_eq!(
+            err.code,
+            ErrorCode::CBKI001_INVALID_STATE,
+            "Expected CBKI001_INVALID_STATE"
+        );
+        assert!(
+            err.message.contains("LRECL"),
+            "Error should mention LRECL requirement"
+        );
+    }
+}
+
+/// Test CBKI001_INVALID_STATE: FixedRecordReader requires non-zero LRECL
+#[test]
+fn test_cbki001_fixed_reader_requires_nonzero_lrecl() {
+    let data = Cursor::new(b"test data");
+
+    // Attempt to create reader with zero LRECL
+    let result = FixedRecordReader::new(data, Some(0));
+
+    assert!(result.is_err(), "Expected CBKI001 error for zero LRECL");
+    if let Err(err) = result {
+        assert_eq!(
+            err.code,
+            ErrorCode::CBKI001_INVALID_STATE,
+            "Expected CBKI001_INVALID_STATE"
+        );
+        assert!(
+            err.message.contains("greater than zero"),
+            "Error should mention LRECL must be greater than zero"
+        );
+    }
+}
+
+/// Test CBKD101_INVALID_FIELD_TYPE: RENAMES field without resolved metadata
+///
+/// This tests the codec path that handles RENAMES fields missing their
+/// resolved metadata (offset, length, members). This is a synthetic error
+/// condition since the parser normally resolves all RENAMES.
+#[test]
+fn test_cbkd101_renames_without_resolved_metadata() {
+    use copybook_codec::Codepage;
+    use copybook_codec::{DecodeOptions, decode_record};
+    use copybook_core::schema::{Field, FieldKind, Schema};
+
+    // Create a synthetic schema with RENAMES but no resolved_renames
+    let mut root = Field::new(1, "ROOT".to_string());
+    root.path = "ROOT".to_string();
+    root.kind = FieldKind::Group;
+
+    let mut field1 = Field::new(5, "FIELD1".to_string());
+    field1.path = "ROOT.FIELD1".to_string();
+    field1.kind = FieldKind::Alphanum { len: 10 };
+    field1.len = 10;
+    field1.offset = 0;
+
+    // Create a RENAMES field without resolved_renames metadata
+    let mut renames = Field::new(66, "ALIAS".to_string());
+    renames.path = "ROOT.ALIAS".to_string();
+    renames.level = 66;
+    renames.kind = FieldKind::Renames {
+        from_field: "FIELD1".to_string(),
+        thru_field: "FIELD1".to_string(),
+    };
+    // Intentionally NOT setting resolved_renames
+    renames.resolved_renames = None;
+    renames.offset = 0;
+    renames.len = 10;
+
+    root.children = vec![field1, renames];
+
+    let mut schema = Schema::from_fields(vec![root]);
+    schema.lrecl_fixed = Some(10);
+
+    // Create test data
+    let data = b"TEST DATA!";
+
+    let options = DecodeOptions::new().with_codepage(Codepage::CP037);
+
+    // Attempt to decode - should fail with CBKD101
+    let result = decode_record(&schema, data, &options);
+
+    assert!(
+        result.is_err(),
+        "Expected CBKD101 error for unresolved RENAMES"
+    );
+    if let Err(err) = result {
+        assert_eq!(
+            err.code,
+            ErrorCode::CBKD101_INVALID_FIELD_TYPE,
+            "Expected CBKD101_INVALID_FIELD_TYPE"
+        );
+        assert!(
+            err.message.contains("ALIAS") || err.message.contains("RENAMES"),
+            "Error should mention the RENAMES field"
+        );
+    }
+}
+
+/// Test CBKE515_STRING_LENGTH_VIOLATION: String exceeds field capacity
+#[test]
+fn test_cbke515_string_length_exceeds_capacity() {
+    // Create a simple schema with a 5-byte alphanumeric field
+    let mut root = Field::new(1, "ROOT".to_string());
+    root.path = "ROOT".to_string();
+    root.kind = FieldKind::Group;
+
+    let mut field = Field::new(5, "SHORT-FIELD".to_string());
+    field.path = "ROOT.SHORT-FIELD".to_string();
+    field.kind = FieldKind::Alphanum { len: 5 };
+    field.len = 5;
+    field.offset = 0;
+
+    root.children = vec![field];
+
+    let mut schema = Schema::from_fields(vec![root]);
+    schema.lrecl_fixed = Some(5);
+
+    // Try to encode a string that's too long
+    let json_value = json!({
+        "ROOT": {
+            "SHORT-FIELD": "THIS STRING IS WAY TOO LONG"
+        }
+    });
+
+    let options = EncodeOptions::new().with_codepage(Codepage::CP037);
+
+    let result = encode_record(&schema, &json_value, &options);
+
+    assert!(
+        result.is_err(),
+        "Expected CBKE515 error for string too long"
+    );
+    if let Err(err) = result {
+        assert_eq!(
+            err.code,
+            ErrorCode::CBKE515_STRING_LENGTH_VIOLATION,
+            "Expected CBKE515_STRING_LENGTH_VIOLATION, got {:?}",
+            err.code
+        );
+        assert!(
+            err.message.contains("String length") && err.message.contains("exceeds"),
+            "Error should mention string length exceeds capacity: {}",
+            err.message
+        );
+    }
+}
+
+/// Test CBKE510_NUMERIC_OVERFLOW: Zoned decimal value too large
+#[test]
+fn test_cbke510_zoned_decimal_overflow() {
+    // Create a schema with a 3-digit zoned decimal field
+    let mut root = Field::new(1, "ROOT".to_string());
+    root.path = "ROOT".to_string();
+    root.kind = FieldKind::Group;
+
+    let mut field = Field::new(5, "SMALL-NUM".to_string());
+    field.path = "ROOT.SMALL-NUM".to_string();
+    field.kind = FieldKind::ZonedDecimal {
+        digits: 3,
+        scale: 0,
+        signed: false,
+    };
+    field.len = 3;
+    field.offset = 0;
+
+    root.children = vec![field];
+
+    let mut schema = Schema::from_fields(vec![root]);
+    schema.lrecl_fixed = Some(3);
+
+    // Try to encode a value that's too large for 3 digits
+    let json_value = json!({
+        "ROOT": {
+            "SMALL-NUM": "99999"  // 5 digits, but only 3 allowed
+        }
+    });
+
+    let options = EncodeOptions::new().with_codepage(Codepage::CP037);
+
+    let result = encode_record(&schema, &json_value, &options);
+
+    assert!(
+        result.is_err(),
+        "Expected CBKE510 error for numeric overflow"
+    );
+    if let Err(err) = result {
+        assert_eq!(
+            err.code,
+            ErrorCode::CBKE510_NUMERIC_OVERFLOW,
+            "Expected CBKE510_NUMERIC_OVERFLOW, got {:?}",
+            err.code
+        );
+        assert!(
+            err.message.contains("too large") || err.message.contains("overflow"),
+            "Error should mention value too large: {}",
+            err.message
+        );
+    }
+}
+
+/// Test CBKE510_NUMERIC_OVERFLOW: Packed decimal value too large
+#[test]
+fn test_cbke510_packed_decimal_overflow() {
+    // Create a schema with a 4-digit packed decimal field (3 bytes)
+    let mut root = Field::new(1, "ROOT".to_string());
+    root.path = "ROOT".to_string();
+    root.kind = FieldKind::Group;
+
+    let mut field = Field::new(5, "SMALL-COMP3".to_string());
+    field.path = "ROOT.SMALL-COMP3".to_string();
+    field.kind = FieldKind::PackedDecimal {
+        digits: 4,
+        scale: 0,
+        signed: true,
+    };
+    field.len = 3; // (4+1)/2 = 2.5 -> 3 bytes
+    field.offset = 0;
+
+    root.children = vec![field];
+
+    let mut schema = Schema::from_fields(vec![root]);
+    schema.lrecl_fixed = Some(3);
+
+    // Try to encode a value that's too large for 4 digits
+    let json_value = json!({
+        "ROOT": {
+            "SMALL-COMP3": "999999"  // 6 digits, but only 4 allowed
+        }
+    });
+
+    let options = EncodeOptions::new().with_codepage(Codepage::CP037);
+
+    let result = encode_record(&schema, &json_value, &options);
+
+    assert!(
+        result.is_err(),
+        "Expected CBKE510 error for packed decimal overflow"
+    );
+    if let Err(err) = result {
+        assert_eq!(
+            err.code,
+            ErrorCode::CBKE510_NUMERIC_OVERFLOW,
+            "Expected CBKE510_NUMERIC_OVERFLOW, got {:?}",
+            err.code
+        );
+        assert!(
+            err.message.contains("too large") || err.message.contains("overflow"),
+            "Error should mention value too large: {}",
+            err.message
+        );
+    }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -39,9 +39,9 @@ Criteria → Risks/Mitigations.
 | **RENAMES codec** (#110) | ✅ Complete | - | None (R1-R3 implemented) |
 | **Determinism CI** (#112 Phase 3) | ✅ Ready | 0.5 PD | CI-off mode |
 | **Quality gates** (#97-100) | ⏳ Blocked | 6-8 weeks | CI-off mode |
-| **Benchmark container** (#113) | ✅ Complete | - | None (close issue) |
+| **Benchmark container** (#113) | ✅ Complete | - | None |
 
-**Issues to close**: #113 (benchmark container), #51 (dialect lever), #110 (RENAMES codec)
+**Issues closed (2025-12-31)**: #113, #51, #110 ✅
 
 ---
 
@@ -383,8 +383,13 @@ and are tracked for future sprints:
 
 ### Test Coverage (Future Sprints)
 
-* [ ] Add dedicated tests for 9 untested error codes (CBKS701-703,
-  CBKD101, CBKE510/515, CBKF102/104, CBKI001)
+* [x] Add dedicated tests for error codes CBKS701, CBKS702, CBKD101, CBKI001
+  — Added 2025-12-31 in `projection_tests.rs` and `error_code_tests.rs`
+* [x] CBKS703, CBKF102, CBKF104 already have tests (verified 2025-12-31)
+* [x] CBKE510/515 fixed — Corrected error code usage (was using CBKE501):
+  - CBKE515 now emitted for string length violations (3 locations)
+  - CBKE510 now emitted for numeric overflow (3 locations)
+  — Fixed 2025-12-31 with 3 new tests in `error_code_tests.rs`
 * [ ] Add unit tests for memory/iterator infrastructure
 * [ ] Improve audit feature test coverage (currently ~10%)
 


### PR DESCRIPTION
## Summary

- CBKE515 now emitted for string length violations (was CBKE501)
- CBKE510 now emitted for numeric overflow (was CBKE501)
- Fix clippy pedantic violations in lib_api.rs and edited_pic.rs
- Add focused tests for CBKE510/515, CBKS701/702, CBKI001, CBKD101
- Update ROADMAP test-coverage checkboxes

## Changes

### Error Code Corrections
- `numeric.rs`: CBKE510 for SmallDecimal overflow, zoned/packed decimal encoding (3 locations)
- `json.rs`: CBKE515 for string length violations in JsonEncoder (2 locations)
- `lib_api.rs`: CBKE515 for string length violations in encode_alphanum_field (1 location)

### Clippy Fixes
- `lib_api.rs`: Remove redundant else blocks (2 locations)
- `edited_pic.rs`: Use explicit PicToken::Space instead of wildcard match (2 locations)

### New Tests
- `error_code_tests.rs`: CBKI001, CBKD101, CBKE510, CBKE515 (6 tests)
- `projection_tests.rs`: CBKS701, CBKS702 (2 tests)

## Local Validation (CI-off mode)

```bash
cargo fmt --all --check              # ✅ Pass
cargo clippy --workspace -- -D warnings -W clippy::pedantic  # ✅ Pass
CARGO_INCREMENTAL=0 cargo test -p copybook-core --test projection_tests -j1  # ✅ 19 passed
CARGO_INCREMENTAL=0 cargo test -p copybook-codec --test error_code_tests -j1 # ✅ 6 passed
```

**Note**: CI is blocked by GitHub billing issue; local gates pass.