### PR TITLE
Extract FeatureId into dedicated `copybook-support-id` microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,12 +1077,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "copybook-support-matrix"
+name = "copybook-support-id"
 version = "0.4.3"
 dependencies = [
  "serde",
- "serde_json",
  "serde_plain",
+]
+
+[[package]]
+name = "copybook-support-matrix"
+version = "0.4.3"
+dependencies = [
+ "copybook-support-id",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "copybook-arrow",
     "copybook-contracts",
     "copybook-support-matrix",
+    "copybook-support-id",
     "xtask",
     "tests/bdd",
     "tests/proptest",
@@ -76,6 +77,7 @@ copybook-governance-contracts = { version = "=0.4.3", path = "copybook-governanc
 copybook-bench = { version = "=0.4.3", path = "copybook-bench" }
 copybook-contracts = { version = "=0.4.3", path = "copybook-contracts" }
 copybook-support-matrix = { version = "=0.4.3", path = "copybook-support-matrix" }
+copybook-support-id = { version = "=0.4.3", path = "copybook-support-id" }
 
 # Core dependencies
 serde = { version = "1.0.228", features = ["derive"] }

--- a/copybook-support-id/Cargo.toml
+++ b/copybook-support-id/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "copybook-support-id"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Canonical support-matrix feature identifiers for copybook-rs"
+keywords.workspace = true
+categories.workspace = true
+documentation = "https://docs.rs/copybook-support-id"
+
+[dependencies]
+serde.workspace = true
+serde_plain.workspace = true
+
+[lints]
+workspace = true

--- a/copybook-support-id/src/lib.rs
+++ b/copybook-support-id/src/lib.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Canonical support-matrix feature identifiers.
+
+use core::str::FromStr;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub enum FeatureId {
+    #[serde(rename = "level-88")]
+    Level88Conditions,
+    #[serde(rename = "level-66-renames")]
+    Level66Renames,
+    #[serde(rename = "occurs-depending")]
+    OccursDepending,
+    #[serde(rename = "edited-pic")]
+    EditedPic,
+    #[serde(rename = "comp-1-comp-2")]
+    Comp1Comp2,
+    #[serde(rename = "sign-separate")]
+    SignSeparate,
+    #[serde(rename = "nested-odo")]
+    NestedOdo,
+}
+
+impl FeatureId {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Level88Conditions => "level-88",
+            Self::Level66Renames => "level-66-renames",
+            Self::OccursDepending => "occurs-depending",
+            Self::EditedPic => "edited-pic",
+            Self::Comp1Comp2 => "comp-1-comp-2",
+            Self::SignSeparate => "sign-separate",
+            Self::NestedOdo => "nested-odo",
+        }
+    }
+}
+
+impl FromStr for FeatureId {
+    type Err = serde_plain::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_plain::from_str(s)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn as_str_matches_serde_encoding() {
+        for id in [
+            FeatureId::Level88Conditions,
+            FeatureId::Level66Renames,
+            FeatureId::OccursDepending,
+            FeatureId::EditedPic,
+            FeatureId::Comp1Comp2,
+            FeatureId::SignSeparate,
+            FeatureId::NestedOdo,
+        ] {
+            let encoded = serde_plain::to_string(&id).expect("must encode");
+            assert_eq!(encoded, id.as_str());
+            assert_eq!(FeatureId::from_str(id.as_str()).ok(), Some(id));
+        }
+    }
+}

--- a/copybook-support-matrix/Cargo.toml
+++ b/copybook-support-matrix/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["config", "development-tools"]
 
 [dependencies]
 serde.workspace = true
-serde_plain.workspace = true
+copybook-support-id.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/copybook-support-matrix/src/lib.rs
+++ b/copybook-support-matrix/src/lib.rs
@@ -1,33 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! COBOL feature support matrix registry.
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-#[non_exhaustive]
-pub enum FeatureId {
-    #[serde(rename = "level-88")]
-    Level88Conditions,
-
-    #[serde(rename = "level-66-renames")]
-    Level66Renames,
-
-    #[serde(rename = "occurs-depending")]
-    OccursDepending,
-
-    #[serde(rename = "edited-pic")]
-    EditedPic,
-
-    #[serde(rename = "comp-1-comp-2")]
-    Comp1Comp2,
-
-    #[serde(rename = "sign-separate")]
-    SignSeparate,
-
-    #[serde(rename = "nested-odo")]
-    NestedOdo,
-}
+pub use copybook_support_id::FeatureId;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -121,14 +97,12 @@ pub fn find_feature_by_id(id: FeatureId) -> Option<&'static FeatureSupport> {
 #[inline]
 #[must_use]
 pub fn find_feature(id: &str) -> Option<&'static FeatureSupport> {
-    all_features()
-        .iter()
-        .find(|f| serde_plain::to_string(&f.id).ok().as_deref() == Some(id))
+    let id = id.parse().ok()?;
+    find_feature_by_id(id)
 }
 
 #[cfg(test)]
 #[allow(clippy::expect_used)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 
@@ -161,7 +135,6 @@ mod tests {
     #[test]
     fn test_feature_id_serde_roundtrip() {
         let id = FeatureId::Level88Conditions;
-        let serialized = serde_plain::to_string(&id).expect("serialization should succeed");
-        assert_eq!(serialized, "level-88");
+        assert_eq!(id.as_str(), "level-88");
     }
 }


### PR DESCRIPTION
### Motivation
- Isolate the canonical support-matrix feature identifiers into a single-responsibility microcrate so other crates can depend only on stable IDs without pulling the full matrix data.

### Description
- Added a new workspace crate `copybook-support-id` that defines the `FeatureId` enum with `as_str` and `FromStr` implementations and focused unit tests in `copybook-support-id/src/lib.rs`.
- Wired the new crate into the workspace members and `workspace.dependencies` in `Cargo.toml` and updated `Cargo.lock` accordingly.
- Updated `copybook-support-matrix` to depend on and re-export `FeatureId` from `copybook-support-id` and simplified `find_feature` to parse the incoming id string and delegate to `find_feature_by_id`.
- Minor formatting via `cargo fmt` and small test/usability adjustments in `copybook-support-matrix/src/lib.rs` to use the extracted type.

### Testing
- Ran `cargo fmt` to normalize formatting and the command completed successfully.
- Ran `cargo test -p copybook-support-id -p copybook-support-matrix -p copybook-governance-grid -p copybook-governance-runtime` and all unit tests for those packages passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d6a4ea0c8333a7a25400278a5d68)