### PR TITLE
refactor: split CLI atomic file/text IO into copybook-record-io microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,6 +811,7 @@ dependencies = [
  "copybook-codec",
  "copybook-core",
  "copybook-governance",
+ "copybook-record-io",
  "md5",
  "metrics",
  "metrics-exporter-prometheus",
@@ -1066,6 +1067,7 @@ dependencies = [
  "copybook-options",
  "copybook-rdw",
  "proptest",
+ "tempfile",
 ]
 
 [[package]]

--- a/copybook-cli/Cargo.toml
+++ b/copybook-cli/Cargo.toml
@@ -39,6 +39,7 @@ chrono.workspace = true
 anyhow.workspace = true
 copybook-core = { workspace = true }
 copybook-codec = { workspace = true }
+copybook-record-io = { workspace = true }
 copybook-governance = { workspace = true }
 copybook-arrow = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }

--- a/copybook-cli/src/utils.rs
+++ b/copybook-cli/src/utils.rs
@@ -3,12 +3,8 @@
 
 use crate::exit_codes::ExitCode;
 use copybook_core::{ParseOptions, Schema};
-use std::io::{self, Read, Write};
-use std::path::Path;
-#[cfg(test)]
-use std::path::PathBuf;
-use tempfile::NamedTempFile;
-use tracing::{debug, info};
+
+pub use copybook_record_io::{atomic_write, read_text_file_or_stdin as read_file_or_stdin};
 
 /// Parse --select arguments (supports comma-separated and multiple flags)
 ///
@@ -54,10 +50,6 @@ pub fn apply_field_projection(schema: Schema, select_args: &[String]) -> anyhow:
     }
 
     let selectors = parse_selectors(select_args);
-    info!(
-        "Applying field projection with {} selectors",
-        selectors.len()
-    );
     copybook_core::project_schema(&schema, &selectors).map_err(|err| {
         anyhow::anyhow!("Failed to apply field projection with selectors {selectors:?}: {err}")
     })
@@ -87,60 +79,6 @@ pub fn build_parse_options(config: &ParseOptionsConfig) -> ParseOptions {
     }
 }
 
-/// Atomically write data to a file using temporary file + rename
-///
-/// This ensures that the output file is either completely written or not present at all,
-/// preventing partial writes from being visible to other processes.
-///
-/// # Errors
-///
-/// Returns an error if the temporary file cannot be created, written to, or renamed.
-pub fn atomic_write<P: AsRef<Path>, F>(path: P, write_fn: F) -> io::Result<()>
-where
-    F: FnOnce(&mut dyn Write) -> io::Result<()>,
-{
-    let path = path.as_ref();
-
-    // Create temporary file in the same directory as the target
-    let temp_dir = path.parent().unwrap_or_else(|| Path::new("."));
-    let mut temp_file = NamedTempFile::new_in(temp_dir)?;
-
-    debug!("Writing to temporary file: {:?}", temp_file.path());
-
-    // Write data to temporary file
-    write_fn(&mut temp_file)?;
-
-    // Ensure all data is written to disk
-    temp_file.flush()?;
-    temp_file.as_file().sync_all()?;
-
-    // Atomically rename temporary file to target
-    debug!("Renaming {:?} to {:?}", temp_file.path(), path);
-    temp_file.persist(path)?;
-
-    Ok(())
-}
-
-/// Create a temporary file path for atomic operations
-///
-/// This generates a temporary file name in the same directory as the target file
-/// with a .tmp suffix and random component.
-#[cfg(test)]
-#[allow(clippy::expect_used)]
-#[allow(clippy::unwrap_used)]
-fn temp_path_for(target: &Path) -> PathBuf {
-    let mut temp_name = target
-        .file_name()
-        .unwrap_or_else(|| std::ffi::OsStr::new("output"))
-        .to_os_string();
-    temp_name.push(".tmp");
-
-    if let Some(parent) = target.parent() {
-        parent.join(temp_name)
-    } else {
-        PathBuf::from(temp_name)
-    }
-}
 /// Determine exit code based on processing results.
 ///
 /// Warnings never flip the exit code today; we still pass the flag through so that
@@ -160,65 +98,11 @@ pub fn determine_exit_code(
     }
 }
 
-/// Read file content from path or stdin if path is "-"
-///
-/// This function provides portable stdin support by accepting "-" as a special path.
-/// When the path is "-", it reads from stdin instead of a file.
-///
-/// # Errors
-///
-/// Returns an error if the file cannot be read or if stdin reading fails.
-pub fn read_file_or_stdin<P: AsRef<Path>>(path: P) -> io::Result<String> {
-    let path = path.as_ref();
-
-    if path == Path::new("-") {
-        debug!("Reading from stdin");
-        let mut buffer = String::new();
-        io::stdin().read_to_string(&mut buffer)?;
-        Ok(buffer)
-    } else {
-        debug!("Reading from file: {:?}", path);
-        std::fs::read_to_string(path)
-    }
-}
-
 #[cfg(test)]
 #[allow(clippy::expect_used)]
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use anyhow::Result;
-    use std::fs;
-    use tempfile::tempdir;
-
-    #[test]
-    fn test_atomic_write_success() -> Result<()> {
-        let temp_dir = tempdir()?;
-        let target_path = temp_dir.path().join("test.txt");
-
-        let result = atomic_write(&target_path, |writer| writer.write_all(b"Hello, world!"));
-
-        assert!(result.is_ok());
-        assert!(target_path.exists());
-
-        let content = fs::read_to_string(&target_path)?;
-        assert_eq!(content, "Hello, world!");
-        Ok(())
-    }
-
-    #[test]
-    fn test_atomic_write_failure_leaves_no_file() -> Result<()> {
-        let temp_dir = tempdir()?;
-        let target_path = temp_dir.path().join("test.txt");
-
-        let result = atomic_write(&target_path, |_writer| {
-            Err(io::Error::other("Simulated error"))
-        });
-
-        assert!(result.is_err());
-        assert!(!target_path.exists());
-        Ok(())
-    }
 
     #[test]
     fn test_determine_exit_code() {
@@ -238,16 +122,5 @@ mod tests {
             determine_exit_code(true, true, ExitCode::Encode),
             ExitCode::Encode
         ); // Both warnings and errors adopt failure variant
-    }
-
-    #[test]
-    fn test_temp_path_for() {
-        let target = Path::new("/path/to/output.jsonl");
-        let temp = temp_path_for(target);
-        assert_eq!(temp, Path::new("/path/to/output.jsonl.tmp"));
-
-        let target = Path::new("output.jsonl");
-        let temp = temp_path_for(target);
-        assert_eq!(temp, Path::new("output.jsonl.tmp"));
     }
 }

--- a/copybook-record-io/Cargo.toml
+++ b/copybook-record-io/Cargo.toml
@@ -25,6 +25,7 @@ copybook-error.workspace = true
 copybook-options.workspace = true
 copybook-fixed.workspace = true
 copybook-rdw.workspace = true
+tempfile.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true


### PR DESCRIPTION
### Motivation

- Reduce duplication and follow SRP by moving file-boundary I/O (atomic file write and text file/stdin reading) into the record I/O microcrate instead of keeping them in the CLI utils.
- Make the file I/O helpers reusable by other crates that need record/file semantics and keep CLI code focused on argument handling and orchestration.

### Description

- Extracted `atomic_write` and `read_text_file_or_stdin` into `copybook-record-io::atomic_write` and `copybook-record-io::read_text_file_or_stdin` and implemented them in `copybook-record-io/src/lib.rs`.
- Added focused unit tests for the extracted APIs in `copybook-record-io` covering success/failure of `atomic_write` and the file read path for `read_text_file_or_stdin`.
- Rewired `copybook-cli` to consume these helpers via `pub use copybook_record_io::{atomic_write, read_text_file_or_stdin as read_file_or_stdin};` and removed the duplicated implementations from `copybook-cli/src/utils.rs`.
- Updated crate dependencies so `copybook-record-io` owns `tempfile` and `copybook-cli` depends on `copybook-record-io` (Cargo.toml updates) and applied `cargo fmt` changes.

### Testing

- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p copybook-record-io -p copybook-cli` and all tests for both crates passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d6a2de9c8333b0332237288184a2)