### PR TITLE
🛡️ Sentinel: [HIGH] Fix Unbounded File Read DoS Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-14 - [DOS Prevention: Unbounded File Reads]
+**Vulnerability:** `std::fs::read_to_string` was used directly on user-supplied copybook files in `copybook-cli`, allowing reading arbitrarily large files into memory. This creates a Denial of Service (DoS) risk via memory exhaustion (OOM), especially if the CLI is exposed as a service.
+**Learning:** Even simple CLI tools need input limits. Use `std::io::Read::take(limit)` to strictly bound memory usage when reading files whose size is untrusted or potentially large. Metadata checks (`fs::metadata(path).len()`) are an optimization but not a substitute for read limits (race conditions, special files).
+**Prevention:** Always wrap file reading in a helper that enforces a size limit (e.g., `read_file_with_limit`). Defined `MAX_COPYBOOK_SIZE` (16 MiB) as a safe upper bound for metadata files.

--- a/copybook-cli/src/commands/audit.rs
+++ b/copybook-cli/src/commands/audit.rs
@@ -632,7 +632,7 @@ fn run_audit_report(
     write_stdout_line("Generating comprehensive audit report...")?;
 
     // Parse copybook to validate it
-    let copybook_text = std::fs::read_to_string(_copybook)?;
+    let copybook_text = crate::utils::read_file_with_limit(_copybook)?;
     let _schema = copybook_core::parse_copybook(&copybook_text)?;
 
     // Create basic audit report structure
@@ -709,7 +709,7 @@ async fn run_compliance_validation(
 
     // Run compliance validation
     // Parse copybook to validate it
-    let copybook_text = std::fs::read_to_string(_copybook)?;
+    let copybook_text = crate::utils::read_file_with_limit(_copybook)?;
     let _schema = copybook_core::parse_copybook(&copybook_text)?;
 
     let compliance_result = compliance_engine
@@ -777,7 +777,7 @@ fn run_lineage_analysis(
     write_stdout_line("Analyzing data lineage...")?;
 
     // Parse source copybook
-    let source_text = std::fs::read_to_string(_source_copybook)?;
+    let source_text = crate::utils::read_file_with_limit(_source_copybook)?;
     let _source_schema = copybook_core::parse_copybook(&source_text)?;
 
     // Create lineage report
@@ -834,7 +834,7 @@ fn run_performance_audit(
     write_stdout_line("Running performance audit...")?;
 
     // Parse copybook
-    let copybook_text = std::fs::read_to_string(_copybook)?;
+    let copybook_text = crate::utils::read_file_with_limit(_copybook)?;
     let _schema = copybook_core::parse_copybook(&copybook_text)?;
 
     // Create performance report
@@ -897,7 +897,7 @@ fn run_security_audit(
     write_stdout_line("Running security audit...")?;
 
     // Parse copybook
-    let copybook_text = std::fs::read_to_string(_copybook)?;
+    let copybook_text = crate::utils::read_file_with_limit(_copybook)?;
     let _schema = copybook_core::parse_copybook(&copybook_text)?;
 
     // Create security report


### PR DESCRIPTION
Enforce 16 MiB limit on copybook files to prevent memory exhaustion DoS.

---
*PR created automatically by Jules for task [1021085793817392839](https://jules.google.com/task/1021085793817392839) started by @EffortlessSteven*