### PR TITLE
🎨 Palette: Implement tree view for inspect command

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - [Hierarchical Data Visualization]
+**Learning:** Flat lists fail to convey the structure of deeply nested data like COBOL copybooks. Users need visual cues (indentation, connectors) to understand parent-child relationships (Groups, Redefines, Occurs).
+**Action:** When displaying nested schemas or structures, always prefer a tree view with visual guides (box-drawing characters) over flat tables.


### PR DESCRIPTION
💡 What: Replaced flat list with hierarchical tree view in `inspect` command.
🎯 Why: Flat lists fail to convey the structure of deeply nested data like COBOL copybooks. Users need visual cues (indentation, connectors) to understand parent-child relationships.
📸 Before/After: Verified via manual inspection of CLI output (see journal).
♿ Accessibility: Improved cognitive accessibility by making structure explicit.

---
*PR created automatically by Jules for task [13101417742480509478](https://jules.google.com/task/13101417742480509478) started by @EffortlessSteven*