### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unbounded file read DoS in CLI

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-?? - Unbounded File Read DoS
+**Vulnerability:** `read_file_or_stdin` in `copybook-cli` read entire inputs into memory without size limits using `read_to_string`.
+**Learning:** Even in memory-safe languages like Rust, unbounded resource consumption (memory) is a simple but effective DoS vector. Standard library convenience functions like `fs::read_to_string` are dangerous for untrusted input.
+**Prevention:** Always use `reader.take(limit)` or explicit buffer size checks when reading potentially large or untrusted inputs, especially from stdin.


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `copybook-cli` read entire copybook files (or stdin) into memory without limits using `read_to_string`. This allowed malicious inputs (e.g. infinite streams or massive files) to cause OOM (Out Of Memory) crashes, leading to Denial of Service.
🎯 Impact: An attacker could crash the CLI tool by feeding it a large file or stream, disrupting data processing pipelines.
🔧 Fix: Implemented `read_with_limit` helper and enforced a 16 MiB (`MAX_COPYBOOK_SIZE`) limit on copybook inputs in `read_file_or_stdin`.
✅ Verification: Added unit tests in `copybook-cli/src/utils.rs` (`test_read_with_limit_exceeds`) to verify that inputs larger than the limit are rejected with an error.

---
*PR created automatically by Jules for task [1735029840636630826](https://jules.google.com/task/1735029840636630826) started by @EffortlessSteven*