### PR TITLE
🎨 Palette: Implement tree view for inspect command

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-25 - Tree View for Nested Structures
+**Learning:** For deeply nested data structures like COBOL copybooks, a flat list with dot-notation paths is difficult to scan. Replacing it with a tree view using box-drawing characters (├──, └──) significantly improves readability and user understanding of the structure.
+**Action:** When displaying hierarchical data in CLI tools, prefer recursive tree visualizations over flat lists, even if it requires slightly more complex printing logic.

--- a/copybook-cli/src/commands/inspect.rs
+++ b/copybook-cli/src/commands/inspect.rs
@@ -4,7 +4,7 @@ use crate::exit_codes::ExitCode;
 use crate::utils::read_file_or_stdin;
 use crate::write_stdout_all;
 use copybook_codec::Codepage;
-use copybook_core::{ParseOptions, parse_copybook_with_options};
+use copybook_core::{Field, FieldKind, Occurs, ParseOptions, parse_copybook_with_options};
 use std::fmt::Write as _;
 use std::path::PathBuf;
 use tracing::info;
@@ -46,79 +46,100 @@ pub fn run(
     writeln!(
         output,
         "{:<40} {:<8} {:<8} {:<12} {:<20}",
-        "Field Path", "Offset", "Length", "Type", "Details"
+        "Tree View", "Offset", "Length", "Type", "Details"
     )
     .ok();
     writeln!(output, "{:-<88}", "").ok();
 
-    for field in schema.all_fields() {
-        let type_str = match &field.kind {
-            copybook_core::FieldKind::Alphanum { len } => format!("X({len})"),
-            copybook_core::FieldKind::ZonedDecimal {
-                digits,
-                scale,
-                signed,
-            } => {
-                if *signed {
-                    format!("S9({digits})V9({scale})")
-                } else {
-                    format!("9({digits})V9({scale})")
-                }
-            }
-            copybook_core::FieldKind::BinaryInt { bits, signed } => {
-                format!("COMP-{} ({}bit)", if *signed { "S" } else { "" }, bits)
-            }
-            copybook_core::FieldKind::PackedDecimal {
-                digits,
-                scale,
-                signed,
-            } => {
-                if *signed {
-                    format!("S9({digits})V9({scale}) COMP-3")
-                } else {
-                    format!("9({digits})V9({scale}) COMP-3")
-                }
-            }
-            copybook_core::FieldKind::Group => "GROUP".to_string(),
-            copybook_core::FieldKind::Condition { values } => {
-                format!("LEVEL-88: {values:?}")
-            }
-            copybook_core::FieldKind::Renames {
-                from_field,
-                thru_field,
-            } => {
-                format!("RENAMES {from_field} THRU {thru_field}")
-            }
-            copybook_core::FieldKind::EditedNumeric { pic_string, .. } => {
-                format!("EDITED PIC {pic_string}")
-            }
-        };
-
-        let details = if let Some(ref occurs) = field.occurs {
-            match occurs {
-                copybook_core::Occurs::Fixed { count } => format!("OCCURS {count}"),
-                copybook_core::Occurs::ODO {
-                    min,
-                    max,
-                    counter_path,
-                } => {
-                    format!("ODO {min}-{max} ({counter_path})")
-                }
-            }
-        } else {
-            String::new()
-        };
-
-        writeln!(
-            output,
-            "{:<40} {:<8} {:<8} {:<12} {:<20}",
-            field.path, field.offset, field.len, type_str, details
-        )
-        .ok();
+    for (i, field) in schema.fields.iter().enumerate() {
+        print_tree_recursive(&mut output, field, "", i == schema.fields.len() - 1);
     }
 
     write_stdout_all(output.as_bytes())?;
 
     info!("Inspect completed successfully");
     Ok(ExitCode::Ok)
+}
+
+fn print_tree_recursive(output: &mut String, field: &Field, prefix: &str, is_last: bool) {
+    let type_str = match &field.kind {
+        FieldKind::Alphanum { len } => format!("X({len})"),
+        FieldKind::ZonedDecimal {
+            digits,
+            scale,
+            signed,
+        } => {
+            if *signed {
+                format!("S9({digits})V9({scale})")
+            } else {
+                format!("9({digits})V9({scale})")
+            }
+        }
+        FieldKind::BinaryInt { bits, signed } => {
+            format!("COMP-{} ({}bit)", if *signed { "S" } else { "" }, bits)
+        }
+        FieldKind::PackedDecimal {
+            digits,
+            scale,
+            signed,
+        } => {
+            if *signed {
+                format!("S9({digits})V9({scale}) COMP-3")
+            } else {
+                format!("9({digits})V9({scale}) COMP-3")
+            }
+        }
+        FieldKind::Group => "GROUP".to_string(),
+        FieldKind::Condition { values } => {
+            format!("LEVEL-88: {values:?}")
+        }
+        FieldKind::Renames {
+            from_field,
+            thru_field,
+        } => {
+            format!("RENAMES {from_field} THRU {thru_field}")
+        }
+        FieldKind::EditedNumeric { pic_string, .. } => {
+            format!("EDITED PIC {pic_string}")
+        }
+    };
+
+    let details = if let Some(ref occurs) = field.occurs {
+        match occurs {
+            Occurs::Fixed { count } => format!("OCCURS {count}"),
+            Occurs::ODO {
+                min,
+                max,
+                counter_path,
+            } => {
+                format!("ODO {min}-{max} ({counter_path})")
+            }
+        }
+    } else {
+        String::new()
+    };
+
+    let connector = if is_last { "└── " } else { "├── " };
+    let tree_name = format!("{prefix}{connector}{}", field.name);
+
+    // Truncate if too long to maintain alignment
+    let display_name = if tree_name.chars().count() > 39 {
+        let mut s: String = tree_name.chars().take(38).collect();
+        s.push('…');
+        s
+    } else {
+        tree_name
+    };
+
+    writeln!(
+        output,
+        "{:<40} {:<8} {:<8} {:<12} {:<20}",
+        display_name, field.offset, field.len, type_str, details
+    )
+    .ok();
+
+    let child_prefix = format!("{prefix}{}", if is_last { "    " } else { "│   " });
+    for (i, child) in field.children.iter().enumerate() {
+        print_tree_recursive(output, child, &child_prefix, i == field.children.len() - 1);
+    }
 }


### PR DESCRIPTION
💡 What: Replaced the flat table output in the `inspect` command with a hierarchical tree view using box-drawing characters.
🎯 Why: Deeply nested COBOL structures are difficult to visualize in a flat list. The tree view makes the hierarchy immediately apparent.
📸 Before/After: Before was a flat list of full paths. After is a tree structure with indentation.
♿ Accessibility: Improved cognitive accessibility by making structure explicit.

---
*PR created automatically by Jules for task [14954343310003408962](https://jules.google.com/task/14954343310003408962) started by @EffortlessSteven*