### PR TITLE
🎨 Palette: Enable colored CLI output

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-01-27 - Safe Color Implementation in CLI
+**Learning:** Enabling `ColorChoice::Auto` in `clap` is a quick UX win, but it MUST be paired with strict environment controls in integration tests. Specifically, `assert_cmd` tests running in non-TTY environments can be unpredictable with colors unless `NO_COLOR=1` is explicitly set in the test harness.
+**Action:** Always wrap `cargo_bin_cmd!` in a helper that sets `.env("NO_COLOR", "1")` when working on CLI tools that support colored output.

--- a/copybook-cli/src/main.rs
+++ b/copybook-cli/src/main.rs
@@ -13,7 +13,7 @@ use copybook_core::Error as CoreError;
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::error::Error as StdError;
-use std::io::{self, ErrorKind, Write};
+use std::io::{self, ErrorKind, IsTerminal, Write};
 use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode as ProcessExitCode;
@@ -60,7 +60,7 @@ fn invocation_id() -> &'static str {
 }
 
 #[derive(Parser)]
-#[command(name = "copybook", color = ColorChoice::Never)]
+#[command(name = "copybook", color = ColorChoice::Auto)]
 #[command(about = "Modern COBOL copybook parser and data converter")]
 #[command(version)]
 struct Cli {
@@ -543,9 +543,12 @@ fn run() -> anyhow::Result<ExitCode> {
     let default_directive = if verbose { "debug" } else { "warn" };
     let env_filter =
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_directive));
+
+    let use_colors = std::io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none();
+
     tracing_subscriber::fmt()
         .with_env_filter(env_filter)
-        .with_ansi(false)
+        .with_ansi(use_colors)
         .with_writer(|| BrokenPipeSafeStderr(std::io::stderr()))
         .init();
 

--- a/copybook-cli/tests/common.rs
+++ b/copybook-cli/tests/common.rs
@@ -13,7 +13,9 @@ pub type TestResult<T> = Result<T, Box<dyn Error>>;
 #[allow(dead_code)] // shared test helper: some suites only rely on write_file
 #[must_use]
 pub fn bin() -> Command {
-    cargo_bin_cmd!("copybook")
+    let mut cmd = cargo_bin_cmd!("copybook");
+    cmd.env("NO_COLOR", "1");
+    cmd
 }
 
 #[allow(dead_code)] // shared test helper: silences per-binary unused warnings

--- a/copybook-cli/tests/test_utils.rs
+++ b/copybook-cli/tests/test_utils.rs
@@ -62,6 +62,7 @@ pub fn test_data_path(relative_path: &str) -> PathBuf {
 #[must_use]
 pub fn copybook_cmd(args: &[&str]) -> Command {
     let mut cmd = cargo_bin_cmd!("copybook");
+    cmd.env("NO_COLOR", "1");
     cmd.args(args)
         .arg("--format")
         .arg("fixed")
@@ -74,7 +75,9 @@ pub fn copybook_cmd(args: &[&str]) -> Command {
 #[must_use]
 #[allow(dead_code)] // shared test helper for fixture tests
 pub fn bin() -> Command {
-    cargo_bin_cmd!("copybook")
+    let mut cmd = cargo_bin_cmd!("copybook");
+    cmd.env("NO_COLOR", "1");
+    cmd
 }
 
 /// Convert an `Option<T>` into a [`TestResult`] with a helpful error message.


### PR DESCRIPTION
🎨 Palette: Enable colored CLI output

💡 What: Changed the CLI color mode from `Never` to `Auto` and updated the logger to support ANSI colors when appropriate.
🎯 Why: To make the CLI experience more modern and readable, especially for help text and error diagnostics.
📸 Before: Plain text output. After: Colored output (on supported terminals).
♿ Accessibility: Respects `NO_COLOR` standard for users who prefer or require plain text.


---
*PR created automatically by Jules for task [4768449775666322057](https://jules.google.com/task/4768449775666322057) started by @EffortlessSteven*