### PR TITLE
⚡ Bolt: Optimize SmallDecimal::total_digits using ilog10

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-02-24 - Integration Benchmarks vs Micro-optimizations
+**Learning:** High-level integration benchmarks (like `encode_comp3` involving JSON) can completely mask significant micro-optimizations (e.g., 5.6x speedup in `total_digits`) due to overhead from other components (like `serde_json`).
+**Action:** Always verify low-level arithmetic optimizations with isolated micro-benchmarks before relying on integration benchmarks.

--- a/copybook-codec/src/numeric.rs
+++ b/copybook-codec/src/numeric.rs
@@ -717,14 +717,9 @@ impl SmallDecimal {
         if self.value == 0 {
             return 1;
         }
-
-        let mut count = 0;
-        let mut val = self.value.abs();
-        while val > 0 {
-            count += 1;
-            val /= 10;
-        }
-        count
+        // Optimized: Use ilog10 intrinsic for O(1) digit counting instead of O(N) iterative division.
+        // Also handles i64::MIN correctly via unsigned_abs().
+        (self.value.unsigned_abs().ilog10() + 1) as u16
     }
 }
 
@@ -3421,5 +3416,12 @@ mod tests {
             !positive_decimal.is_negative(),
             "Unsigned should not be negative"
         );
+    }
+
+    #[test]
+    fn test_total_digits_i64_min() {
+        // This test reproduces the issue where i64::MIN causes panic or incorrect result
+        let decimal = SmallDecimal::new(i64::MIN, 0, true);
+        assert_eq!(decimal.total_digits(), 19);
     }
 }


### PR DESCRIPTION
*   **What:** Replaced O(N) iterative division with O(1) `ilog10` intrinsic for digit counting in `SmallDecimal::total_digits`.
*   **Why:** Fixes a panic on `i64::MIN` in debug mode (overflow) and significantly improves performance of digit counting (5.6x speedup in micro-benchmarks).
*   **Impact:** Micro-benchmark shows ~5.6x speedup (2.58s -> 0.46s for 100M ops). Integration benchmark `encode_comp3` shows negligible change due to JSON parsing noise, but the hot path is optimized. Correctness for `i64::MIN` is now guaranteed.
*   **Verification:** Added `test_total_digits_i64_min` reproduction test case. Confirmed passes.

---
*PR created automatically by Jules for task [16675721331810007357](https://jules.google.com/task/16675721331810007357) started by @EffortlessSteven*