### PR TITLE
🛡️ Sentinel: [HIGH] Enforce input size limit to prevent DoS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-17 - Unbounded Input Reading
+**Vulnerability:** `read_file_or_stdin` in `copybook-cli` read the entire input into a string without size limits, exposing the application to OOM DoS attacks via large files or infinite stdin streams.
+**Learning:** Utility functions for reading inputs often default to "read everything" for convenience, bypassing necessary resource constraints.
+**Prevention:** Always use bounded readers (e.g., `take()`) or check metadata size before reading untrusted inputs into memory. Enforce explicit limits at the I/O boundary.


### PR DESCRIPTION
Enforced a 16 MiB size limit on input files and stdin streams in `copybook-cli` to prevent memory exhaustion DoS attacks. Implemented `read_with_limit` helper and added unit tests.

---
*PR created automatically by Jules for task [215517223676901687](https://jules.google.com/task/215517223676901687) started by @EffortlessSteven*