### PR TITLE
fix(e2e): use cargo_bin for portable binary resolution

### DIFF
--- a/tests/e2e/e2e_cli_error_code_coverage.rs
+++ b/tests/e2e/e2e_cli_error_code_coverage.rs
@@ -18,33 +18,12 @@
 
 use std::io::Write;
 use std::path::PathBuf;
-use std::process::{Command, Output};
+use assert_cmd::Command;
+use std::process::Output;
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/// Build a `Command` pointing at the compiled `copybook` binary.
-fn copybook_cmd() -> Command {
-    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-    let workspace_root = manifest_dir
-        .parent()
-        .expect("parent of tests/e2e")
-        .parent()
-        .expect("workspace root");
-    let bin_name = if cfg!(windows) {
-        "copybook.exe"
-    } else {
-        "copybook"
-    };
-    let bin_path = workspace_root.join("target").join("debug").join(bin_name);
-    assert!(
-        bin_path.exists(),
-        "copybook binary not found at {}. Run `cargo build --bin copybook` first.",
-        bin_path.display()
-    );
-    Command::new(bin_path)
-}
 
 fn stderr_str(output: &Output) -> String {
     String::from_utf8_lossy(&output.stderr).into_owned()
@@ -104,7 +83,7 @@ fn setup_encode(cpy_text: &str, jsonl: &str) -> tempfile::TempDir {
 fn cli_cbkp001_syntax_garbage_parse() {
     let dir = write_temp_file("bad.cpy", b"@#$%^&*() NOT COBOL AT ALL");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "bad.cpy"))
         .output()
@@ -124,7 +103,7 @@ fn cli_cbkp001_syntax_garbage_parse() {
 fn cli_cbkp001_syntax_empty_inspect() {
     let dir = write_temp_file("empty.cpy", b"");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("inspect")
         .arg(temp_path(&dir, "empty.cpy"))
         .output()
@@ -147,7 +126,7 @@ fn cli_cbkp001_syntax_invalid_pic_char() {
         b"       01  REC.\n           05  FLD   PIC Q(5).\n",
     );
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "bad_pic.cpy"))
         .output()
@@ -173,7 +152,7 @@ fn cli_cbkp021_odo_not_tail() {
            05  TRAILER  PIC X(10).\n";
     let dir = write_temp_file("odo_tail.cpy", cpy);
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "odo_tail.cpy"))
         .output()
@@ -200,7 +179,7 @@ fn cli_cbkp022_nested_odo() {
                          PIC X(5).\n";
     let dir = write_temp_file("nested_odo.cpy", cpy);
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "nested_odo.cpy"))
         .output()
@@ -226,7 +205,7 @@ fn cli_cbkp023_odo_redefines() {
                         DEPENDING ON CTR PIC X(1).\n";
     let dir = write_temp_file("odo_redef.cpy", cpy);
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "odo_redef.cpy"))
         .output()
@@ -254,7 +233,7 @@ fn cli_cbks121_counter_not_found() {
                     PIC X(5).\n";
     let dir = write_temp_file("odo_no_ctr.cpy", cpy);
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "odo_no_ctr.cpy"))
         .output()
@@ -278,7 +257,7 @@ fn cli_cbks601_rename_unknown_from() {
            66  MY-ALIAS RENAMES NONEXISTENT.\n";
     let dir = write_temp_file("ren601.cpy", cpy);
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "ren601.cpy"))
         .output()
@@ -303,7 +282,7 @@ fn cli_cbks602_rename_unknown_thru() {
            66  MY-ALIAS RENAMES A THRU NONEXISTENT.\n";
     let dir = write_temp_file("ren602.cpy", cpy);
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "ren602.cpy"))
         .output()
@@ -328,7 +307,7 @@ fn cli_cbks604_rename_reversed_range() {
            66  MY-ALIAS RENAMES B THRU A.\n";
     let dir = write_temp_file("ren604.cpy", cpy);
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "ren604.cpy"))
         .output()
@@ -354,7 +333,7 @@ fn cli_cbks607_rename_crosses_occurs() {
            66  MY-ALIAS RENAMES A THRU C.\n";
     let dir = write_temp_file("ren607.cpy", cpy);
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "ren607.cpy"))
         .output()
@@ -378,7 +357,7 @@ fn cli_cbks703_projection_not_found_decode() {
         &[0x40; 10],
     );
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -412,7 +391,7 @@ fn cli_cbks703_projection_not_found_encode() {
         "{\"REC\":{\"NAME\":\"ALICE\"}}\n",
     );
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["encode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "input.jsonl"))
@@ -446,7 +425,7 @@ fn cli_cbks703_projection_not_found_verify() {
         &[0x40; 10],
     );
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["verify"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -483,7 +462,7 @@ fn cli_cbkd401_comp3_invalid_nibble_decode() {
         &[0xFF, 0xFF, 0xFF],
     );
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -510,7 +489,7 @@ fn cli_cbkd401_comp3_invalid_nibble_verify() {
         &[0xFF, 0xFF, 0xFF],
     );
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["verify"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -537,7 +516,7 @@ fn cli_cbkd411_zoned_bad_sign_decode() {
         &[0xF1, 0xF2, 0xF3, 0xF4, 0x05],
     );
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -565,7 +544,7 @@ fn cli_cbkd411_zoned_spaces_in_numeric() {
         &[0x40, 0x40, 0x40],
     );
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -595,7 +574,7 @@ fn cli_cbkd411_zoned_bad_sign_verify() {
         ],
     );
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["verify"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -622,7 +601,7 @@ fn cli_cbkd411_sign_separate_invalid() {
         &[0x00, 0xF1, 0xF2, 0xF3],
     );
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -651,7 +630,7 @@ fn cli_cbkd421_edited_pic_invalid_decode() {
         &[0xC1, 0xC2, 0xC3, 0xC4],
     );
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -678,7 +657,7 @@ fn cli_cbkd421_edited_pic_invalid_verify() {
         &[0xC1, 0xC2, 0xC3, 0xC4],
     );
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["verify"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -708,7 +687,7 @@ fn cli_cbke_numeric_overflow_encode() {
         "{\"REC\":{\"NUM\":\"99999\"}}\n",
     );
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["encode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "input.jsonl"))
@@ -739,7 +718,7 @@ fn cli_cbke_string_too_long_encode() {
         "{\"REC\":{\"NAME\":\"THIS STRING IS WAY TOO LONG FOR FIVE BYTES\"}}\n",
     );
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["encode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "input.jsonl"))
@@ -766,7 +745,7 @@ fn cli_cbke_type_mismatch_encode() {
         "{\"REC\":{\"NAME\":null,\"NUM\":\"12345\"}}\n",
     );
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["encode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "input.jsonl"))
@@ -795,7 +774,7 @@ fn cli_cbkf102_rdw_record_length_invalid() {
         &[0x00, 0x02, 0x00, 0x00], // length=2 < 4 → underflow
     );
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -825,7 +804,7 @@ fn cli_cbkf104_rdw_suspect_ascii() {
         ],
     );
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -853,7 +832,7 @@ fn cli_cbkf221_rdw_underflow_fixed() {
         &[0xC1, 0xD3, 0xC9, 0xC3, 0xC5],
     );
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -881,7 +860,7 @@ fn cli_cbkf221_rdw_underflow_fixed() {
 fn cli_parse_error_propagates_to_inspect() {
     let dir = write_temp_file("garbage.cpy", b"NOT VALID COBOL SYNTAX");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("inspect")
         .arg(temp_path(&dir, "garbage.cpy"))
         .output()
@@ -901,7 +880,7 @@ fn cli_parse_error_propagates_to_inspect() {
 fn cli_parse_error_propagates_to_decode() {
     let dir = setup_decode("GARBAGE NOT COBOL", &[0x00; 10]);
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -925,7 +904,7 @@ fn cli_parse_error_propagates_to_decode() {
 fn cli_parse_error_propagates_to_encode() {
     let dir = setup_encode("GARBAGE NOT COBOL", "{\"REC\":{\"A\":\"X\"}}\n");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["encode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "input.jsonl"))
@@ -949,7 +928,7 @@ fn cli_parse_error_propagates_to_encode() {
 fn cli_parse_error_propagates_to_verify() {
     let dir = setup_decode("GARBAGE NOT COBOL", &[0x00; 10]);
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["verify"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -975,7 +954,7 @@ fn cli_parse_error_propagates_to_verify() {
 fn cli_exit_code_parse_error() {
     let dir = write_temp_file("bad.cpy", b"INVALID");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "bad.cpy"))
         .output()
@@ -994,7 +973,7 @@ fn cli_exit_code_decode_error() {
         &[0xFF, 0xFF, 0xFF],
     );
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -1017,7 +996,7 @@ fn cli_exit_code_rdw_error() {
         &[0x31, 0x32, 0x00, 0x00, 0x41, 0x42],
     );
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))

--- a/tests/e2e/e2e_cli_exit_codes.rs
+++ b/tests/e2e/e2e_cli_exit_codes.rs
@@ -7,32 +7,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use std::io::Write;
-use std::process::Command;
-
-/// Build a `Command` pointing at the compiled `copybook` binary.
-///
-/// Locates the binary in the target directory. The binary must be built
-/// before running these tests (e.g., via `cargo build --bin copybook`).
-fn copybook_cmd() -> Command {
-    // Walk up from CARGO_MANIFEST_DIR to find workspace target dir.
-    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-    let workspace_root = manifest_dir
-        .parent()
-        .expect("parent of tests/e2e")
-        .parent()
-        .expect("workspace root");
-    let bin_name = if cfg!(windows) {
-        "copybook.exe"
-    } else {
-        "copybook"
-    };
-    let bin_path = workspace_root.join("target").join("debug").join(bin_name);
-    assert!(
-        bin_path.exists(),
-        "copybook binary not found at {bin_path:?}. Run `cargo build --bin copybook` first."
-    );
-    Command::new(bin_path)
-}
+use assert_cmd::Command;
 
 /// Assert that stderr does not contain panic markers.
 fn assert_no_panic(stderr: &str) {
@@ -82,7 +57,7 @@ fn write_temp_file(name: &str, contents: &[u8]) -> tempfile::TempDir {
 
 #[test]
 fn help_flag_exits_zero() {
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("--help")
         .output()
         .expect("failed to run copybook --help");
@@ -102,7 +77,7 @@ fn help_flag_exits_zero() {
 
 #[test]
 fn version_flag_exits_zero() {
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("--version")
         .output()
         .expect("failed to run copybook --version");
@@ -122,7 +97,7 @@ fn version_flag_exits_zero() {
 
 #[test]
 fn unknown_subcommand_exits_nonzero() {
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("unknown-subcommand")
         .output()
         .expect("failed to run copybook unknown-subcommand");
@@ -145,7 +120,7 @@ fn parse_valid_copybook_exits_zero() {
     let dir = write_temp_file("valid.cpy", VALID_COPYBOOK.as_bytes());
     let cpy_path = dir.path().join("valid.cpy");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["parse"])
         .arg(&cpy_path)
         .output()
@@ -172,7 +147,7 @@ fn parse_valid_copybook_exits_zero() {
 
 #[test]
 fn parse_nonexistent_file_exits_nonzero() {
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["parse", "this_file_absolutely_does_not_exist_12345.cpy"])
         .output()
         .expect("failed to run copybook parse");
@@ -195,7 +170,7 @@ fn parse_invalid_syntax_exits_nonzero() {
     let dir = write_temp_file("invalid.cpy", INVALID_COPYBOOK.as_bytes());
     let cpy_path = dir.path().join("invalid.cpy");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["parse"])
         .arg(&cpy_path)
         .output()
@@ -229,7 +204,7 @@ fn decode_valid_data_exits_zero() {
 
     let output_path = dir.path().join("output.jsonl");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(&cpy_path)
         .arg(&data_path)
@@ -267,7 +242,7 @@ fn decode_truncated_data_exits_nonzero() {
 
     let output_path = dir.path().join("output.jsonl");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(&cpy_path)
         .arg(&data_path)
@@ -298,7 +273,7 @@ fn verify_valid_data_exits_zero() {
     let data_path = dir.path().join("data.bin");
     std::fs::write(&data_path, valid_record_bytes()).expect("write data file");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["verify"])
         .arg(&cpy_path)
         .arg(&data_path)
@@ -340,7 +315,7 @@ fn verify_invalid_data_exits_nonzero() {
     let data_path = dir.path().join("bad_num.bin");
     std::fs::write(&data_path, [0xC1; 8]).expect("write bad data file");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["verify"])
         .arg(&cpy_path)
         .arg(&data_path)
@@ -381,7 +356,7 @@ fn verify_data_with_errors_exits_3() {
     let data_path = dir.path().join("bad_num.bin");
     std::fs::write(&data_path, [0xC1; 8]).expect("write bad data file");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["verify"])
         .arg(&cpy_path)
         .arg(&data_path)
@@ -412,7 +387,7 @@ fn decode_nonexistent_input_exits_nonzero() {
     let cpy_path = dir.path().join("schema.cpy");
     let output_path = dir.path().join("output.jsonl");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(&cpy_path)
         .arg("no_such_file_99999.bin")
@@ -437,7 +412,7 @@ fn decode_nonexistent_input_exits_nonzero() {
 
 #[test]
 fn parse_help_exits_zero() {
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["parse", "--help"])
         .output()
         .expect("failed to run copybook parse --help");
@@ -458,7 +433,7 @@ fn parse_help_exits_zero() {
 #[test]
 fn decode_missing_required_args_exits_nonzero() {
     // decode without required positional args
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .output()
         .expect("failed to run copybook decode");
@@ -486,7 +461,7 @@ fn encode_valid_data_exits_zero() {
     std::fs::write(&data_path, valid_record_bytes()).expect("write data file");
     let jsonl_path = dir.path().join("decoded.jsonl");
 
-    let decode_out = copybook_cmd()
+    let decode_out = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(&cpy_path)
         .arg(&data_path)
@@ -504,7 +479,7 @@ fn encode_valid_data_exits_zero() {
 
     // Now encode the JSONL back to binary
     let encoded_path = dir.path().join("encoded.bin");
-    let encode_out = copybook_cmd()
+    let encode_out = Command::cargo_bin("copybook").unwrap()
         .args(["encode"])
         .arg(&cpy_path)
         .arg(&jsonl_path)
@@ -532,7 +507,7 @@ fn inspect_valid_copybook_exits_zero() {
     let dir = write_temp_file("schema.cpy", VALID_COPYBOOK.as_bytes());
     let cpy_path = dir.path().join("schema.cpy");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["inspect"])
         .arg(&cpy_path)
         .output()
@@ -566,7 +541,7 @@ fn all_exit_codes_are_in_expected_range() {
     ];
 
     for (label, args) in &scenarios {
-        let output = copybook_cmd()
+        let output = Command::cargo_bin("copybook").unwrap()
             .args(args.iter())
             .output()
             .unwrap_or_else(|e| panic!("failed to run scenario '{label}': {e}"));
@@ -589,7 +564,7 @@ fn error_paths_do_not_produce_backtraces() {
     let dir = write_temp_file("bad.cpy", INVALID_COPYBOOK.as_bytes());
     let cpy_path = dir.path().join("bad.cpy");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["parse"])
         .arg(&cpy_path)
         .output()

--- a/tests/e2e/e2e_cli_field_projection.rs
+++ b/tests/e2e/e2e_cli_field_projection.rs
@@ -8,31 +8,12 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use std::path::PathBuf;
-use std::process::{Command, Output};
+use assert_cmd::Command;
+use std::process::Output;
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-fn copybook_cmd() -> Command {
-    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-    let workspace_root = manifest_dir
-        .parent()
-        .expect("parent of tests/e2e")
-        .parent()
-        .expect("workspace root");
-    let bin_name = if cfg!(windows) {
-        "copybook.exe"
-    } else {
-        "copybook"
-    };
-    let bin_path = workspace_root.join("target").join("debug").join(bin_name);
-    assert!(
-        bin_path.exists(),
-        "copybook binary not found at {bin_path:?}. Run `cargo build --bin copybook` first."
-    );
-    Command::new(bin_path)
-}
 
 fn stdout_str(output: &Output) -> String {
     String::from_utf8_lossy(&output.stdout).into_owned()
@@ -199,7 +180,7 @@ fn setup_simple_two_records() -> tempfile::TempDir {
 fn select_single_field() {
     let dir = setup_multi_field();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args([
             "decode",
             "--format",
@@ -244,7 +225,7 @@ fn select_single_field() {
 fn select_comma_separated_fields() {
     let dir = setup_multi_field();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args([
             "decode",
             "--format",
@@ -286,7 +267,7 @@ fn select_comma_separated_fields() {
 fn select_multiple_flags() {
     let dir = setup_multi_field();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args([
             "decode",
             "--format",
@@ -330,7 +311,7 @@ fn select_multiple_flags() {
 fn select_nonexistent_field_produces_error() {
     let dir = setup_multi_field();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args([
             "decode",
             "--format",
@@ -370,7 +351,7 @@ fn select_nonexistent_field_produces_error() {
 fn select_odo_array_auto_includes_counter() {
     let dir = setup_odo();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args([
             "decode",
             "--format",
@@ -414,7 +395,7 @@ fn select_all_fields_same_as_no_select() {
     let out_with_select = temp_path(&dir, "with_select.jsonl");
 
     // Decode without --select
-    let o1 = copybook_cmd()
+    let o1 = Command::cargo_bin("copybook").unwrap()
         .args(["decode", "--format", "fixed", "--codepage", "cp037"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -425,7 +406,7 @@ fn select_all_fields_same_as_no_select() {
     assert_eq!(o1.status.code(), Some(0));
 
     // Decode with --select all fields
-    let o2 = copybook_cmd()
+    let o2 = Command::cargo_bin("copybook").unwrap()
         .args([
             "decode",
             "--format",
@@ -465,7 +446,7 @@ fn select_all_fields_same_as_no_select() {
 fn select_group_field() {
     let dir = setup_group();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args([
             "decode",
             "--format",
@@ -522,7 +503,7 @@ fn select_group_field() {
 fn select_with_multiple_records() {
     let dir = setup_simple_two_records();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args([
             "decode",
             "--format",
@@ -565,7 +546,7 @@ fn select_with_multiple_records() {
 fn select_with_dialect_flag() {
     let dir = setup_odo();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args([
             "decode",
             "--format",
@@ -599,7 +580,7 @@ fn select_with_dialect_flag() {
 #[test]
 fn verify_with_select_flag() {
     let dir = setup_multi_field();
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args([
             "verify",
             "--format",
@@ -630,7 +611,7 @@ fn verify_with_select_flag() {
 fn select_last_field_only() {
     let dir = setup_multi_field();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args([
             "decode",
             "--format",
@@ -669,7 +650,7 @@ fn select_last_field_only() {
 fn select_odo_counter_without_array() {
     let dir = setup_odo();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args([
             "decode",
             "--format",
@@ -710,7 +691,7 @@ fn select_odo_counter_without_array() {
 fn select_counter_and_array_explicitly() {
     let dir = setup_odo();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args([
             "decode",
             "--format",
@@ -755,7 +736,7 @@ fn select_counter_and_array_explicitly() {
 fn select_non_odo_field_from_odo_schema() {
     let dir = setup_odo();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args([
             "decode",
             "--format",
@@ -792,7 +773,7 @@ fn select_non_odo_field_from_odo_schema() {
 fn select_multiple_nonexistent_fields_error() {
     let dir = setup_multi_field();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args([
             "decode",
             "--format",
@@ -824,7 +805,7 @@ fn select_multiple_nonexistent_fields_error() {
 fn select_mix_valid_and_nonexistent_produces_error() {
     let dir = setup_multi_field();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args([
             "decode",
             "--format",
@@ -858,7 +839,7 @@ fn encode_with_select_flag() {
     let decode_out = temp_path(&dir, "decoded.jsonl");
 
     // First decode to get JSONL
-    let o1 = copybook_cmd()
+    let o1 = Command::cargo_bin("copybook").unwrap()
         .args(["decode", "--format", "fixed", "--codepage", "cp037"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -870,7 +851,7 @@ fn encode_with_select_flag() {
 
     // Now encode with --select
     let encode_out = temp_path(&dir, "encoded.bin");
-    let o2 = copybook_cmd()
+    let o2 = Command::cargo_bin("copybook").unwrap()
         .args([
             "encode",
             "--format",

--- a/tests/e2e/e2e_cli_help_output.rs
+++ b/tests/e2e/e2e_cli_help_output.rs
@@ -6,32 +6,12 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use std::process::{Command, Output};
+use assert_cmd::Command;
+use std::process::Output;
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/// Build a `Command` pointing at the compiled `copybook` binary.
-fn copybook_cmd() -> Command {
-    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-    let workspace_root = manifest_dir
-        .parent()
-        .expect("parent of tests/e2e")
-        .parent()
-        .expect("workspace root");
-    let bin_name = if cfg!(windows) {
-        "copybook.exe"
-    } else {
-        "copybook"
-    };
-    let bin_path = workspace_root.join("target").join("debug").join(bin_name);
-    assert!(
-        bin_path.exists(),
-        "copybook binary not found at {bin_path:?}. Run `cargo build --bin copybook` first."
-    );
-    Command::new(bin_path)
-}
 
 fn stdout_str(output: &Output) -> String {
     String::from_utf8_lossy(&output.stdout).into_owned()
@@ -51,7 +31,7 @@ fn assert_no_panic(stderr: &str) {
 
 /// Run `copybook <args>` and return the output, asserting success.
 fn run_help(args: &[&str]) -> Output {
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(args)
         .output()
         .unwrap_or_else(|e| panic!("failed to run copybook {args:?}: {e}"));
@@ -353,7 +333,7 @@ fn version_output_contains_program_name() {
 
 #[test]
 fn short_help_flag_works() {
-    let output = copybook_cmd().arg("-h").output().expect("run -h");
+    let output = Command::cargo_bin("copybook").unwrap().arg("-h").output().expect("run -h");
     assert_eq!(output.status.code(), Some(0), "exit code must be 0");
     let text = help_text(&output);
     assert!(
@@ -368,7 +348,7 @@ fn short_help_flag_works() {
 
 #[test]
 fn short_version_flag_works() {
-    let output = copybook_cmd().arg("-V").output().expect("run -V");
+    let output = Command::cargo_bin("copybook").unwrap().arg("-V").output().expect("run -V");
     assert_eq!(output.status.code(), Some(0), "exit code must be 0");
     let text = help_text(&output);
     let has_version = regex::Regex::new(r"\d+\.\d+\.\d+").unwrap().is_match(&text);

--- a/tests/e2e/e2e_cli_integration.rs
+++ b/tests/e2e/e2e_cli_integration.rs
@@ -9,32 +9,12 @@
 
 use std::io::Write;
 use std::path::PathBuf;
-use std::process::{Command, Output};
+use assert_cmd::Command;
+use std::process::Output;
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/// Build a `Command` pointing at the compiled `copybook` binary.
-fn copybook_cmd() -> Command {
-    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-    let workspace_root = manifest_dir
-        .parent()
-        .expect("parent of tests/e2e")
-        .parent()
-        .expect("workspace root");
-    let bin_name = if cfg!(windows) {
-        "copybook.exe"
-    } else {
-        "copybook"
-    };
-    let bin_path = workspace_root.join("target").join("debug").join(bin_name);
-    assert!(
-        bin_path.exists(),
-        "copybook binary not found at {bin_path:?}. Run `cargo build --bin copybook` first."
-    );
-    Command::new(bin_path)
-}
 
 /// Assert that stderr does not contain panic markers.
 fn assert_no_panic(stderr: &str) {
@@ -127,7 +107,7 @@ fn setup_two_records() -> tempfile::TempDir {
 fn parse_valid_copybook_produces_json_schema() {
     let dir = setup_simple();
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "schema.cpy"))
         .output()
@@ -155,7 +135,7 @@ fn parse_valid_copybook_to_output_file() {
     let dir = setup_simple();
     let out_path = temp_path(&dir, "schema.json");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["parse"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg("-o")
@@ -176,7 +156,7 @@ fn parse_valid_copybook_to_output_file() {
 
 #[test]
 fn parse_nonexistent_file_exits_nonzero() {
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["parse", "does_not_exist_12345.cpy"])
         .output()
         .expect("run parse");
@@ -189,7 +169,7 @@ fn parse_nonexistent_file_exits_nonzero() {
 fn parse_invalid_syntax_exits_nonzero() {
     let dir = write_temp_file("bad.cpy", b"THIS IS NOT VALID COBOL !!!");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "bad.cpy"))
         .output()
@@ -206,7 +186,7 @@ fn parse_invalid_syntax_exits_nonzero() {
 
 #[test]
 fn parse_missing_args_exits_nonzero() {
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("parse")
         .output()
         .expect("run parse without args");
@@ -217,7 +197,7 @@ fn parse_missing_args_exits_nonzero() {
 
 #[test]
 fn parse_help_exits_zero_with_usage() {
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["parse", "--help"])
         .output()
         .expect("run parse --help");
@@ -238,7 +218,7 @@ fn parse_help_exits_zero_with_usage() {
 fn inspect_valid_copybook_shows_layout() {
     let dir = setup_simple();
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("inspect")
         .arg(temp_path(&dir, "schema.cpy"))
         .output()
@@ -266,7 +246,7 @@ fn inspect_valid_copybook_shows_layout() {
 fn inspect_invalid_file_exits_nonzero() {
     let dir = write_temp_file("bad.cpy", b"NOT COBOL");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("inspect")
         .arg(temp_path(&dir, "bad.cpy"))
         .output()
@@ -278,7 +258,7 @@ fn inspect_invalid_file_exits_nonzero() {
 
 #[test]
 fn inspect_missing_args_exits_nonzero() {
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("inspect")
         .output()
         .expect("run inspect without args");
@@ -289,7 +269,7 @@ fn inspect_missing_args_exits_nonzero() {
 
 #[test]
 fn inspect_help_exits_zero() {
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["inspect", "--help"])
         .output()
         .expect("run inspect --help");
@@ -311,7 +291,7 @@ fn decode_single_record_to_jsonl() {
     let dir = setup_simple();
     let out = temp_path(&dir, "output.jsonl");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -347,7 +327,7 @@ fn decode_multiple_records() {
     let dir = setup_two_records();
     let out = temp_path(&dir, "output.jsonl");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -372,7 +352,7 @@ fn decode_multiple_records() {
 fn decode_to_stdout() {
     let dir = setup_simple();
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -395,7 +375,7 @@ fn decode_with_lossless_number_mode() {
     let dir = setup_simple();
     let out = temp_path(&dir, "output.jsonl");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -429,7 +409,7 @@ fn decode_truncated_data_exits_nonzero() {
     std::fs::write(dir.path().join("data.bin"), [0xF0; 5]).unwrap();
     let out = temp_path(&dir, "output.jsonl");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -448,7 +428,7 @@ fn decode_nonexistent_input_exits_nonzero() {
     let dir = setup_simple();
     let out = temp_path(&dir, "output.jsonl");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg("nonexistent_file_99999.bin")
@@ -464,7 +444,7 @@ fn decode_nonexistent_input_exits_nonzero() {
 
 #[test]
 fn decode_missing_required_args_exits_nonzero() {
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("decode")
         .output()
         .expect("run decode without args");
@@ -478,7 +458,7 @@ fn decode_missing_format_flag_exits_nonzero() {
     let dir = setup_simple();
     let out = temp_path(&dir, "output.jsonl");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -494,7 +474,7 @@ fn decode_missing_format_flag_exits_nonzero() {
 
 #[test]
 fn decode_help_exits_zero() {
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode", "--help"])
         .output()
         .expect("run decode --help");
@@ -514,7 +494,7 @@ fn decode_help_exits_zero() {
 /// Helper: decode a record to produce valid JSONL, return the JSONL file path.
 fn decode_to_jsonl(dir: &tempfile::TempDir) -> PathBuf {
     let jsonl_path = dir.path().join("decoded.jsonl");
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(dir.path().join("schema.cpy"))
         .arg(dir.path().join("data.bin"))
@@ -538,7 +518,7 @@ fn encode_valid_jsonl_to_binary() {
     let jsonl_path = decode_to_jsonl(&dir);
     let encoded_path = temp_path(&dir, "encoded.bin");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["encode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(&jsonl_path)
@@ -571,7 +551,7 @@ fn encode_round_trip_binary_fidelity() {
     let jsonl_path = decode_to_jsonl(&dir);
     let encoded_path = temp_path(&dir, "encoded.bin");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["encode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(&jsonl_path)
@@ -603,7 +583,7 @@ fn encode_invalid_jsonl_exits_nonzero() {
     std::fs::write(&bad_jsonl, "THIS IS NOT JSON\n").unwrap();
     let encoded_path = temp_path(&dir, "encoded.bin");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["encode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(&bad_jsonl)
@@ -622,7 +602,7 @@ fn encode_nonexistent_input_exits_nonzero() {
     let dir = setup_simple();
     let encoded_path = temp_path(&dir, "encoded.bin");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["encode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg("nonexistent_99999.jsonl")
@@ -638,7 +618,7 @@ fn encode_nonexistent_input_exits_nonzero() {
 
 #[test]
 fn encode_missing_required_args_exits_nonzero() {
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("encode")
         .output()
         .expect("run encode without args");
@@ -649,7 +629,7 @@ fn encode_missing_required_args_exits_nonzero() {
 
 #[test]
 fn encode_help_exits_zero() {
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["encode", "--help"])
         .output()
         .expect("run encode --help");
@@ -667,7 +647,7 @@ fn encode_to_stdout() {
     let dir = setup_simple();
     let jsonl_path = decode_to_jsonl(&dir);
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["encode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(&jsonl_path)
@@ -696,7 +676,7 @@ fn encode_to_stdout() {
 fn verify_valid_data_exits_zero() {
     let dir = setup_simple();
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["verify"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -725,7 +705,7 @@ fn verify_truncated_data_reports_zero_records() {
     // 5 bytes is not a complete record (13 needed); verify processes 0 records.
     std::fs::write(dir.path().join("data.bin"), [0xF0; 5]).unwrap();
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["verify"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -746,7 +726,7 @@ fn verify_truncated_data_reports_zero_records() {
 fn verify_nonexistent_data_exits_nonzero() {
     let dir = setup_simple();
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["verify"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg("nonexistent_99999.bin")
@@ -760,7 +740,7 @@ fn verify_nonexistent_data_exits_nonzero() {
 
 #[test]
 fn verify_missing_required_args_exits_nonzero() {
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("verify")
         .output()
         .expect("run verify without args");
@@ -771,7 +751,7 @@ fn verify_missing_required_args_exits_nonzero() {
 
 #[test]
 fn verify_help_exits_zero() {
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["verify", "--help"])
         .output()
         .expect("run verify --help");
@@ -789,7 +769,7 @@ fn verify_with_report_flag() {
     let dir = setup_simple();
     let report_path = temp_path(&dir, "report.json");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["verify"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -824,7 +804,7 @@ fn verify_with_report_flag() {
 fn determinism_decode_exits_zero_for_valid_data() {
     let dir = setup_simple();
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["determinism", "decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -855,7 +835,7 @@ fn determinism_encode_exits_zero_for_valid_data() {
     let dir = setup_simple();
     let jsonl_path = decode_to_jsonl(&dir);
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["determinism", "encode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(&jsonl_path)
@@ -876,7 +856,7 @@ fn determinism_encode_exits_zero_for_valid_data() {
 fn determinism_round_trip_exits_zero_for_valid_data() {
     let dir = setup_simple();
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["determinism", "round-trip"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -897,7 +877,7 @@ fn determinism_round_trip_exits_zero_for_valid_data() {
 fn determinism_json_output_format() {
     let dir = setup_simple();
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["determinism", "decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -926,7 +906,7 @@ fn determinism_json_output_format() {
 
 #[test]
 fn determinism_missing_args_exits_nonzero() {
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["determinism", "decode"])
         .output()
         .expect("run determinism decode without args");
@@ -937,7 +917,7 @@ fn determinism_missing_args_exits_nonzero() {
 
 #[test]
 fn determinism_help_exits_zero() {
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["determinism", "--help"])
         .output()
         .expect("run determinism --help");
@@ -952,7 +932,7 @@ fn determinism_help_exits_zero() {
 
 #[test]
 fn determinism_decode_help_exits_zero() {
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["determinism", "decode", "--help"])
         .output()
         .expect("run determinism decode --help");
@@ -966,7 +946,7 @@ fn determinism_decode_help_exits_zero() {
 
 #[test]
 fn global_help_exits_zero() {
-    let output = copybook_cmd().arg("--help").output().expect("run --help");
+    let output = Command::cargo_bin("copybook").unwrap().arg("--help").output().expect("run --help");
 
     assert_eq!(output.status.code(), Some(0));
     let so = stdout_str(&output);
@@ -986,7 +966,7 @@ fn global_help_exits_zero() {
 
 #[test]
 fn version_flag_exits_zero() {
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("--version")
         .output()
         .expect("run --version");
@@ -1001,7 +981,7 @@ fn version_flag_exits_zero() {
 
 #[test]
 fn unknown_subcommand_exits_nonzero() {
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("not-a-real-command")
         .output()
         .expect("run unknown subcommand");
@@ -1014,7 +994,7 @@ fn unknown_subcommand_exits_nonzero() {
 fn error_paths_never_produce_backtraces() {
     let dir = write_temp_file("bad.cpy", b"NOT COBOL");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "bad.cpy"))
         .output()
@@ -1038,7 +1018,7 @@ fn exit_codes_are_in_expected_range() {
     ];
 
     for (label, args) in scenarios {
-        let output = copybook_cmd()
+        let output = Command::cargo_bin("copybook").unwrap()
             .args(args.iter())
             .output()
             .unwrap_or_else(|e| panic!("failed to run scenario '{label}': {e}"));
@@ -1061,7 +1041,7 @@ fn full_pipeline_decode_encode_verify() {
 
     // Step 1: Decode binary → JSONL
     let jsonl_path = temp_path(&dir, "decoded.jsonl");
-    let decode_out = copybook_cmd()
+    let decode_out = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -1079,7 +1059,7 @@ fn full_pipeline_decode_encode_verify() {
 
     // Step 2: Encode JSONL → binary
     let encoded_path = temp_path(&dir, "encoded.bin");
-    let encode_out = copybook_cmd()
+    let encode_out = Command::cargo_bin("copybook").unwrap()
         .args(["encode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(&jsonl_path)
@@ -1096,7 +1076,7 @@ fn full_pipeline_decode_encode_verify() {
     );
 
     // Step 3: Verify re-encoded binary
-    let verify_out = copybook_cmd()
+    let verify_out = Command::cargo_bin("copybook").unwrap()
         .args(["verify"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(&encoded_path)
@@ -1128,7 +1108,7 @@ fn parse_with_dialect_flag() {
     let dir = setup_simple();
 
     for dialect in &["n", "0", "1"] {
-        let output = copybook_cmd()
+        let output = Command::cargo_bin("copybook").unwrap()
             .args(["parse"])
             .arg(temp_path(&dir, "schema.cpy"))
             .args(["--dialect", dialect])
@@ -1149,7 +1129,7 @@ fn decode_with_emit_meta() {
     let dir = setup_simple();
     let out = temp_path(&dir, "output.jsonl");
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))

--- a/tests/e2e/e2e_dialect_behavior.rs
+++ b/tests/e2e/e2e_dialect_behavior.rs
@@ -10,31 +10,12 @@
 
 use std::io::Write;
 use std::path::PathBuf;
-use std::process::{Command, Output};
+use assert_cmd::Command;
+use std::process::Output;
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-fn copybook_cmd() -> Command {
-    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-    let workspace_root = manifest_dir
-        .parent()
-        .expect("parent of tests/e2e")
-        .parent()
-        .expect("workspace root");
-    let bin_name = if cfg!(windows) {
-        "copybook.exe"
-    } else {
-        "copybook"
-    };
-    let bin_path = workspace_root.join("target").join("debug").join(bin_name);
-    assert!(
-        bin_path.exists(),
-        "copybook binary not found at {bin_path:?}. Run `cargo build --bin copybook` first."
-    );
-    Command::new(bin_path)
-}
 
 fn stdout_str(output: &Output) -> String {
     String::from_utf8_lossy(&output.stdout).into_owned()
@@ -155,7 +136,7 @@ fn setup_simple() -> tempfile::TempDir {
 #[test]
 fn parse_with_dialect_normative() {
     let dir = write_temp_file("schema.cpy", ODO_MIN2_CPY.as_bytes());
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["parse", "--dialect", "n"])
         .arg(temp_path(&dir, "schema.cpy"))
         .output()
@@ -176,7 +157,7 @@ fn parse_with_dialect_normative() {
 #[test]
 fn parse_with_dialect_zero_tolerant() {
     let dir = write_temp_file("schema.cpy", ODO_MIN2_CPY.as_bytes());
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["parse", "--dialect", "0"])
         .arg(temp_path(&dir, "schema.cpy"))
         .output()
@@ -197,7 +178,7 @@ fn parse_with_dialect_zero_tolerant() {
 #[test]
 fn parse_with_dialect_one_tolerant() {
     let dir = write_temp_file("schema.cpy", ODO_MIN2_CPY.as_bytes());
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["parse", "--dialect", "1"])
         .arg(temp_path(&dir, "schema.cpy"))
         .output()
@@ -218,7 +199,7 @@ fn parse_with_dialect_one_tolerant() {
 #[test]
 fn invalid_dialect_value_produces_error() {
     let dir = write_temp_file("schema.cpy", ODO_MIN2_CPY.as_bytes());
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["parse", "--dialect", "xyz"])
         .arg(temp_path(&dir, "schema.cpy"))
         .output()
@@ -236,7 +217,7 @@ fn invalid_dialect_value_produces_error() {
 fn decode_dialect_normative_valid_count() {
     let dir = setup_odo_min2(3); // count=3, min=2, within bounds
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args([
             "decode",
             "--format",
@@ -270,7 +251,7 @@ fn decode_dialect_normative_valid_count() {
 fn decode_dialect_zero_tolerant_allows_zero_count() {
     let dir = setup_odo_min2(0); // count=0, min=2 but zero-tolerant ignores min
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args([
             "decode",
             "--format",
@@ -305,7 +286,7 @@ fn decode_dialect_zero_tolerant_allows_zero_count() {
 fn decode_dialect_one_tolerant_with_min0_schema() {
     let dir = setup_odo_min0(1); // count=1, min_count=0 but one-tolerant clamps to 1
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args([
             "decode",
             "--format",
@@ -337,7 +318,7 @@ fn decode_dialect_one_tolerant_with_min0_schema() {
 #[test]
 fn env_var_copybook_dialect_is_respected() {
     let dir = write_temp_file("schema.cpy", ODO_MIN2_CPY.as_bytes());
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .env("COPYBOOK_DIALECT", "0")
         .args(["parse"])
         .arg(temp_path(&dir, "schema.cpy"))
@@ -360,7 +341,7 @@ fn env_var_copybook_dialect_is_respected() {
 fn cli_dialect_flag_overrides_env_var() {
     let dir = write_temp_file("schema.cpy", ODO_MIN2_CPY.as_bytes());
     // Set env to "0" but CLI to "1" – should use "1"
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .env("COPYBOOK_DIALECT", "0")
         .args(["parse", "--dialect", "1"])
         .arg(temp_path(&dir, "schema.cpy"))
@@ -382,7 +363,7 @@ fn cli_dialect_flag_overrides_env_var() {
 #[test]
 fn default_dialect_is_normative() {
     let dir = write_temp_file("schema.cpy", SIMPLE_CPY.as_bytes());
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .env_remove("COPYBOOK_DIALECT")
         .args(["parse"])
         .arg(temp_path(&dir, "schema.cpy"))
@@ -404,7 +385,7 @@ fn default_dialect_is_normative() {
 #[test]
 fn inspect_with_dialect_zero() {
     let dir = write_temp_file("schema.cpy", ODO_MIN2_CPY.as_bytes());
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["inspect", "--dialect", "0"])
         .arg(temp_path(&dir, "schema.cpy"))
         .output()
@@ -425,7 +406,7 @@ fn inspect_with_dialect_zero() {
 #[test]
 fn inspect_with_dialect_one() {
     let dir = write_temp_file("schema.cpy", ODO_MIN2_CPY.as_bytes());
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["inspect", "--dialect", "1"])
         .arg(temp_path(&dir, "schema.cpy"))
         .output()
@@ -447,7 +428,7 @@ fn inspect_with_dialect_one() {
 #[ignore = "ODO schemas have lrecl_fixed=None; --format fixed requires LRECL (pre-existing limitation)"]
 fn verify_with_dialect_zero() {
     let dir = setup_odo_min2(3);
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args([
             "verify",
             "--format",
@@ -477,7 +458,7 @@ fn verify_with_dialect_zero() {
 #[test]
 fn dialect_value_two_is_invalid() {
     let dir = write_temp_file("schema.cpy", ODO_MIN2_CPY.as_bytes());
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["parse", "--dialect", "2"])
         .arg(temp_path(&dir, "schema.cpy"))
         .output()
@@ -493,7 +474,7 @@ fn dialect_value_two_is_invalid() {
 #[test]
 fn empty_dialect_value_is_invalid() {
     let dir = write_temp_file("schema.cpy", ODO_MIN2_CPY.as_bytes());
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["parse", "--dialect", ""])
         .arg(temp_path(&dir, "schema.cpy"))
         .output()
@@ -517,7 +498,7 @@ fn encode_with_dialect_flag() {
     let dir = setup_odo_min2(3);
     let out_path = temp_path(&dir, "out.jsonl");
     // Decode first
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args([
             "decode",
             "--format",
@@ -542,7 +523,7 @@ fn encode_with_dialect_flag() {
 
     // Now encode with dialect
     let enc_out = temp_path(&dir, "encoded.bin");
-    let enc_output = copybook_cmd()
+    let enc_output = Command::cargo_bin("copybook").unwrap()
         .args([
             "encode",
             "--format",
@@ -574,7 +555,7 @@ fn encode_with_dialect_flag() {
 fn decode_normative_count_below_min_is_handled() {
     let dir = setup_odo_min2(1); // count=1, min=2 in normative → should clip/error
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args([
             "decode",
             "--format",
@@ -602,7 +583,7 @@ fn decode_normative_count_below_min_is_handled() {
 #[test]
 fn env_var_invalid_dialect_produces_error() {
     let dir = write_temp_file("schema.cpy", ODO_MIN2_CPY.as_bytes());
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .env("COPYBOOK_DIALECT", "invalid")
         .args(["parse"])
         .arg(temp_path(&dir, "schema.cpy"))
@@ -620,7 +601,7 @@ fn env_var_invalid_dialect_produces_error() {
 fn all_three_dialects_on_inspect() {
     let dir = write_temp_file("schema.cpy", ODO_MIN2_CPY.as_bytes());
     for dialect in &["n", "0", "1"] {
-        let output = copybook_cmd()
+        let output = Command::cargo_bin("copybook").unwrap()
             .args(["inspect", "--dialect", dialect])
             .arg(temp_path(&dir, "schema.cpy"))
             .output()

--- a/tests/e2e/e2e_parallel_determinism.rs
+++ b/tests/e2e/e2e_parallel_determinism.rs
@@ -7,31 +7,12 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use sha2::{Digest, Sha256};
-use std::process::{Command, Output};
+use assert_cmd::Command;
+use std::process::Output;
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-fn copybook_cmd() -> Command {
-    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-    let workspace_root = manifest_dir
-        .parent()
-        .expect("parent of tests/e2e")
-        .parent()
-        .expect("workspace root");
-    let bin_name = if cfg!(windows) {
-        "copybook.exe"
-    } else {
-        "copybook"
-    };
-    let bin_path = workspace_root.join("target").join("debug").join(bin_name);
-    assert!(
-        bin_path.exists(),
-        "copybook binary not found at {bin_path:?}. Run `cargo build --bin copybook` first."
-    );
-    Command::new(bin_path)
-}
 
 fn stdout_str(output: &Output) -> String {
     String::from_utf8_lossy(&output.stdout).into_owned()
@@ -116,7 +97,7 @@ fn setup_multi_record_dir() -> tempfile::TempDir {
 fn run_decode(dir: &tempfile::TempDir, threads: usize) -> Vec<u8> {
     let out_path = dir.path().join(format!("output_{threads}t.jsonl"));
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("decode")
         .arg(dir.path().join("schema.cpy"))
         .arg(dir.path().join("data.bin"))
@@ -142,7 +123,7 @@ fn run_decode(dir: &tempfile::TempDir, threads: usize) -> Vec<u8> {
 fn run_decode_to(dir: &tempfile::TempDir, out_name: &str, threads: usize) -> Vec<u8> {
     let out_path = dir.path().join(out_name);
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .arg("decode")
         .arg(dir.path().join("schema.cpy"))
         .arg(dir.path().join("data.bin"))
@@ -313,7 +294,7 @@ fn test_schema_fingerprint_stable_across_runs() {
 fn test_determinism_subcommand_decode_exit_zero() {
     let dir = setup_multi_record_dir();
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["determinism", "decode"])
         .arg(dir.path().join("schema.cpy"))
         .arg(dir.path().join("data.bin"))
@@ -346,7 +327,7 @@ fn test_determinism_subcommand_encode_exit_zero() {
 
     // First decode to get JSONL for encode input
     let jsonl_path = dir.path().join("for_encode.jsonl");
-    let decode_output = copybook_cmd()
+    let decode_output = Command::cargo_bin("copybook").unwrap()
         .arg("decode")
         .arg(dir.path().join("schema.cpy"))
         .arg(dir.path().join("data.bin"))
@@ -362,7 +343,7 @@ fn test_determinism_subcommand_encode_exit_zero() {
         stderr_str(&decode_output)
     );
 
-    let output = copybook_cmd()
+    let output = Command::cargo_bin("copybook").unwrap()
         .args(["determinism", "encode"])
         .arg(dir.path().join("schema.cpy"))
         .arg(&jsonl_path)
@@ -389,7 +370,7 @@ fn test_encode_deterministic_across_thread_counts() {
 
     // Decode once to get JSONL
     let jsonl_path = dir.path().join("source.jsonl");
-    let decode_output = copybook_cmd()
+    let decode_output = Command::cargo_bin("copybook").unwrap()
         .arg("decode")
         .arg(dir.path().join("schema.cpy"))
         .arg(dir.path().join("data.bin"))
@@ -408,7 +389,7 @@ fn test_encode_deterministic_across_thread_counts() {
     // Encode with 1 thread as baseline
     let encode_with = |threads: usize| -> Vec<u8> {
         let out = dir.path().join(format!("encoded_{threads}t.bin"));
-        let output = copybook_cmd()
+        let output = Command::cargo_bin("copybook").unwrap()
             .arg("encode")
             .arg(dir.path().join("schema.cpy"))
             .arg(&jsonl_path)


### PR DESCRIPTION
## What changed
Replace custom copybook_cmd() helper that hardcodes target/debug/copybook with assert_cmd::Command::cargo_bin("copybook") in 7 e2e test files.

## Why
The custom helper fails under:
- cargo llvm-cov (binaries in target/llvm-cov-target/debug/)
- cargo tarpaulin (instrumented build paths)
- Release builds (target/release/ vs target/debug/)

cargo_bin() uses the CARGO_BIN_EXE_copybook env var set by cargo during test compilation, which always points to the correct binary location regardless of profile.

5 other e2e test files already use cargo_bin(). This PR aligns the remaining 7.

## Files changed
- tests/e2e/e2e_cli_exit_codes.rs
- tests/e2e/e2e_cli_field_projection.rs
- tests/e2e/e2e_cli_error_code_coverage.rs
- tests/e2e/e2e_cli_help_output.rs
- tests/e2e/e2e_cli_integration.rs
- tests/e2e/e2e_dialect_behavior.rs
- tests/e2e/e2e_parallel_determinism.rs

## What I ran locally
cargo test -p copybook-e2e --no-run (all 27 test binaries compiled)

## Impact
- Determinism: none (test infrastructure only)
- Taxonomy: none
- Perf: none
- Docs: none

## Recommended disposition: MERGE
