### PR TITLE
🛡️ Sentinel: [MEDIUM] Enforce 16MiB limit on copybook input

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-18 - Unbounded File Reads in CLI Tools
+**Vulnerability:** `copybook-cli` used `std::fs::read_to_string` and `stdin().read_to_string` without limits, exposing the application to Memory Exhaustion (DoS) attacks via large files or infinite streams (e.g., `/dev/zero`).
+**Learning:** Checking `fs::metadata(path).len()` is insufficient for special files (like `/dev/zero` or named pipes) which may report 0 size but provide infinite data.
+**Prevention:** Always use `take(LIMIT)` or a bounded reader wrapper when processing user-supplied files or streams. Implemented `read_with_limit` helper to enforce strict 16 MiB bounds on all input sources.


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Enforce 16MiB limit on copybook input

**Severity:** MEDIUM
**Vulnerability:** Unbounded memory allocation when reading input files or stdin allowed for Denial of Service (DoS) via resource exhaustion.
**Impact:** An attacker could crash the `copybook-cli` tool by providing a large file or an infinite stream (like `/dev/zero`), potentially disrupting automated pipelines.
**Fix:** Implemented a strict 16 MiB limit (`MAX_COPYBOOK_SIZE`) on all inputs. The `read_file_or_stdin` utility now enforces this limit using `Read::take`, ensuring memory usage remains bounded.
**Verification:** Added unit tests in `copybook-cli/src/utils.rs` confirming that inputs under the limit are accepted and inputs over the limit are rejected.

---
*PR created automatically by Jules for task [14025825617790548638](https://jules.google.com/task/14025825617790548638) started by @EffortlessSteven*