### PR TITLE
fix: detect Windows temp directories with backslash in bench-report

### DIFF
--- a/copybook-bench/src/bin/bench-report.rs
+++ b/copybook-bench/src/bin/bench-report.rs
@@ -321,10 +321,12 @@ fn get_baseline_path() -> PathBuf {
     let current_dir = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
 
     // Check for temp directory using multiple indicators
-    let is_temp_dir = current_dir.to_string_lossy().contains("/tmp")
-        || current_dir.to_string_lossy().contains("tmp.")
-        || current_dir.to_string_lossy().contains("/var/folders")  // macOS temp
-        || current_dir.to_string_lossy().contains("/Temp")  // Windows temp
+    let current_dir_str = current_dir.to_string_lossy();
+    let is_temp_dir = current_dir_str.contains("/tmp")
+        || current_dir_str.contains("tmp.")
+        || current_dir_str.contains("/var/folders")  // macOS temp
+        || current_dir_str.contains("/Temp")  // Windows temp (forward slash)
+        || current_dir_str.contains("\\Temp")  // Windows temp (backslash)
         || env::var("COPYBOOK_TEST_TEMP").is_ok(); // Explicit test flag
 
     if is_temp_dir {


### PR DESCRIPTION
## Summary
- Fixed `get_baseline_path()` in `bench-report` to detect Windows temp directories using backslash (`\Temp`) in addition to forward slash (`/Temp`)
- This caused `test_cli_baseline_mutations` to fail on Windows because the temp dir was not recognized, so the tool fell through to the workspace baseline path instead of using a local `baseline.json`

## Test plan
- [x] `cargo test -p copybook-bench --test cli_tool_mutation_testing -- test_cli_baseline_mutations` passes
- [x] Full `cargo test --workspace` passes (1826 tests, 0 failures)
- [x] `cargo clippy --workspace -- -D warnings -W clippy::pedantic` clean
- [x] `cargo fmt --all --check` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temporary directory detection across platforms, including enhanced Windows support.
  * Added environment variable control for deterministic test behavior configuration.

* **Chores**
  * Optimized directory path handling for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->