### PR TITLE
🎨 Palette: Enable ANSI colors for CLI output

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-01-29 - Enable ANSI Colors
+**Learning:** CLI tools often default to disabling colors to be safe, but this hurts UX significantly. `clap` handles color auto-detection robustly. For `tracing-subscriber`, explicitly checking `IsTerminal` AND `NO_COLOR` is critical to respect user preferences and avoid breaking scripts.
+**Action:** Always check `IsTerminal` and `NO_COLOR` when configuring logging libraries that don't do it automatically.


### PR DESCRIPTION
Enables ANSI colors in the CLI output to improve readability of help messages and logs.
Colors are enabled automatically when running in a terminal, but disabled if `NO_COLOR` env var is set or if stderr is not a terminal (e.g., piped output).
This aligns with the project's goal of a user-friendly CLI.

---
*PR created automatically by Jules for task [1365194081818245746](https://jules.google.com/task/1365194081818245746) started by @EffortlessSteven*