### PR TITLE
fix(ci): format e2e tests, suppress deprecated lint, re-include e2e in llvm-cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,8 @@ jobs:
           -A clippy::dbg_macro \
           -A clippy::print_stdout \
           -A clippy::print_stderr \
-          -A clippy::duplicated_attributes
+          -A clippy::duplicated_attributes \
+          -A deprecated
     - name: Enforce panic prevention lints (shipped targets)
       run: cargo clippy --workspace --lib --bins --examples --all-features -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::unreachable -D clippy::todo -D clippy::unimplemented
 
@@ -418,7 +419,7 @@ jobs:
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
     - name: Generate code coverage
-      run: cargo llvm-cov --workspace --exclude copybook-bench --exclude copybook-bdd --exclude copybook-e2e --lcov --output-path lcov.info
+      run: cargo llvm-cov --workspace --exclude copybook-bench --exclude copybook-bdd --lcov --output-path lcov.info
     # Make upload non-blocking and always run
     - name: Upload coverage to Codecov
       if: always()

--- a/.github/workflows/feature-flags.yml
+++ b/.github/workflows/feature-flags.yml
@@ -150,7 +150,8 @@ jobs:
             -A clippy::print_stdout \
             -A clippy::print_stderr \
             -A clippy::missing_inline_in_public_items \
-            -A clippy::duplicated_attributes
+            -A clippy::duplicated_attributes \
+            -A deprecated
 
   test-features-module:
     if: needs.changes.outputs.rust == 'true'

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -68,7 +68,8 @@ jobs:
             -A clippy::print_stdout \
             -A clippy::print_stderr \
             -A clippy::missing_inline_in_public_items \
-            -A clippy::duplicated_attributes
+            -A clippy::duplicated_attributes \
+            -A deprecated
           cargo build --workspace --release
           cargo nextest run --workspace
 

--- a/scripts/ci/quick.sh
+++ b/scripts/ci/quick.sh
@@ -28,7 +28,8 @@ echo "==> Running cargo clippy (tests: allow common test-only lints)"
   -A clippy::print_stdout \
   -A clippy::print_stderr \
   -A clippy::missing_inline_in_public_items \
-  -A clippy::duplicated_attributes
+  -A clippy::duplicated_attributes \
+  -A deprecated
 
 echo "==> Running cargo build --workspace --release"
 "$CARGO_BIN" build --workspace --release

--- a/tests/e2e/e2e_cli_error_code_coverage.rs
+++ b/tests/e2e/e2e_cli_error_code_coverage.rs
@@ -16,9 +16,9 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
+use assert_cmd::Command;
 use std::io::Write;
 use std::path::PathBuf;
-use assert_cmd::Command;
 use std::process::Output;
 
 // ---------------------------------------------------------------------------
@@ -83,7 +83,8 @@ fn setup_encode(cpy_text: &str, jsonl: &str) -> tempfile::TempDir {
 fn cli_cbkp001_syntax_garbage_parse() {
     let dir = write_temp_file("bad.cpy", b"@#$%^&*() NOT COBOL AT ALL");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "bad.cpy"))
         .output()
@@ -103,7 +104,8 @@ fn cli_cbkp001_syntax_garbage_parse() {
 fn cli_cbkp001_syntax_empty_inspect() {
     let dir = write_temp_file("empty.cpy", b"");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("inspect")
         .arg(temp_path(&dir, "empty.cpy"))
         .output()
@@ -126,7 +128,8 @@ fn cli_cbkp001_syntax_invalid_pic_char() {
         b"       01  REC.\n           05  FLD   PIC Q(5).\n",
     );
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "bad_pic.cpy"))
         .output()
@@ -152,7 +155,8 @@ fn cli_cbkp021_odo_not_tail() {
            05  TRAILER  PIC X(10).\n";
     let dir = write_temp_file("odo_tail.cpy", cpy);
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "odo_tail.cpy"))
         .output()
@@ -179,7 +183,8 @@ fn cli_cbkp022_nested_odo() {
                          PIC X(5).\n";
     let dir = write_temp_file("nested_odo.cpy", cpy);
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "nested_odo.cpy"))
         .output()
@@ -205,7 +210,8 @@ fn cli_cbkp023_odo_redefines() {
                         DEPENDING ON CTR PIC X(1).\n";
     let dir = write_temp_file("odo_redef.cpy", cpy);
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "odo_redef.cpy"))
         .output()
@@ -233,7 +239,8 @@ fn cli_cbks121_counter_not_found() {
                     PIC X(5).\n";
     let dir = write_temp_file("odo_no_ctr.cpy", cpy);
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "odo_no_ctr.cpy"))
         .output()
@@ -257,7 +264,8 @@ fn cli_cbks601_rename_unknown_from() {
            66  MY-ALIAS RENAMES NONEXISTENT.\n";
     let dir = write_temp_file("ren601.cpy", cpy);
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "ren601.cpy"))
         .output()
@@ -282,7 +290,8 @@ fn cli_cbks602_rename_unknown_thru() {
            66  MY-ALIAS RENAMES A THRU NONEXISTENT.\n";
     let dir = write_temp_file("ren602.cpy", cpy);
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "ren602.cpy"))
         .output()
@@ -307,7 +316,8 @@ fn cli_cbks604_rename_reversed_range() {
            66  MY-ALIAS RENAMES B THRU A.\n";
     let dir = write_temp_file("ren604.cpy", cpy);
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "ren604.cpy"))
         .output()
@@ -333,7 +343,8 @@ fn cli_cbks607_rename_crosses_occurs() {
            66  MY-ALIAS RENAMES A THRU C.\n";
     let dir = write_temp_file("ren607.cpy", cpy);
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "ren607.cpy"))
         .output()
@@ -357,7 +368,8 @@ fn cli_cbks703_projection_not_found_decode() {
         &[0x40; 10],
     );
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -391,7 +403,8 @@ fn cli_cbks703_projection_not_found_encode() {
         "{\"REC\":{\"NAME\":\"ALICE\"}}\n",
     );
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["encode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "input.jsonl"))
@@ -425,7 +438,8 @@ fn cli_cbks703_projection_not_found_verify() {
         &[0x40; 10],
     );
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["verify"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -462,7 +476,8 @@ fn cli_cbkd401_comp3_invalid_nibble_decode() {
         &[0xFF, 0xFF, 0xFF],
     );
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -489,7 +504,8 @@ fn cli_cbkd401_comp3_invalid_nibble_verify() {
         &[0xFF, 0xFF, 0xFF],
     );
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["verify"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -516,7 +532,8 @@ fn cli_cbkd411_zoned_bad_sign_decode() {
         &[0xF1, 0xF2, 0xF3, 0xF4, 0x05],
     );
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -544,7 +561,8 @@ fn cli_cbkd411_zoned_spaces_in_numeric() {
         &[0x40, 0x40, 0x40],
     );
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -574,7 +592,8 @@ fn cli_cbkd411_zoned_bad_sign_verify() {
         ],
     );
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["verify"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -601,7 +620,8 @@ fn cli_cbkd411_sign_separate_invalid() {
         &[0x00, 0xF1, 0xF2, 0xF3],
     );
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -630,7 +650,8 @@ fn cli_cbkd421_edited_pic_invalid_decode() {
         &[0xC1, 0xC2, 0xC3, 0xC4],
     );
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -657,7 +678,8 @@ fn cli_cbkd421_edited_pic_invalid_verify() {
         &[0xC1, 0xC2, 0xC3, 0xC4],
     );
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["verify"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -687,7 +709,8 @@ fn cli_cbke_numeric_overflow_encode() {
         "{\"REC\":{\"NUM\":\"99999\"}}\n",
     );
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["encode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "input.jsonl"))
@@ -718,7 +741,8 @@ fn cli_cbke_string_too_long_encode() {
         "{\"REC\":{\"NAME\":\"THIS STRING IS WAY TOO LONG FOR FIVE BYTES\"}}\n",
     );
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["encode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "input.jsonl"))
@@ -745,7 +769,8 @@ fn cli_cbke_type_mismatch_encode() {
         "{\"REC\":{\"NAME\":null,\"NUM\":\"12345\"}}\n",
     );
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["encode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "input.jsonl"))
@@ -774,7 +799,8 @@ fn cli_cbkf102_rdw_record_length_invalid() {
         &[0x00, 0x02, 0x00, 0x00], // length=2 < 4 → underflow
     );
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -804,7 +830,8 @@ fn cli_cbkf104_rdw_suspect_ascii() {
         ],
     );
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -832,7 +859,8 @@ fn cli_cbkf221_rdw_underflow_fixed() {
         &[0xC1, 0xD3, 0xC9, 0xC3, 0xC5],
     );
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -860,7 +888,8 @@ fn cli_cbkf221_rdw_underflow_fixed() {
 fn cli_parse_error_propagates_to_inspect() {
     let dir = write_temp_file("garbage.cpy", b"NOT VALID COBOL SYNTAX");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("inspect")
         .arg(temp_path(&dir, "garbage.cpy"))
         .output()
@@ -880,7 +909,8 @@ fn cli_parse_error_propagates_to_inspect() {
 fn cli_parse_error_propagates_to_decode() {
     let dir = setup_decode("GARBAGE NOT COBOL", &[0x00; 10]);
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -904,7 +934,8 @@ fn cli_parse_error_propagates_to_decode() {
 fn cli_parse_error_propagates_to_encode() {
     let dir = setup_encode("GARBAGE NOT COBOL", "{\"REC\":{\"A\":\"X\"}}\n");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["encode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "input.jsonl"))
@@ -928,7 +959,8 @@ fn cli_parse_error_propagates_to_encode() {
 fn cli_parse_error_propagates_to_verify() {
     let dir = setup_decode("GARBAGE NOT COBOL", &[0x00; 10]);
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["verify"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -954,7 +986,8 @@ fn cli_parse_error_propagates_to_verify() {
 fn cli_exit_code_parse_error() {
     let dir = write_temp_file("bad.cpy", b"INVALID");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "bad.cpy"))
         .output()
@@ -973,7 +1006,8 @@ fn cli_exit_code_decode_error() {
         &[0xFF, 0xFF, 0xFF],
     );
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -996,7 +1030,8 @@ fn cli_exit_code_rdw_error() {
         &[0x31, 0x32, 0x00, 0x00, 0x41, 0x42],
     );
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))

--- a/tests/e2e/e2e_cli_exit_codes.rs
+++ b/tests/e2e/e2e_cli_exit_codes.rs
@@ -6,8 +6,8 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use std::io::Write;
 use assert_cmd::Command;
+use std::io::Write;
 
 /// Assert that stderr does not contain panic markers.
 fn assert_no_panic(stderr: &str) {
@@ -57,7 +57,8 @@ fn write_temp_file(name: &str, contents: &[u8]) -> tempfile::TempDir {
 
 #[test]
 fn help_flag_exits_zero() {
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("--help")
         .output()
         .expect("failed to run copybook --help");
@@ -77,7 +78,8 @@ fn help_flag_exits_zero() {
 
 #[test]
 fn version_flag_exits_zero() {
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("--version")
         .output()
         .expect("failed to run copybook --version");
@@ -97,7 +99,8 @@ fn version_flag_exits_zero() {
 
 #[test]
 fn unknown_subcommand_exits_nonzero() {
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("unknown-subcommand")
         .output()
         .expect("failed to run copybook unknown-subcommand");
@@ -120,7 +123,8 @@ fn parse_valid_copybook_exits_zero() {
     let dir = write_temp_file("valid.cpy", VALID_COPYBOOK.as_bytes());
     let cpy_path = dir.path().join("valid.cpy");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["parse"])
         .arg(&cpy_path)
         .output()
@@ -147,7 +151,8 @@ fn parse_valid_copybook_exits_zero() {
 
 #[test]
 fn parse_nonexistent_file_exits_nonzero() {
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["parse", "this_file_absolutely_does_not_exist_12345.cpy"])
         .output()
         .expect("failed to run copybook parse");
@@ -170,7 +175,8 @@ fn parse_invalid_syntax_exits_nonzero() {
     let dir = write_temp_file("invalid.cpy", INVALID_COPYBOOK.as_bytes());
     let cpy_path = dir.path().join("invalid.cpy");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["parse"])
         .arg(&cpy_path)
         .output()
@@ -204,7 +210,8 @@ fn decode_valid_data_exits_zero() {
 
     let output_path = dir.path().join("output.jsonl");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(&cpy_path)
         .arg(&data_path)
@@ -242,7 +249,8 @@ fn decode_truncated_data_exits_nonzero() {
 
     let output_path = dir.path().join("output.jsonl");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(&cpy_path)
         .arg(&data_path)
@@ -273,7 +281,8 @@ fn verify_valid_data_exits_zero() {
     let data_path = dir.path().join("data.bin");
     std::fs::write(&data_path, valid_record_bytes()).expect("write data file");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["verify"])
         .arg(&cpy_path)
         .arg(&data_path)
@@ -315,7 +324,8 @@ fn verify_invalid_data_exits_nonzero() {
     let data_path = dir.path().join("bad_num.bin");
     std::fs::write(&data_path, [0xC1; 8]).expect("write bad data file");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["verify"])
         .arg(&cpy_path)
         .arg(&data_path)
@@ -356,7 +366,8 @@ fn verify_data_with_errors_exits_3() {
     let data_path = dir.path().join("bad_num.bin");
     std::fs::write(&data_path, [0xC1; 8]).expect("write bad data file");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["verify"])
         .arg(&cpy_path)
         .arg(&data_path)
@@ -387,7 +398,8 @@ fn decode_nonexistent_input_exits_nonzero() {
     let cpy_path = dir.path().join("schema.cpy");
     let output_path = dir.path().join("output.jsonl");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(&cpy_path)
         .arg("no_such_file_99999.bin")
@@ -412,7 +424,8 @@ fn decode_nonexistent_input_exits_nonzero() {
 
 #[test]
 fn parse_help_exits_zero() {
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["parse", "--help"])
         .output()
         .expect("failed to run copybook parse --help");
@@ -433,7 +446,8 @@ fn parse_help_exits_zero() {
 #[test]
 fn decode_missing_required_args_exits_nonzero() {
     // decode without required positional args
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .output()
         .expect("failed to run copybook decode");
@@ -461,7 +475,8 @@ fn encode_valid_data_exits_zero() {
     std::fs::write(&data_path, valid_record_bytes()).expect("write data file");
     let jsonl_path = dir.path().join("decoded.jsonl");
 
-    let decode_out = Command::cargo_bin("copybook").unwrap()
+    let decode_out = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(&cpy_path)
         .arg(&data_path)
@@ -479,7 +494,8 @@ fn encode_valid_data_exits_zero() {
 
     // Now encode the JSONL back to binary
     let encoded_path = dir.path().join("encoded.bin");
-    let encode_out = Command::cargo_bin("copybook").unwrap()
+    let encode_out = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["encode"])
         .arg(&cpy_path)
         .arg(&jsonl_path)
@@ -507,7 +523,8 @@ fn inspect_valid_copybook_exits_zero() {
     let dir = write_temp_file("schema.cpy", VALID_COPYBOOK.as_bytes());
     let cpy_path = dir.path().join("schema.cpy");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["inspect"])
         .arg(&cpy_path)
         .output()
@@ -541,7 +558,8 @@ fn all_exit_codes_are_in_expected_range() {
     ];
 
     for (label, args) in &scenarios {
-        let output = Command::cargo_bin("copybook").unwrap()
+        let output = Command::cargo_bin("copybook")
+            .unwrap()
             .args(args.iter())
             .output()
             .unwrap_or_else(|e| panic!("failed to run scenario '{label}': {e}"));
@@ -564,7 +582,8 @@ fn error_paths_do_not_produce_backtraces() {
     let dir = write_temp_file("bad.cpy", INVALID_COPYBOOK.as_bytes());
     let cpy_path = dir.path().join("bad.cpy");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["parse"])
         .arg(&cpy_path)
         .output()

--- a/tests/e2e/e2e_cli_field_projection.rs
+++ b/tests/e2e/e2e_cli_field_projection.rs
@@ -7,8 +7,8 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use std::path::PathBuf;
 use assert_cmd::Command;
+use std::path::PathBuf;
 use std::process::Output;
 
 // ---------------------------------------------------------------------------
@@ -180,7 +180,8 @@ fn setup_simple_two_records() -> tempfile::TempDir {
 fn select_single_field() {
     let dir = setup_multi_field();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args([
             "decode",
             "--format",
@@ -225,7 +226,8 @@ fn select_single_field() {
 fn select_comma_separated_fields() {
     let dir = setup_multi_field();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args([
             "decode",
             "--format",
@@ -267,7 +269,8 @@ fn select_comma_separated_fields() {
 fn select_multiple_flags() {
     let dir = setup_multi_field();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args([
             "decode",
             "--format",
@@ -311,7 +314,8 @@ fn select_multiple_flags() {
 fn select_nonexistent_field_produces_error() {
     let dir = setup_multi_field();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args([
             "decode",
             "--format",
@@ -351,7 +355,8 @@ fn select_nonexistent_field_produces_error() {
 fn select_odo_array_auto_includes_counter() {
     let dir = setup_odo();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args([
             "decode",
             "--format",
@@ -395,7 +400,8 @@ fn select_all_fields_same_as_no_select() {
     let out_with_select = temp_path(&dir, "with_select.jsonl");
 
     // Decode without --select
-    let o1 = Command::cargo_bin("copybook").unwrap()
+    let o1 = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode", "--format", "fixed", "--codepage", "cp037"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -406,7 +412,8 @@ fn select_all_fields_same_as_no_select() {
     assert_eq!(o1.status.code(), Some(0));
 
     // Decode with --select all fields
-    let o2 = Command::cargo_bin("copybook").unwrap()
+    let o2 = Command::cargo_bin("copybook")
+        .unwrap()
         .args([
             "decode",
             "--format",
@@ -446,7 +453,8 @@ fn select_all_fields_same_as_no_select() {
 fn select_group_field() {
     let dir = setup_group();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args([
             "decode",
             "--format",
@@ -503,7 +511,8 @@ fn select_group_field() {
 fn select_with_multiple_records() {
     let dir = setup_simple_two_records();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args([
             "decode",
             "--format",
@@ -546,7 +555,8 @@ fn select_with_multiple_records() {
 fn select_with_dialect_flag() {
     let dir = setup_odo();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args([
             "decode",
             "--format",
@@ -580,7 +590,8 @@ fn select_with_dialect_flag() {
 #[test]
 fn verify_with_select_flag() {
     let dir = setup_multi_field();
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args([
             "verify",
             "--format",
@@ -611,7 +622,8 @@ fn verify_with_select_flag() {
 fn select_last_field_only() {
     let dir = setup_multi_field();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args([
             "decode",
             "--format",
@@ -650,7 +662,8 @@ fn select_last_field_only() {
 fn select_odo_counter_without_array() {
     let dir = setup_odo();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args([
             "decode",
             "--format",
@@ -691,7 +704,8 @@ fn select_odo_counter_without_array() {
 fn select_counter_and_array_explicitly() {
     let dir = setup_odo();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args([
             "decode",
             "--format",
@@ -736,7 +750,8 @@ fn select_counter_and_array_explicitly() {
 fn select_non_odo_field_from_odo_schema() {
     let dir = setup_odo();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args([
             "decode",
             "--format",
@@ -773,7 +788,8 @@ fn select_non_odo_field_from_odo_schema() {
 fn select_multiple_nonexistent_fields_error() {
     let dir = setup_multi_field();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args([
             "decode",
             "--format",
@@ -805,7 +821,8 @@ fn select_multiple_nonexistent_fields_error() {
 fn select_mix_valid_and_nonexistent_produces_error() {
     let dir = setup_multi_field();
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args([
             "decode",
             "--format",
@@ -839,7 +856,8 @@ fn encode_with_select_flag() {
     let decode_out = temp_path(&dir, "decoded.jsonl");
 
     // First decode to get JSONL
-    let o1 = Command::cargo_bin("copybook").unwrap()
+    let o1 = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode", "--format", "fixed", "--codepage", "cp037"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -851,7 +869,8 @@ fn encode_with_select_flag() {
 
     // Now encode with --select
     let encode_out = temp_path(&dir, "encoded.bin");
-    let o2 = Command::cargo_bin("copybook").unwrap()
+    let o2 = Command::cargo_bin("copybook")
+        .unwrap()
         .args([
             "encode",
             "--format",

--- a/tests/e2e/e2e_cli_help_output.rs
+++ b/tests/e2e/e2e_cli_help_output.rs
@@ -31,7 +31,8 @@ fn assert_no_panic(stderr: &str) {
 
 /// Run `copybook <args>` and return the output, asserting success.
 fn run_help(args: &[&str]) -> Output {
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(args)
         .output()
         .unwrap_or_else(|e| panic!("failed to run copybook {args:?}: {e}"));
@@ -333,7 +334,11 @@ fn version_output_contains_program_name() {
 
 #[test]
 fn short_help_flag_works() {
-    let output = Command::cargo_bin("copybook").unwrap().arg("-h").output().expect("run -h");
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
+        .arg("-h")
+        .output()
+        .expect("run -h");
     assert_eq!(output.status.code(), Some(0), "exit code must be 0");
     let text = help_text(&output);
     assert!(
@@ -348,7 +353,11 @@ fn short_help_flag_works() {
 
 #[test]
 fn short_version_flag_works() {
-    let output = Command::cargo_bin("copybook").unwrap().arg("-V").output().expect("run -V");
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
+        .arg("-V")
+        .output()
+        .expect("run -V");
     assert_eq!(output.status.code(), Some(0), "exit code must be 0");
     let text = help_text(&output);
     let has_version = regex::Regex::new(r"\d+\.\d+\.\d+").unwrap().is_match(&text);

--- a/tests/e2e/e2e_cli_integration.rs
+++ b/tests/e2e/e2e_cli_integration.rs
@@ -7,9 +7,9 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
+use assert_cmd::Command;
 use std::io::Write;
 use std::path::PathBuf;
-use assert_cmd::Command;
 use std::process::Output;
 
 // ---------------------------------------------------------------------------
@@ -107,7 +107,8 @@ fn setup_two_records() -> tempfile::TempDir {
 fn parse_valid_copybook_produces_json_schema() {
     let dir = setup_simple();
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "schema.cpy"))
         .output()
@@ -135,7 +136,8 @@ fn parse_valid_copybook_to_output_file() {
     let dir = setup_simple();
     let out_path = temp_path(&dir, "schema.json");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["parse"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg("-o")
@@ -156,7 +158,8 @@ fn parse_valid_copybook_to_output_file() {
 
 #[test]
 fn parse_nonexistent_file_exits_nonzero() {
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["parse", "does_not_exist_12345.cpy"])
         .output()
         .expect("run parse");
@@ -169,7 +172,8 @@ fn parse_nonexistent_file_exits_nonzero() {
 fn parse_invalid_syntax_exits_nonzero() {
     let dir = write_temp_file("bad.cpy", b"THIS IS NOT VALID COBOL !!!");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "bad.cpy"))
         .output()
@@ -186,7 +190,8 @@ fn parse_invalid_syntax_exits_nonzero() {
 
 #[test]
 fn parse_missing_args_exits_nonzero() {
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("parse")
         .output()
         .expect("run parse without args");
@@ -197,7 +202,8 @@ fn parse_missing_args_exits_nonzero() {
 
 #[test]
 fn parse_help_exits_zero_with_usage() {
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["parse", "--help"])
         .output()
         .expect("run parse --help");
@@ -218,7 +224,8 @@ fn parse_help_exits_zero_with_usage() {
 fn inspect_valid_copybook_shows_layout() {
     let dir = setup_simple();
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("inspect")
         .arg(temp_path(&dir, "schema.cpy"))
         .output()
@@ -246,7 +253,8 @@ fn inspect_valid_copybook_shows_layout() {
 fn inspect_invalid_file_exits_nonzero() {
     let dir = write_temp_file("bad.cpy", b"NOT COBOL");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("inspect")
         .arg(temp_path(&dir, "bad.cpy"))
         .output()
@@ -258,7 +266,8 @@ fn inspect_invalid_file_exits_nonzero() {
 
 #[test]
 fn inspect_missing_args_exits_nonzero() {
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("inspect")
         .output()
         .expect("run inspect without args");
@@ -269,7 +278,8 @@ fn inspect_missing_args_exits_nonzero() {
 
 #[test]
 fn inspect_help_exits_zero() {
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["inspect", "--help"])
         .output()
         .expect("run inspect --help");
@@ -291,7 +301,8 @@ fn decode_single_record_to_jsonl() {
     let dir = setup_simple();
     let out = temp_path(&dir, "output.jsonl");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -327,7 +338,8 @@ fn decode_multiple_records() {
     let dir = setup_two_records();
     let out = temp_path(&dir, "output.jsonl");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -352,7 +364,8 @@ fn decode_multiple_records() {
 fn decode_to_stdout() {
     let dir = setup_simple();
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -375,7 +388,8 @@ fn decode_with_lossless_number_mode() {
     let dir = setup_simple();
     let out = temp_path(&dir, "output.jsonl");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -409,7 +423,8 @@ fn decode_truncated_data_exits_nonzero() {
     std::fs::write(dir.path().join("data.bin"), [0xF0; 5]).unwrap();
     let out = temp_path(&dir, "output.jsonl");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -428,7 +443,8 @@ fn decode_nonexistent_input_exits_nonzero() {
     let dir = setup_simple();
     let out = temp_path(&dir, "output.jsonl");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg("nonexistent_file_99999.bin")
@@ -444,7 +460,8 @@ fn decode_nonexistent_input_exits_nonzero() {
 
 #[test]
 fn decode_missing_required_args_exits_nonzero() {
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("decode")
         .output()
         .expect("run decode without args");
@@ -458,7 +475,8 @@ fn decode_missing_format_flag_exits_nonzero() {
     let dir = setup_simple();
     let out = temp_path(&dir, "output.jsonl");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -474,7 +492,8 @@ fn decode_missing_format_flag_exits_nonzero() {
 
 #[test]
 fn decode_help_exits_zero() {
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode", "--help"])
         .output()
         .expect("run decode --help");
@@ -494,7 +513,8 @@ fn decode_help_exits_zero() {
 /// Helper: decode a record to produce valid JSONL, return the JSONL file path.
 fn decode_to_jsonl(dir: &tempfile::TempDir) -> PathBuf {
     let jsonl_path = dir.path().join("decoded.jsonl");
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(dir.path().join("schema.cpy"))
         .arg(dir.path().join("data.bin"))
@@ -518,7 +538,8 @@ fn encode_valid_jsonl_to_binary() {
     let jsonl_path = decode_to_jsonl(&dir);
     let encoded_path = temp_path(&dir, "encoded.bin");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["encode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(&jsonl_path)
@@ -551,7 +572,8 @@ fn encode_round_trip_binary_fidelity() {
     let jsonl_path = decode_to_jsonl(&dir);
     let encoded_path = temp_path(&dir, "encoded.bin");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["encode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(&jsonl_path)
@@ -583,7 +605,8 @@ fn encode_invalid_jsonl_exits_nonzero() {
     std::fs::write(&bad_jsonl, "THIS IS NOT JSON\n").unwrap();
     let encoded_path = temp_path(&dir, "encoded.bin");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["encode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(&bad_jsonl)
@@ -602,7 +625,8 @@ fn encode_nonexistent_input_exits_nonzero() {
     let dir = setup_simple();
     let encoded_path = temp_path(&dir, "encoded.bin");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["encode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg("nonexistent_99999.jsonl")
@@ -618,7 +642,8 @@ fn encode_nonexistent_input_exits_nonzero() {
 
 #[test]
 fn encode_missing_required_args_exits_nonzero() {
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("encode")
         .output()
         .expect("run encode without args");
@@ -629,7 +654,8 @@ fn encode_missing_required_args_exits_nonzero() {
 
 #[test]
 fn encode_help_exits_zero() {
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["encode", "--help"])
         .output()
         .expect("run encode --help");
@@ -647,7 +673,8 @@ fn encode_to_stdout() {
     let dir = setup_simple();
     let jsonl_path = decode_to_jsonl(&dir);
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["encode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(&jsonl_path)
@@ -676,7 +703,8 @@ fn encode_to_stdout() {
 fn verify_valid_data_exits_zero() {
     let dir = setup_simple();
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["verify"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -705,7 +733,8 @@ fn verify_truncated_data_reports_zero_records() {
     // 5 bytes is not a complete record (13 needed); verify processes 0 records.
     std::fs::write(dir.path().join("data.bin"), [0xF0; 5]).unwrap();
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["verify"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -726,7 +755,8 @@ fn verify_truncated_data_reports_zero_records() {
 fn verify_nonexistent_data_exits_nonzero() {
     let dir = setup_simple();
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["verify"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg("nonexistent_99999.bin")
@@ -740,7 +770,8 @@ fn verify_nonexistent_data_exits_nonzero() {
 
 #[test]
 fn verify_missing_required_args_exits_nonzero() {
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("verify")
         .output()
         .expect("run verify without args");
@@ -751,7 +782,8 @@ fn verify_missing_required_args_exits_nonzero() {
 
 #[test]
 fn verify_help_exits_zero() {
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["verify", "--help"])
         .output()
         .expect("run verify --help");
@@ -769,7 +801,8 @@ fn verify_with_report_flag() {
     let dir = setup_simple();
     let report_path = temp_path(&dir, "report.json");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["verify"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -804,7 +837,8 @@ fn verify_with_report_flag() {
 fn determinism_decode_exits_zero_for_valid_data() {
     let dir = setup_simple();
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["determinism", "decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -835,7 +869,8 @@ fn determinism_encode_exits_zero_for_valid_data() {
     let dir = setup_simple();
     let jsonl_path = decode_to_jsonl(&dir);
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["determinism", "encode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(&jsonl_path)
@@ -856,7 +891,8 @@ fn determinism_encode_exits_zero_for_valid_data() {
 fn determinism_round_trip_exits_zero_for_valid_data() {
     let dir = setup_simple();
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["determinism", "round-trip"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -877,7 +913,8 @@ fn determinism_round_trip_exits_zero_for_valid_data() {
 fn determinism_json_output_format() {
     let dir = setup_simple();
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["determinism", "decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -906,7 +943,8 @@ fn determinism_json_output_format() {
 
 #[test]
 fn determinism_missing_args_exits_nonzero() {
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["determinism", "decode"])
         .output()
         .expect("run determinism decode without args");
@@ -917,7 +955,8 @@ fn determinism_missing_args_exits_nonzero() {
 
 #[test]
 fn determinism_help_exits_zero() {
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["determinism", "--help"])
         .output()
         .expect("run determinism --help");
@@ -932,7 +971,8 @@ fn determinism_help_exits_zero() {
 
 #[test]
 fn determinism_decode_help_exits_zero() {
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["determinism", "decode", "--help"])
         .output()
         .expect("run determinism decode --help");
@@ -946,7 +986,11 @@ fn determinism_decode_help_exits_zero() {
 
 #[test]
 fn global_help_exits_zero() {
-    let output = Command::cargo_bin("copybook").unwrap().arg("--help").output().expect("run --help");
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
+        .arg("--help")
+        .output()
+        .expect("run --help");
 
     assert_eq!(output.status.code(), Some(0));
     let so = stdout_str(&output);
@@ -966,7 +1010,8 @@ fn global_help_exits_zero() {
 
 #[test]
 fn version_flag_exits_zero() {
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("--version")
         .output()
         .expect("run --version");
@@ -981,7 +1026,8 @@ fn version_flag_exits_zero() {
 
 #[test]
 fn unknown_subcommand_exits_nonzero() {
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("not-a-real-command")
         .output()
         .expect("run unknown subcommand");
@@ -994,7 +1040,8 @@ fn unknown_subcommand_exits_nonzero() {
 fn error_paths_never_produce_backtraces() {
     let dir = write_temp_file("bad.cpy", b"NOT COBOL");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("parse")
         .arg(temp_path(&dir, "bad.cpy"))
         .output()
@@ -1018,7 +1065,8 @@ fn exit_codes_are_in_expected_range() {
     ];
 
     for (label, args) in scenarios {
-        let output = Command::cargo_bin("copybook").unwrap()
+        let output = Command::cargo_bin("copybook")
+            .unwrap()
             .args(args.iter())
             .output()
             .unwrap_or_else(|e| panic!("failed to run scenario '{label}': {e}"));
@@ -1041,7 +1089,8 @@ fn full_pipeline_decode_encode_verify() {
 
     // Step 1: Decode binary → JSONL
     let jsonl_path = temp_path(&dir, "decoded.jsonl");
-    let decode_out = Command::cargo_bin("copybook").unwrap()
+    let decode_out = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))
@@ -1059,7 +1108,8 @@ fn full_pipeline_decode_encode_verify() {
 
     // Step 2: Encode JSONL → binary
     let encoded_path = temp_path(&dir, "encoded.bin");
-    let encode_out = Command::cargo_bin("copybook").unwrap()
+    let encode_out = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["encode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(&jsonl_path)
@@ -1076,7 +1126,8 @@ fn full_pipeline_decode_encode_verify() {
     );
 
     // Step 3: Verify re-encoded binary
-    let verify_out = Command::cargo_bin("copybook").unwrap()
+    let verify_out = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["verify"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(&encoded_path)
@@ -1108,7 +1159,8 @@ fn parse_with_dialect_flag() {
     let dir = setup_simple();
 
     for dialect in &["n", "0", "1"] {
-        let output = Command::cargo_bin("copybook").unwrap()
+        let output = Command::cargo_bin("copybook")
+            .unwrap()
             .args(["parse"])
             .arg(temp_path(&dir, "schema.cpy"))
             .args(["--dialect", dialect])
@@ -1129,7 +1181,8 @@ fn decode_with_emit_meta() {
     let dir = setup_simple();
     let out = temp_path(&dir, "output.jsonl");
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["decode"])
         .arg(temp_path(&dir, "schema.cpy"))
         .arg(temp_path(&dir, "data.bin"))

--- a/tests/e2e/e2e_dialect_behavior.rs
+++ b/tests/e2e/e2e_dialect_behavior.rs
@@ -8,9 +8,9 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
+use assert_cmd::Command;
 use std::io::Write;
 use std::path::PathBuf;
-use assert_cmd::Command;
 use std::process::Output;
 
 // ---------------------------------------------------------------------------
@@ -136,7 +136,8 @@ fn setup_simple() -> tempfile::TempDir {
 #[test]
 fn parse_with_dialect_normative() {
     let dir = write_temp_file("schema.cpy", ODO_MIN2_CPY.as_bytes());
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["parse", "--dialect", "n"])
         .arg(temp_path(&dir, "schema.cpy"))
         .output()
@@ -157,7 +158,8 @@ fn parse_with_dialect_normative() {
 #[test]
 fn parse_with_dialect_zero_tolerant() {
     let dir = write_temp_file("schema.cpy", ODO_MIN2_CPY.as_bytes());
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["parse", "--dialect", "0"])
         .arg(temp_path(&dir, "schema.cpy"))
         .output()
@@ -178,7 +180,8 @@ fn parse_with_dialect_zero_tolerant() {
 #[test]
 fn parse_with_dialect_one_tolerant() {
     let dir = write_temp_file("schema.cpy", ODO_MIN2_CPY.as_bytes());
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["parse", "--dialect", "1"])
         .arg(temp_path(&dir, "schema.cpy"))
         .output()
@@ -199,7 +202,8 @@ fn parse_with_dialect_one_tolerant() {
 #[test]
 fn invalid_dialect_value_produces_error() {
     let dir = write_temp_file("schema.cpy", ODO_MIN2_CPY.as_bytes());
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["parse", "--dialect", "xyz"])
         .arg(temp_path(&dir, "schema.cpy"))
         .output()
@@ -217,7 +221,8 @@ fn invalid_dialect_value_produces_error() {
 fn decode_dialect_normative_valid_count() {
     let dir = setup_odo_min2(3); // count=3, min=2, within bounds
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args([
             "decode",
             "--format",
@@ -251,7 +256,8 @@ fn decode_dialect_normative_valid_count() {
 fn decode_dialect_zero_tolerant_allows_zero_count() {
     let dir = setup_odo_min2(0); // count=0, min=2 but zero-tolerant ignores min
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args([
             "decode",
             "--format",
@@ -286,7 +292,8 @@ fn decode_dialect_zero_tolerant_allows_zero_count() {
 fn decode_dialect_one_tolerant_with_min0_schema() {
     let dir = setup_odo_min0(1); // count=1, min_count=0 but one-tolerant clamps to 1
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args([
             "decode",
             "--format",
@@ -318,7 +325,8 @@ fn decode_dialect_one_tolerant_with_min0_schema() {
 #[test]
 fn env_var_copybook_dialect_is_respected() {
     let dir = write_temp_file("schema.cpy", ODO_MIN2_CPY.as_bytes());
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .env("COPYBOOK_DIALECT", "0")
         .args(["parse"])
         .arg(temp_path(&dir, "schema.cpy"))
@@ -341,7 +349,8 @@ fn env_var_copybook_dialect_is_respected() {
 fn cli_dialect_flag_overrides_env_var() {
     let dir = write_temp_file("schema.cpy", ODO_MIN2_CPY.as_bytes());
     // Set env to "0" but CLI to "1" – should use "1"
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .env("COPYBOOK_DIALECT", "0")
         .args(["parse", "--dialect", "1"])
         .arg(temp_path(&dir, "schema.cpy"))
@@ -363,7 +372,8 @@ fn cli_dialect_flag_overrides_env_var() {
 #[test]
 fn default_dialect_is_normative() {
     let dir = write_temp_file("schema.cpy", SIMPLE_CPY.as_bytes());
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .env_remove("COPYBOOK_DIALECT")
         .args(["parse"])
         .arg(temp_path(&dir, "schema.cpy"))
@@ -385,7 +395,8 @@ fn default_dialect_is_normative() {
 #[test]
 fn inspect_with_dialect_zero() {
     let dir = write_temp_file("schema.cpy", ODO_MIN2_CPY.as_bytes());
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["inspect", "--dialect", "0"])
         .arg(temp_path(&dir, "schema.cpy"))
         .output()
@@ -406,7 +417,8 @@ fn inspect_with_dialect_zero() {
 #[test]
 fn inspect_with_dialect_one() {
     let dir = write_temp_file("schema.cpy", ODO_MIN2_CPY.as_bytes());
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["inspect", "--dialect", "1"])
         .arg(temp_path(&dir, "schema.cpy"))
         .output()
@@ -428,7 +440,8 @@ fn inspect_with_dialect_one() {
 #[ignore = "ODO schemas have lrecl_fixed=None; --format fixed requires LRECL (pre-existing limitation)"]
 fn verify_with_dialect_zero() {
     let dir = setup_odo_min2(3);
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args([
             "verify",
             "--format",
@@ -458,7 +471,8 @@ fn verify_with_dialect_zero() {
 #[test]
 fn dialect_value_two_is_invalid() {
     let dir = write_temp_file("schema.cpy", ODO_MIN2_CPY.as_bytes());
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["parse", "--dialect", "2"])
         .arg(temp_path(&dir, "schema.cpy"))
         .output()
@@ -474,7 +488,8 @@ fn dialect_value_two_is_invalid() {
 #[test]
 fn empty_dialect_value_is_invalid() {
     let dir = write_temp_file("schema.cpy", ODO_MIN2_CPY.as_bytes());
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["parse", "--dialect", ""])
         .arg(temp_path(&dir, "schema.cpy"))
         .output()
@@ -498,7 +513,8 @@ fn encode_with_dialect_flag() {
     let dir = setup_odo_min2(3);
     let out_path = temp_path(&dir, "out.jsonl");
     // Decode first
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args([
             "decode",
             "--format",
@@ -523,7 +539,8 @@ fn encode_with_dialect_flag() {
 
     // Now encode with dialect
     let enc_out = temp_path(&dir, "encoded.bin");
-    let enc_output = Command::cargo_bin("copybook").unwrap()
+    let enc_output = Command::cargo_bin("copybook")
+        .unwrap()
         .args([
             "encode",
             "--format",
@@ -555,7 +572,8 @@ fn encode_with_dialect_flag() {
 fn decode_normative_count_below_min_is_handled() {
     let dir = setup_odo_min2(1); // count=1, min=2 in normative → should clip/error
     let out_path = temp_path(&dir, "out.jsonl");
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args([
             "decode",
             "--format",
@@ -583,7 +601,8 @@ fn decode_normative_count_below_min_is_handled() {
 #[test]
 fn env_var_invalid_dialect_produces_error() {
     let dir = write_temp_file("schema.cpy", ODO_MIN2_CPY.as_bytes());
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .env("COPYBOOK_DIALECT", "invalid")
         .args(["parse"])
         .arg(temp_path(&dir, "schema.cpy"))
@@ -601,7 +620,8 @@ fn env_var_invalid_dialect_produces_error() {
 fn all_three_dialects_on_inspect() {
     let dir = write_temp_file("schema.cpy", ODO_MIN2_CPY.as_bytes());
     for dialect in &["n", "0", "1"] {
-        let output = Command::cargo_bin("copybook").unwrap()
+        let output = Command::cargo_bin("copybook")
+            .unwrap()
             .args(["inspect", "--dialect", dialect])
             .arg(temp_path(&dir, "schema.cpy"))
             .output()

--- a/tests/e2e/e2e_parallel_determinism.rs
+++ b/tests/e2e/e2e_parallel_determinism.rs
@@ -6,8 +6,8 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use sha2::{Digest, Sha256};
 use assert_cmd::Command;
+use sha2::{Digest, Sha256};
 use std::process::Output;
 
 // ---------------------------------------------------------------------------
@@ -97,7 +97,8 @@ fn setup_multi_record_dir() -> tempfile::TempDir {
 fn run_decode(dir: &tempfile::TempDir, threads: usize) -> Vec<u8> {
     let out_path = dir.path().join(format!("output_{threads}t.jsonl"));
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("decode")
         .arg(dir.path().join("schema.cpy"))
         .arg(dir.path().join("data.bin"))
@@ -123,7 +124,8 @@ fn run_decode(dir: &tempfile::TempDir, threads: usize) -> Vec<u8> {
 fn run_decode_to(dir: &tempfile::TempDir, out_name: &str, threads: usize) -> Vec<u8> {
     let out_path = dir.path().join(out_name);
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("decode")
         .arg(dir.path().join("schema.cpy"))
         .arg(dir.path().join("data.bin"))
@@ -294,7 +296,8 @@ fn test_schema_fingerprint_stable_across_runs() {
 fn test_determinism_subcommand_decode_exit_zero() {
     let dir = setup_multi_record_dir();
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["determinism", "decode"])
         .arg(dir.path().join("schema.cpy"))
         .arg(dir.path().join("data.bin"))
@@ -327,7 +330,8 @@ fn test_determinism_subcommand_encode_exit_zero() {
 
     // First decode to get JSONL for encode input
     let jsonl_path = dir.path().join("for_encode.jsonl");
-    let decode_output = Command::cargo_bin("copybook").unwrap()
+    let decode_output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("decode")
         .arg(dir.path().join("schema.cpy"))
         .arg(dir.path().join("data.bin"))
@@ -343,7 +347,8 @@ fn test_determinism_subcommand_encode_exit_zero() {
         stderr_str(&decode_output)
     );
 
-    let output = Command::cargo_bin("copybook").unwrap()
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
         .args(["determinism", "encode"])
         .arg(dir.path().join("schema.cpy"))
         .arg(&jsonl_path)
@@ -370,7 +375,8 @@ fn test_encode_deterministic_across_thread_counts() {
 
     // Decode once to get JSONL
     let jsonl_path = dir.path().join("source.jsonl");
-    let decode_output = Command::cargo_bin("copybook").unwrap()
+    let decode_output = Command::cargo_bin("copybook")
+        .unwrap()
         .arg("decode")
         .arg(dir.path().join("schema.cpy"))
         .arg(dir.path().join("data.bin"))
@@ -389,7 +395,8 @@ fn test_encode_deterministic_across_thread_counts() {
     // Encode with 1 thread as baseline
     let encode_with = |threads: usize| -> Vec<u8> {
         let out = dir.path().join(format!("encoded_{threads}t.bin"));
-        let output = Command::cargo_bin("copybook").unwrap()
+        let output = Command::cargo_bin("copybook")
+            .unwrap()
             .arg("encode")
             .arg(dir.path().join("schema.cpy"))
             .arg(&jsonl_path)


### PR DESCRIPTION
## What changed
- \cargo fmt\ corrects chain formatting for 7 e2e test files from PR #329 (\.unwrap()\ on separate line)
- Add \-A deprecated\ to test clippy in quick.sh, ci.yml, perf.yml, feature-flags.yml
- Re-include copybook-e2e in llvm-cov coverage (was excluded due to binary path issues fixed by PR #329)
- Supersedes PR #330 (closed)

## Why
assert_cmd 2.1.2 deprecated \Command::cargo_bin()\ in favour of \cargo_bin_cmd!()\ macro. The macro requires \CARGO_BIN_EXE_*\ at compile time (needs copybook-cli as dependency — larger migration). The deprecated function still works correctly; suppress for test code until migration.

## What I ran
\\\
cargo fmt --all --check  # clean
cargo clippy --workspace --tests --all-features -- -D warnings [...] -A deprecated  # clean
cargo clippy --workspace --lib --bins --examples --all-features -- -D warnings -W clippy::pedantic  # clean
\\\

## CI
Rely on CI Quick + CI Full for confirmation.

## Impact
- Determinism: none
- Taxonomy: none
- Perf: none
- Docs: none

## Disposition
MERGE when CI Quick green.