### PR TITLE
docs(license): document SPDX exclusions for tooling dirs

### DIFF
--- a/LICENSE_SCOPE.md
+++ b/LICENSE_SCOPE.md
@@ -6,3 +6,15 @@ Steven Zimmerman / EffortlessMetrics.
 
 No third-party code is vendored. All dependencies are sourced from
 crates.io and are listed with their licenses in THIRD_PARTY_NOTICES.md.
+
+## SPDX Header Exclusions
+
+The following directories intentionally **omit** per-file SPDX license
+headers to preserve tool-parser compatibility (YAML front matter, etc.):
+
+- `.claude/`
+- `.kiro/`
+- `.jules/` (if added in the future)
+
+These directories are covered by the repository-level AGPL-3.0-or-later
+license. Do not inject SPDX headers into these paths.


### PR DESCRIPTION
## What

Document that `.claude/`, `.kiro/`, and `.jules/` intentionally omit per-file SPDX license headers.

## Why

Those directories contain machine-consumed configs (YAML front matter, JSON, etc.); injecting SPDX headers can break tool parsers. They remain covered by the repository-level AGPL-3.0-or-later license.

## Scope

Docs-only change to `LICENSE_SCOPE.md`. No code changes.

## Sanity Checks

- Confirmed no SPDX headers exist in `.claude/` or `.kiro/` (PR #285 already removed them)
- GitHub sidebar shows AGPL-3.0-or-later license badge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated license documentation to clarify header exemptions for designated directories while confirming they remain covered under the repository-level license.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->