### PR TITLE
🛡️ Sentinel: Fix DoS vulnerability in file reading

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Journal 🛡️
+
+## 2026-02-17 - DoS via Unbounded File Read
+**Vulnerability:** `copybook-cli`'s `read_file_or_stdin` utility read the entire input stream into memory using `read_to_string` without any size limit, enabling a Denial of Service (DoS) attack via large files or infinite stdin streams (CWE-400).
+**Learning:** Historical documentation/memory incorrectly stated a 16 MiB limit was enforced, but the actual code lacked this check. This highlights the risk of relying on documentation or "known state" without verifying the source code.
+**Prevention:** Enforce explicit size limits (`take(limit)`) on all unbounded input streams (files, network, stdin) at the point of ingestion. Verify "known" security controls against the actual codebase.

--- a/copybook-cli/src/utils.rs
+++ b/copybook-cli/src/utils.rs
@@ -159,25 +159,53 @@ pub fn determine_exit_code(
     }
 }
 
+/// Maximum allowed size for a copybook file (16 MiB)
+///
+/// This limit prevents memory exhaustion attacks when reading potentially
+/// malicious inputs via stdin or files.
+const MAX_COPYBOOK_SIZE: u64 = 16 * 1024 * 1024;
+
+/// Read content from a reader with a size limit
+///
+/// # Errors
+///
+/// Returns an error if reading fails or if the input exceeds the limit.
+fn read_with_limit<R: Read>(reader: R, limit: u64) -> io::Result<String> {
+    let mut reader = reader.take(limit + 1);
+    let mut buffer = String::new();
+    reader.read_to_string(&mut buffer)?;
+
+    if buffer.len() as u64 > limit {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Input exceeds maximum allowed size of {} bytes", limit),
+        ));
+    }
+
+    Ok(buffer)
+}
+
 /// Read file content from path or stdin if path is "-"
 ///
 /// This function provides portable stdin support by accepting "-" as a special path.
 /// When the path is "-", it reads from stdin instead of a file.
 ///
+/// It enforces a size limit of 16 MiB to prevent memory exhaustion.
+///
 /// # Errors
 ///
-/// Returns an error if the file cannot be read or if stdin reading fails.
+/// Returns an error if the file cannot be read, if stdin reading fails, or if
+/// the content exceeds the 16 MiB limit.
 pub fn read_file_or_stdin<P: AsRef<Path>>(path: P) -> io::Result<String> {
     let path = path.as_ref();
 
     if path == Path::new("-") {
         debug!("Reading from stdin");
-        let mut buffer = String::new();
-        io::stdin().read_to_string(&mut buffer)?;
-        Ok(buffer)
+        read_with_limit(io::stdin(), MAX_COPYBOOK_SIZE)
     } else {
         debug!("Reading from file: {:?}", path);
-        std::fs::read_to_string(path)
+        let file = std::fs::File::open(path)?;
+        read_with_limit(file, MAX_COPYBOOK_SIZE)
     }
 }
 
@@ -248,5 +276,29 @@ mod tests {
         let target = Path::new("output.jsonl");
         let temp = temp_path_for(target);
         assert_eq!(temp, Path::new("output.jsonl.tmp"));
+    }
+
+    #[test]
+    fn test_read_with_limit_success() -> Result<()> {
+        let input = b"Hello world";
+        let result = read_with_limit(&input[..], 20)?;
+        assert_eq!(result, "Hello world");
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_with_limit_exact() -> Result<()> {
+        let input = b"Hello";
+        let result = read_with_limit(&input[..], 5)?;
+        assert_eq!(result, "Hello");
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_with_limit_exceeded() {
+        let input = b"Hello world";
+        let result = read_with_limit(&input[..], 5);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::InvalidInput);
     }
 }


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix DoS vulnerability in file reading

🚨 Severity: HIGH (DoS risk)
💡 Vulnerability: `read_file_or_stdin` previously read the entire input stream into memory without limit.
🎯 Impact: An attacker could supply a very large file or infinite stream (e.g., `/dev/zero`) to exhaust application memory and crash the process.
🔧 Fix: Implemented a 16 MiB (`MAX_COPYBOOK_SIZE`) limit on input reading using `read_with_limit`.
✅ Verification: Added unit tests in `copybook-cli/src/utils.rs` confirming that inputs within the limit are read correctly, and inputs exceeding the limit return an error. Validated with `cargo test`.

---
*PR created automatically by Jules for task [18270594832060515709](https://jules.google.com/task/18270594832060515709) started by @EffortlessSteven*