### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix DoS vulnerability in CLI input

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Journal
+
+## 2026-02-06 - DoS Protection in CLI Input
+**Vulnerability:** Unbounded file/stdin reading in `read_file_or_stdin` allowed memory exhaustion via large inputs.
+**Learning:** Utility functions reading "text" often assume small inputs but must enforce limits when exposed to user input (CLI arguments, pipes).
+**Prevention:** Use `Read::take(limit)` wrapper for all external input reading to enforce strict upper bounds.

--- a/copybook-cli/src/utils.rs
+++ b/copybook-cli/src/utils.rs
@@ -159,25 +159,52 @@ pub fn determine_exit_code(
     }
 }
 
+/// Maximum allowed size for a copybook file (16 MiB)
+///
+/// This limit prevents memory exhaustion attacks where a user provides an
+/// extremely large file or infinite stream as input.
+pub const MAX_COPYBOOK_SIZE: u64 = 16 * 1024 * 1024;
+
+/// Helper to read from a reader with a size limit
+fn read_with_limit<R: Read>(reader: R, limit: u64) -> io::Result<String> {
+    let mut buffer = String::new();
+    // Read up to limit + 1 bytes to detect if we exceeded the limit
+    reader
+        .take(limit + 1)
+        .read_to_string(&mut buffer)?;
+
+    if buffer.len() as u64 > limit {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Input exceeds maximum allowed size of {} bytes", limit),
+        ));
+    }
+
+    Ok(buffer)
+}
+
 /// Read file content from path or stdin if path is "-"
 ///
 /// This function provides portable stdin support by accepting "-" as a special path.
 /// When the path is "-", it reads from stdin instead of a file.
 ///
+/// This function enforces a maximum size limit (`MAX_COPYBOOK_SIZE`) to prevent
+/// memory exhaustion.
+///
 /// # Errors
 ///
-/// Returns an error if the file cannot be read or if stdin reading fails.
+/// Returns an error if the file cannot be read, if stdin reading fails, or if
+/// the content exceeds the maximum allowed size.
 pub fn read_file_or_stdin<P: AsRef<Path>>(path: P) -> io::Result<String> {
     let path = path.as_ref();
 
     if path == Path::new("-") {
-        debug!("Reading from stdin");
-        let mut buffer = String::new();
-        io::stdin().read_to_string(&mut buffer)?;
-        Ok(buffer)
+        debug!("Reading from stdin (max {} bytes)", MAX_COPYBOOK_SIZE);
+        read_with_limit(io::stdin(), MAX_COPYBOOK_SIZE)
     } else {
-        debug!("Reading from file: {:?}", path);
-        std::fs::read_to_string(path)
+        debug!("Reading from file: {:?} (max {} bytes)", path, MAX_COPYBOOK_SIZE);
+        let file = std::fs::File::open(path)?;
+        read_with_limit(file, MAX_COPYBOOK_SIZE)
     }
 }
 
@@ -248,5 +275,24 @@ mod tests {
         let target = Path::new("output.jsonl");
         let temp = temp_path_for(target);
         assert_eq!(temp, Path::new("output.jsonl.tmp"));
+    }
+
+    #[test]
+    fn test_read_with_limit() {
+        // Test within limit
+        let data = b"Hello world";
+        let result = read_with_limit(&data[..], 20);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "Hello world");
+
+        // Test exactly limit
+        let result = read_with_limit(&data[..], 11);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "Hello world");
+
+        // Test exceeding limit
+        let result = read_with_limit(&data[..], 5);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::InvalidData);
     }
 }


### PR DESCRIPTION
This PR addresses a security vulnerability where the CLI could be crashed by providing an extremely large input file or an infinite stream to stdin, causing memory exhaustion (OOM).

**Changes:**
- Implemented a 16 MiB limit (`MAX_COPYBOOK_SIZE`) for input files read via `read_file_or_stdin`.
- Added `read_with_limit` helper function that uses `Read::take` to enforce the limit efficiently.
- Added unit tests to verify the limit logic.
- Added a security journal entry in `.jules/sentinel.md`.

**Verification:**
- Ran `cargo test -p copybook-cli utils::tests` which includes new tests for `read_with_limit`.
- Verified that reading within limit works, and exceeding limit returns an error.

---
*PR created automatically by Jules for task [5245537165644379171](https://jules.google.com/task/5245537165644379171) started by @EffortlessSteven*