### PR TITLE
fix(ci): exclude copybook-e2e and copybook-proptest from tarpaulin coverage

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -45,6 +45,8 @@ jobs:
           --workspace \
           --exclude copybook-bench \
           --exclude copybook-bdd \
+          --exclude copybook-e2e \
+          --exclude copybook-proptest \
           --exclude-files 'examples/*' \
           --exclude-files 'tests/*' \
           --exclude-files 'tools/xtask/*' \
@@ -130,6 +132,8 @@ jobs:
           --workspace \
           --exclude copybook-bench \
           --exclude copybook-bdd \
+          --exclude copybook-e2e \
+          --exclude copybook-proptest \
           --exclude-files 'examples/*' \
           --exclude-files 'tests/*' \
           --exclude-files 'tools/xtask/*' \
@@ -148,6 +152,8 @@ jobs:
           --workspace \
           --exclude copybook-bench \
           --exclude copybook-bdd \
+          --exclude copybook-e2e \
+          --exclude copybook-proptest \
           --exclude-files 'examples/*' \
           --exclude-files 'tests/*' \
           --exclude-files 'tools/xtask/*' \


### PR DESCRIPTION
## What changed
- Add \--exclude copybook-e2e\ and \--exclude copybook-proptest\ to all 3 tarpaulin invocations in ci-coverage.yml

## Why
E2E CLI tests reference \	arget/debug/copybook\ but tarpaulin instrumented builds may place binaries elsewhere, similar to the llvm-cov issue fixed in PR #326. Proptest crates don't contribute meaningful library coverage metrics.

Both test suites run separately via nextest and cargo test in CI Quick and CI Full.

## What I ran locally
CI-only change (tarpaulin workflow). Verified YAML syntax.

## What CI says
- CI Quick: skipped (CI-only change, paths-ignore matches)

## Impact
- Determinism: none
- Taxonomy: none  
- Perf: none
- Docs: none

## Recommended disposition: MERGE