### PR TITLE
🎨 Palette: Implement tree view for inspect command

### DIFF
--- a/test-data/multi_root.cpy
+++ b/test-data/multi_root.cpy
@@ -1,0 +1,1 @@
+01 A PIC X. 01 B PIC X.

--- a/test-data/multi_root_nested.cpy
+++ b/test-data/multi_root_nested.cpy
@@ -1,0 +1,1 @@
+01 A. 05 CHILD PIC X. 01 B PIC X.


### PR DESCRIPTION
Implemented a tree view for the `inspect` command to visualize nested COBOL structures more intuitively.
Replaced the flat list output with a recursive traversal that uses box-drawing characters.
Verified with single-root, multi-root, and nested copybook examples.
Ran existing tests to ensure no regressions.

---
*PR created automatically by Jules for task [5292508558019119363](https://jules.google.com/task/5292508558019119363) started by @EffortlessSteven*