### PR TITLE
🎨 Palette: Add tree view to inspect command

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-20 - Tree View for CLI Hierarchies
+**Learning:** Users find flat lists of hierarchical data (like COBOL structures) hard to parse visually. Using box-drawing characters to create a tree view immediately clarifies relationships without needing additional explanation or indentation columns.
+**Action:** When displaying nested data in CLI, default to tree views using standard box-drawing characters (`├`, `└`, `│`) instead of flat paths.


### PR DESCRIPTION
💡 **What**: Replaced the flat list output of `copybook inspect` with a hierarchical tree view using standard box-drawing characters.
🎯 **Why**: Users find flat lists of hierarchical data (like COBOL structures) hard to parse visually. The tree view makes the structure immediately obvious.
📸 **Before/After**:
  * **Before**: `Field Path` column showed `ROOT.CHILD.GRANDCHILD`.
  * **After**: `Field Structure` column shows indented tree:
    ```
    ROOT
    ├── CHILD
    │   └── GRANDCHILD
    ```
♿ **Accessibility**: While ASCII trees can be noisy for screen readers, they are the industry standard for CLI structure inspection (like `tree` command). The content is still text-based and readable.


---
*PR created automatically by Jules for task [7680302662097936188](https://jules.google.com/task/7680302662097936188) started by @EffortlessSteven*