### PR TITLE
Enhance inspect command with tree view

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-xx - CLI Tree Visualization
+**Learning:** Hierarchical data in CLIs is significantly more readable with tree views (using box drawing chars) than flattened dot-notation lists.
+**Action:** Default to tree views for inspect or describe commands in CLI tools dealing with nested structures.


### PR DESCRIPTION
The `inspect` command previously output a flat list of fields using full dot-notation paths, which was hard to scan for deep hierarchies.

This change introduces a tree view using box-drawing characters (`├──`, `└──`) to visualize the nesting of COBOL groups and fields. The "Field Path" column is renamed to "Field" and shows indented names, making the structure immediately obvious.

Example:
```
ROOT
├── GROUP
│   ├── FIELD1
│   └── FIELD2
```

This is a UX improvement with no functional changes to parsing or other commands. Validated with existing tests and manual verification.

---
*PR created automatically by Jules for task [12561974797411106933](https://jules.google.com/task/12561974797411106933) started by @EffortlessSteven*