### PR TITLE
ci: make codecov status checks informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+# Codecov configuration for copybook-rs
+# Prevents codecov/patch status checks from blocking PRs due to narrow
+# threshold misses (e.g., 77.27% vs 77.53% target).
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+ignore:
+  - "tools/**"
+  - "tests/**"
+  - "fuzz/**"
+  - "examples/**"


### PR DESCRIPTION
## Problem

The \codecov/patch\ status check was failing on PRs due to narrow threshold misses. For example, PR #318 failed with:

> 77.27% of diff hit (target 77.53%)

Without a \codecov.yml\, Codecov uses auto-computed thresholds that are fragile and block merges for trivial coverage fluctuations (0.26% miss in this case).

## Fix

Add \codecov.yml\ to:
- Make both **project** and **patch** coverage checks **informational** (reported but non-blocking)
- Exclude \	ools/\, \	ests/\, \uzz/\, and \xamples/\ directories from coverage reporting

Coverage metrics will still be reported on PRs for visibility, but narrow threshold misses will no longer block merges.

## Verification

After merge, the \codecov/patch\ and \codecov/project\ status checks will show as informational (neutral) rather than required (pass/fail).