### PR TITLE
🎨 Palette: Add tree view to inspect command

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-05 - [CLI Tree Visualization]
+**Learning:** Flat lists of hierarchical data (like COBOL paths) create high cognitive load for users trying to understand the structure. Replacing full dot-separated paths with indented tree structures using box-drawing characters (│, ├──, └──) dramatically improves scanability and mental model alignment.
+**Action:** When displaying nested structures in CLI tools (like schemas or file trees), prefer tree visualizations over flat lists of paths. Ensure proper handling of `is_last` for clean connectors.


### PR DESCRIPTION
Replaces the flat list of dot-separated paths in `copybook inspect` with a hierarchical tree view using box-drawing characters.

💡 What:
- Implemented a recursive `print_fields` function.
- Updated the output format to use `├──`, `└──`, and `│` for tree structure.
- Changed "Field Path" column header to "Field Tree".

🎯 Why:
- Nested COBOL structures are difficult to scan as flat lists.
- Tree view provides immediate visual feedback on hierarchy and depth.

♿ Accessibility:
- Maintains tabular layout for screen readers while adding visual structure for sighted users.
- Uses standard Unicode characters.

Verified with `fixtures/copybooks/simple.cpy` and `multi_root.cpy`.

---
*PR created automatically by Jules for task [1754058387558120772](https://jules.google.com/task/1754058387558120772) started by @EffortlessSteven*