### PR TITLE
🛡️ Sentinel: [HIGH] Enforce input size limit on copybooks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Journal
+
+## 2026-02-24 - Missing Input Size Limits in CLI Utilities
+**Vulnerability:** The `read_file_or_stdin` utility in `copybook-cli` read entire files into memory without limits, despite documentation/memory claiming a 16 MiB limit existed.
+**Learning:** Documentation and "known state" can drift from actual implementation. Trusted helpers like "read file" are prime spots for DoS vulnerabilities if not bounded.
+**Prevention:** Always verify "known" security controls in code. Use bounded readers (`take()`) for all user-supplied inputs.


### PR DESCRIPTION
This PR addresses a Denial of Service (DoS) vulnerability where `read_file_or_stdin` would read unbounded amounts of data into memory. 

Changes:
- Added `MAX_COPYBOOK_SIZE` constant (16 MiB).
- Added `read_string_with_limit` helper using `std::io::Read::take`.
- Updated `read_file_or_stdin` to enforce this limit on both file and stdin inputs.
- Added unit tests for the new functionality.
- Documented the finding and fix in the Sentinel security journal.

Impact:
Prevents potential memory exhaustion attacks when processing untrusted copybook inputs.


---
*PR created automatically by Jules for task [4726064080198072681](https://jules.google.com/task/4726064080198072681) started by @EffortlessSteven*