### PR TITLE
fix(ci): re-include copybook-e2e in llvm-cov coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,7 +418,7 @@ jobs:
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
     - name: Generate code coverage
-      run: cargo llvm-cov --workspace --exclude copybook-bench --exclude copybook-bdd --exclude copybook-e2e --lcov --output-path lcov.info
+      run: cargo llvm-cov --workspace --exclude copybook-bench --exclude copybook-bdd --lcov --output-path lcov.info
     # Make upload non-blocking and always run
     - name: Upload coverage to Codecov
       if: always()


### PR DESCRIPTION
## What changed
Re-include copybook-e2e in cargo llvm-cov (ci.yml Code Coverage job).

## Why
PR #329 fixed e2e tests to use assert_cmd::Command::cargo_bin() instead of
hardcoded target/debug/copybook paths. This should make them work under
llvm-cov's instrumented build environment.

## Risk
If cargo_bin() doesn't resolve correctly under llvm-cov, the Code Coverage
job will fail. This is a low-risk experiment since the fallback is to
re-add the exclusion.

## What CI says
- CI Quick: pending (CI-only change but modifies ci.yml which is not docs)
- CI Full Code Coverage: this is the test

## Impact
- Determinism: none
- Taxonomy: none
- Perf: none
- Docs: none

## Recommended disposition: MERGE if Code Coverage passes, REVERT if not
