### PR TITLE
🎨 Palette: Add tree view to inspect command

### DIFF
--- a/copybook-cli/src/commands/inspect.rs
+++ b/copybook-cli/src/commands/inspect.rs
@@ -45,80 +45,113 @@ pub fn run(
     output.push('\n');
     writeln!(
         output,
-        "{:<40} {:<8} {:<8} {:<12} {:<20}",
-        "Field Path", "Offset", "Length", "Type", "Details"
+        "{:<60} {:<8} {:<8} {:<12} {:<20}",
+        "Field", "Offset", "Length", "Type", "Details"
     )
     .ok();
-    writeln!(output, "{:-<88}", "").ok();
+    writeln!(output, "{:-<108}", "").ok();
 
-    for field in schema.all_fields() {
-        let type_str = match &field.kind {
-            copybook_core::FieldKind::Alphanum { len } => format!("X({len})"),
-            copybook_core::FieldKind::ZonedDecimal {
-                digits,
-                scale,
-                signed,
-            } => {
-                if *signed {
-                    format!("S9({digits})V9({scale})")
-                } else {
-                    format!("9({digits})V9({scale})")
-                }
-            }
-            copybook_core::FieldKind::BinaryInt { bits, signed } => {
-                format!("COMP-{} ({}bit)", if *signed { "S" } else { "" }, bits)
-            }
-            copybook_core::FieldKind::PackedDecimal {
-                digits,
-                scale,
-                signed,
-            } => {
-                if *signed {
-                    format!("S9({digits})V9({scale}) COMP-3")
-                } else {
-                    format!("9({digits})V9({scale}) COMP-3")
-                }
-            }
-            copybook_core::FieldKind::Group => "GROUP".to_string(),
-            copybook_core::FieldKind::Condition { values } => {
-                format!("LEVEL-88: {values:?}")
-            }
-            copybook_core::FieldKind::Renames {
-                from_field,
-                thru_field,
-            } => {
-                format!("RENAMES {from_field} THRU {thru_field}")
-            }
-            copybook_core::FieldKind::EditedNumeric { pic_string, .. } => {
-                format!("EDITED PIC {pic_string}")
-            }
-        };
-
-        let details = if let Some(ref occurs) = field.occurs {
-            match occurs {
-                copybook_core::Occurs::Fixed { count } => format!("OCCURS {count}"),
-                copybook_core::Occurs::ODO {
-                    min,
-                    max,
-                    counter_path,
-                } => {
-                    format!("ODO {min}-{max} ({counter_path})")
-                }
-            }
-        } else {
-            String::new()
-        };
-
-        writeln!(
-            output,
-            "{:<40} {:<8} {:<8} {:<12} {:<20}",
-            field.path, field.offset, field.len, type_str, details
-        )
-        .ok();
+    let count = schema.fields.len();
+    for (i, field) in schema.fields.iter().enumerate() {
+        print_field_tree(field, &mut output, "", i == count - 1, true);
     }
 
     write_stdout_all(output.as_bytes())?;
 
     info!("Inspect completed successfully");
     Ok(ExitCode::Ok)
+}
+
+fn print_field_tree(
+    field: &copybook_core::Field,
+    output: &mut String,
+    prefix: &str,
+    is_last: bool,
+    is_root: bool,
+) {
+    let type_str = format_field_type(&field.kind);
+    let details = if let Some(ref occurs) = field.occurs {
+        match occurs {
+            copybook_core::Occurs::Fixed { count } => format!("OCCURS {count}"),
+            copybook_core::Occurs::ODO {
+                min,
+                max,
+                counter_path,
+            } => {
+                format!("ODO {min}-{max} ({counter_path})")
+            }
+        }
+    } else {
+        String::new()
+    };
+
+    let tree_part = if is_root {
+        field.name.clone()
+    } else {
+        let connector = if is_last { "└── " } else { "├── " };
+        format!("{}{}{}", prefix, connector, field.name)
+    };
+
+    writeln!(
+        output,
+        "{:<60} {:<8} {:<8} {:<12} {:<20}",
+        tree_part, field.offset, field.len, type_str, details
+    )
+    .ok();
+
+    let new_prefix = if is_root {
+        "".to_string()
+    } else {
+        let child_prefix = if is_last { "    " } else { "│   " };
+        format!("{}{}", prefix, child_prefix)
+    };
+
+    let count = field.children.len();
+    for (i, child) in field.children.iter().enumerate() {
+        print_field_tree(child, output, &new_prefix, i == count - 1, false);
+    }
+}
+
+fn format_field_type(kind: &copybook_core::FieldKind) -> String {
+    match kind {
+        copybook_core::FieldKind::Alphanum { len } => format!("X({len})"),
+        copybook_core::FieldKind::ZonedDecimal {
+            digits,
+            scale,
+            signed,
+        } => {
+            if *signed {
+                format!("S9({digits})V9({scale})")
+            } else {
+                format!("9({digits})V9({scale})")
+            }
+        }
+        copybook_core::FieldKind::BinaryInt { bits, signed } => {
+            format!("COMP-{} ({}bit)", if *signed { "S" } else { "" }, bits)
+        }
+        copybook_core::FieldKind::PackedDecimal {
+            digits,
+            scale,
+            signed,
+        } => {
+            if *signed {
+                format!("S9({digits})V9({scale}) COMP-3")
+            } else {
+                format!("9({digits})V9({scale}) COMP-3")
+            }
+        }
+        copybook_core::FieldKind::Group => "GROUP".to_string(),
+        copybook_core::FieldKind::Condition { values } => {
+            format!("LEVEL-88: {values:?}")
+        }
+        copybook_core::FieldKind::Renames {
+            from_field,
+            thru_field,
+        } => {
+            format!("RENAMES {from_field} THRU {thru_field}")
+        }
+        copybook_core::FieldKind::EditedNumeric { pic_string, .. } => {
+            format!("EDITED PIC {pic_string}")
+        }
+    }
 }


### PR DESCRIPTION
💡 What:
Implemented a recursive tree view for the `copybook inspect` command using box-drawing characters (`├──`, `└──`, `│`).
Increased the "Field" column width to 60 characters to accommodate indentation.
Refactored field type formatting logic into a `format_field_type` helper function.

🎯 Why:
COBOL copybooks are inherently hierarchical (Groups, Fields, Children).
The previous flat list output made it difficult to visualize the structure and nesting depth.
The new tree view makes the parent-child relationships immediately intuitive.

📸 Before/After:
Before:
Field Path                               Offset   Length   Type         Details
CUSTOMER-RECORD                          0        50       GROUP
CUSTOMER-RECORD.CUSTOMER-ID              0        6        9(6)V9(0)

After:
Field                                                        Offset   Length   Type         Details
CUSTOMER-RECORD                                              0        50       GROUP
├── CUSTOMER-ID                                              0        6        9(6)V9(0)

♿ Accessibility:
Improved readability of hierarchical data by using standard visual indicators for nesting.
Refactored code structure improves maintainability.

---
*PR created automatically by Jules for task [15829092479818115914](https://jules.google.com/task/15829092479818115914) started by @EffortlessSteven*