### PR TITLE
fix: make workspace build and test cleanly on fresh Windows clone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,8 +163,9 @@ jobs:
       run: cargo build --workspace --examples
     - name: Build copybook-arrow examples
       run: cargo build -p copybook-arrow --examples
-    - name: Build kafka_pipeline example
-      run: cargo build -p kafka-pipeline
+    - name: Build kafka_pipeline example (Linux only)
+      if: matrix.os == 'ubuntu-latest'
+      run: cargo build --manifest-path examples/kafka_pipeline/Cargo.toml
 
   security:
     name: Security Checks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,21 +1900,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kafka-pipeline"
-version = "0.4.3"
-dependencies = [
- "copybook-codec",
- "copybook-core",
- "rdkafka",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1994,18 +1979,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "libz-sys"
-version = "1.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "linked-hash-map"
@@ -2303,28 +2276,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
-dependencies = [
- "num_enum_derive",
- "rustversion",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2347,28 +2298,6 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-src"
-version = "300.5.5+3.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "ordered-float"
@@ -2625,15 +2554,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2844,38 +2764,6 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "rdkafka"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b52c81ac3cac39c9639b95c20452076e74b8d9a71bc6fc4d83407af2ea6fff"
-dependencies = [
- "futures-channel",
- "futures-util",
- "libc",
- "log",
- "rdkafka-sys",
- "serde",
- "serde_derive",
- "serde_json",
- "slab",
- "tokio",
-]
-
-[[package]]
-name = "rdkafka-sys"
-version = "4.10.0+2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e234cf318915c1059d4921ef7f75616b5219b10b46e9f3a511a15eb4b56a3f77"
-dependencies = [
- "cmake",
- "libc",
- "libz-sys",
- "num_enum",
- "openssl-sys",
- "pkg-config",
 ]
 
 [[package]]
@@ -3721,18 +3609,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "toml_parser",
- "winnow",
-]
-
-[[package]]
 name = "toml_parser"
 version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3962,12 +3838,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -4477,9 +4347,6 @@ name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ members = [
     "xtask",
     "tests/bdd",
     "tests/proptest",
-    "examples/kafka_pipeline",
 ]
 resolver = "2"
 

--- a/copybook-bench/src/health.rs
+++ b/copybook-bench/src/health.rs
@@ -31,7 +31,16 @@ pub struct HealthCheck {
 /// Run all health checks and return results.
 #[must_use]
 pub fn run_health_checks(baseline_path: &Path) -> Vec<HealthCheck> {
+    #[cfg(target_os = "linux")]
     let mut checks = vec![
+        check_rust_version(),
+        check_baseline_exists(baseline_path),
+        check_disk_space(),
+        check_memory(),
+    ];
+
+    #[cfg(not(target_os = "linux"))]
+    let checks = vec![
         check_rust_version(),
         check_baseline_exists(baseline_path),
         check_disk_space(),

--- a/copybook-bench/tests/baseline_reconciliation.rs
+++ b/copybook-bench/tests/baseline_reconciliation.rs
@@ -304,10 +304,13 @@ fn test_baseline_persistence() {
         "JSON should contain history array"
     );
 
-    // Test persistence error handling
-    let invalid_path = "/invalid/path/baseline.json";
-    let result = store.save(invalid_path);
-    assert!(result.is_err(), "Should fail to save to invalid path");
+    // Test persistence error handling (cross-platform: create a file where the parent dir should be)
+    let error_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let blocker = error_dir.path().join("not_a_dir");
+    std::fs::write(&blocker, b"x").expect("Failed to create blocker file");
+    let invalid_path = blocker.join("baseline.json");
+    let result = store.save(&invalid_path);
+    assert!(result.is_err(), "Should fail to save when parent is a file");
 }
 
 /// AC2: Test baseline documentation requirements

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -136,7 +136,7 @@ The Kafka adapter (`examples/kafka_pipeline`) provides a streaming pipeline for 
 The Kafka adapter is provided as an example. Build it:
 
 ```bash
-cargo build --example kafka_pipeline
+cargo build --manifest-path examples/kafka_pipeline/Cargo.toml
 ```
 
 ### Configuration
@@ -160,7 +160,7 @@ export COPYBOOK_PATH="path/to/copybook.cpy"
 export DATA_PATH="path/to/data.bin"
 
 # Run the pipeline
-cargo run --example kafka_pipeline
+cargo run --manifest-path examples/kafka_pipeline/Cargo.toml
 ```
 
 ### Features
@@ -195,10 +195,10 @@ cargo run --example kafka_pipeline
 
 ```bash
 # Build the example
-cargo build --example kafka_pipeline
+cargo build --manifest-path examples/kafka_pipeline/Cargo.toml
 
 # Build with release optimizations
-cargo build --example kafka_pipeline --release
+cargo build --manifest-path examples/kafka_pipeline/Cargo.toml --release
 ```
 
 ## Building and Running Examples
@@ -216,7 +216,7 @@ cargo build --workspace --examples
 cargo build -p copybook-arrow --examples
 
 # Kafka pipeline example
-cargo build --example kafka_pipeline
+cargo build --manifest-path examples/kafka_pipeline/Cargo.toml
 ```
 
 ### Run Examples
@@ -228,7 +228,7 @@ cargo run --example decode_to_parquet -p copybook-arrow
 cargo run --example batch_processing -p copybook-arrow
 
 # Kafka example
-cargo run --example kafka_pipeline
+cargo run --manifest-path examples/kafka_pipeline/Cargo.toml
 ```
 
 ### Using Just

--- a/examples/kafka_pipeline/Cargo.toml
+++ b/examples/kafka_pipeline/Cargo.toml
@@ -1,17 +1,21 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# NOTE: This crate is NOT a workspace member (requires rdkafka/openssl).
+# Versions must be updated manually on release since workspace inheritance
+# does not apply. Keep in sync with the root Cargo.toml [workspace.package].
 [package]
 name = "kafka-pipeline"
-version.workspace = true
-edition.workspace = true
-rust-version.workspace = true
-license.workspace = true
-authors.workspace = true
-repository.workspace = true
-homepage.workspace = true
+version = "0.4.3"
+edition = "2024"
+rust-version = "1.92"
+license = "AGPL-3.0-or-later"
+authors = ["Steven Zimmerman, CPA <git@effortlesssteven.com>"]
+repository = "https://github.com/EffortlessMetrics/copybook-rs"
+homepage = "https://github.com/EffortlessMetrics/copybook-rs"
 description = "Kafka pipeline example for copybook-rs"
 readme = "README.md"
-keywords.workspace = true
-categories.workspace = true
+keywords = ["cobol", "copybook", "mainframe", "ebcdic", "etl"]
+categories = ["parsing", "encoding", "command-line-utilities"]
 publish = false
 
 [[bin]]
@@ -20,25 +24,38 @@ path = "src/main.rs"
 
 [dependencies]
 # Internal workspace dependencies
-copybook-core = { workspace = true }
-copybook-codec = { workspace = true }
+copybook-core = { version = "=0.4.3", path = "../../copybook-core" }
+copybook-codec = { version = "=0.4.3", path = "../../copybook-codec" }
 
 # Kafka dependencies
 rdkafka = { version = "0.37", features = ["cmake-build", "ssl-vendored"] }
 
 # Async runtime
-tokio = { workspace = true, features = ["full"] }
+tokio = { version = "1.49.0", features = ["full"] }
 
 # Serialization
-serde = { workspace = true }
-serde_json = { workspace = true }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = { version = "1.0.149", features = ["preserve_order"] }
 
 # Error handling
-thiserror = { workspace = true }
+thiserror = "2.0.18"
 
 # Logging
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
+tracing = "0.1.44"
+tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 
-[lints]
-workspace = true
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
+unreachable = "deny"
+todo = "deny"
+unimplemented = "deny"
+missing_inline_in_public_items = "warn"
+cast_lossless = "allow"
+cast_possible_truncation = "allow"
+cast_precision_loss = "allow"
+cast_sign_loss = "allow"

--- a/examples/kafka_pipeline/README.md
+++ b/examples/kafka_pipeline/README.md
@@ -70,13 +70,13 @@ export DATA_PATH="path/to/your/data.bin"
 ### Build the example
 
 ```bash
-cargo build -p kafka-pipeline
+cargo build --manifest-path examples/kafka_pipeline/Cargo.toml
 ```
 
 ### Run with default configuration
 
 ```bash
-cargo run -p kafka-pipeline
+cargo run --manifest-path examples/kafka_pipeline/Cargo.toml
 ```
 
 ### Run with custom configuration
@@ -86,7 +86,7 @@ KAFKA_BROKERS="kafka1:9092,kafka2:9092" \
 KAFKA_TOPIC="my-topic" \
 COPYBOOK_PATH="/data/records.cpy" \
 DATA_PATH="/data/records.bin" \
-cargo run -p kafka-pipeline
+cargo run --manifest-path examples/kafka_pipeline/Cargo.toml
 ```
 
 ## Example Output

--- a/examples/kafka_pipeline/src/main.rs
+++ b/examples/kafka_pipeline/src/main.rs
@@ -23,7 +23,7 @@
 //! # Running the example
 //!
 //! ```bash
-//! cargo run --example kafka_pipeline
+//! cargo run --manifest-path examples/kafka_pipeline/Cargo.toml
 //! ```
 
 use copybook_codec::{Codepage, DecodeOptions, JsonNumberMode, RecordFormat, UnmappablePolicy};

--- a/justfile
+++ b/justfile
@@ -425,8 +425,8 @@ example-arrow-batch:
 
 # Build Kafka example
 example-kafka:
-    cargo build -p kafka-pipeline
+    cargo build --manifest-path examples/kafka_pipeline/Cargo.toml
 
 # Run Kafka example
 example-kafka-run:
-    cargo run -p kafka-pipeline
+    cargo run --manifest-path examples/kafka_pipeline/Cargo.toml


### PR DESCRIPTION
## Summary

- Remove `kafka_pipeline` from workspace members — rdkafka/OpenSSL requires a platform-specific C toolchain that breaks `cargo build --workspace` on Windows. The example now builds via `--manifest-path` in a Linux-only CI step.
- Add `#[cfg(not(target_os = "linux"))]` variant for CPU governor health check in `copybook-bench`, which only exists on Linux.
- Fix `baseline_reconciliation.rs` test to use cross-platform temp paths instead of Unix-only `/invalid/path`.
- Update CI workflow, docs, justfile, and kafka example for the new `--manifest-path` build approach.

## Test plan

- [ ] CI passes on all matrix entries (ubuntu, windows, macos)
- [ ] `kafka_pipeline` still builds in the Linux-only CI step
- [ ] `cargo test --workspace` succeeds on a fresh Windows clone
- [ ] `cargo build --workspace` succeeds on a fresh Windows clone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured Kafka Pipeline example as a standalone crate, restricting builds to Linux in CI/CD.
  * Updated build and run commands to use explicit manifest paths throughout documentation and configuration files.

* **Bug Fixes**
  * Improved test cross-platform compatibility for path validation.

* **New Features**
  * Added Linux-specific CPU governor health check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->