### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS vulnerability in copybook reader

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-24 - Unbounded Input Read DoS
+**Vulnerability:** `read_file_or_stdin` used `read_to_string` without a limit, allowing attackers to cause OOM by providing massive inputs via file or stdin.
+**Learning:** Utility functions intended for "small" configuration or schema files are often reused for larger inputs or exposed to untrusted sources without limits being reconsidered.
+**Prevention:** Always use `take(LIMIT)` or equivalent bounded readers when processing external input, especially for text-based formats like copybooks or config files. Define explicit limits for all I/O operations.


### PR DESCRIPTION
Enforced a 16 MiB limit on copybook input files and stdin streams in `copybook-cli` to prevent Denial of Service (DoS) attacks via memory exhaustion. Implemented `read_with_limit` helper and applied it to `read_file_or_stdin`. Added regression tests.

---
*PR created automatically by Jules for task [4670737941840045681](https://jules.google.com/task/4670737941840045681) started by @EffortlessSteven*