### PR TITLE
🛡️ Sentinel: [HIGH] Enforce 16MB input size limit for copybooks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-23 - [DoS Vulnerability in File Reading]
+**Vulnerability:** `copybook-cli`'s `read_file_or_stdin` used `std::fs::read_to_string` without size limits, allowing potential DoS via memory exhaustion if a user provided a multi-GB file as a copybook argument.
+**Learning:** Shared utility functions for file reading must always enforce reasonable limits, even if they are intended for small configuration files, as they might be exposed to untrusted input.
+**Prevention:** Always use `read_with_limit` (or similar bounded readers) when reading external files into memory. Enforce `MAX_COPYBOOK_SIZE` (16 MiB) for schema inputs.


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Enforce 16MB input size limit for copybooks

**Vulnerability:**
`copybook-cli`'s `read_file_or_stdin` function previously used `std::fs::read_to_string` without any size limit. This allowed a user (or attacker) to provide a massive file (e.g., 10GB) as a copybook argument, causing the process to attempt to read the entire file into memory, leading to a crash or Denial of Service (DoS).

**Fix:**
- Introduced `const MAX_COPYBOOK_SIZE: u64 = 16 * 1024 * 1024;` (16 MiB).
- Implemented `read_with_limit` helper function that reads up to `limit + 1` bytes and returns an `io::Error` (`ErrorKind::FileTooLarge`) if the limit is exceeded.
- Updated `read_file_or_stdin` to use this helper for both file and stdin inputs.

**Verification:**
- Added `test_read_file_or_stdin_enforces_limit` in `copybook-cli/src/utils.rs` which verifies that reading a 17MB file fails with the expected error.
- Verified that all tests pass with `cargo test -p copybook-cli utils::tests`.

**Impact:**
- Prevents memory exhaustion attacks via copybook inputs.
- Legitimate copybooks (which are source code files and typically < 1MB) are unaffected.


---
*PR created automatically by Jules for task [5074963575723729240](https://jules.google.com/task/5074963575723729240) started by @EffortlessSteven*