### PR TITLE
fix: expand mutation testing to 12 crates

### DIFF
--- a/.github/workflows/ci-mutants.yml
+++ b/.github/workflows/ci-mutants.yml
@@ -34,6 +34,13 @@ on:
       - 'crates/copybook-error/**'
       - 'crates/copybook-overpunch/**'
       - 'crates/copybook-overflow/**'
+      - 'crates/copybook-lexer/**'
+      - 'crates/copybook-rdw/**'
+      - 'crates/copybook-fixed/**'
+      - 'crates/copybook-charset/**'
+      - 'crates/copybook-codepage/**'
+      - 'crates/copybook-dialect/**'
+      - 'crates/copybook-record-io/**'
       - 'mutants.toml'
       - '.github/workflows/ci-mutants.yml'
 
@@ -107,6 +114,20 @@ jobs:
             threshold: 80
           - crate: copybook-overflow
             threshold: 80
+          - crate: copybook-lexer
+            threshold: 70
+          - crate: copybook-rdw
+            threshold: 75
+          - crate: copybook-fixed
+            threshold: 75
+          - crate: copybook-charset
+            threshold: 70
+          - crate: copybook-codepage
+            threshold: 70
+          - crate: copybook-dialect
+            threshold: 75
+          - crate: copybook-record-io
+            threshold: 70
 
     steps:
       - name: Checkout code

--- a/crates/copybook-charset/Cargo.toml
+++ b/crates/copybook-charset/Cargo.toml
@@ -28,6 +28,8 @@ tracing.workspace = true
 [features]
 default = []
 clap = ["copybook-codepage/clap"]
+# No-op: allows ci-mutants.yml to pass --features comprehensive-tests uniformly
+comprehensive-tests = []
 
 [lints]
 workspace = true

--- a/crates/copybook-codepage/Cargo.toml
+++ b/crates/copybook-codepage/Cargo.toml
@@ -27,6 +27,8 @@ serde.workspace = true
 [features]
 default = []
 clap = ["dep:clap"]
+# No-op: allows ci-mutants.yml to pass --features comprehensive-tests uniformly
+comprehensive-tests = []
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/copybook-dialect/Cargo.toml
+++ b/crates/copybook-dialect/Cargo.toml
@@ -28,6 +28,8 @@ serde_json.workspace = true
 
 [features]
 default = []
+# No-op: allows ci-mutants.yml to pass --features comprehensive-tests uniformly
+comprehensive-tests = []
 
 [lints]
 workspace = true

--- a/crates/copybook-fixed/Cargo.toml
+++ b/crates/copybook-fixed/Cargo.toml
@@ -28,5 +28,9 @@ tracing.workspace = true
 [dev-dependencies]
 proptest.workspace = true
 
+[features]
+# No-op: allows ci-mutants.yml to pass --features comprehensive-tests uniformly
+comprehensive-tests = []
+
 [lints]
 workspace = true

--- a/crates/copybook-lexer/Cargo.toml
+++ b/crates/copybook-lexer/Cargo.toml
@@ -19,5 +19,9 @@ logos.workspace = true
 [dev-dependencies]
 proptest.workspace = true
 
+[features]
+# No-op: allows ci-mutants.yml to pass --features comprehensive-tests uniformly
+comprehensive-tests = []
+
 [lints]
 workspace = true

--- a/crates/copybook-rdw/Cargo.toml
+++ b/crates/copybook-rdw/Cargo.toml
@@ -29,5 +29,9 @@ tracing.workspace = true
 [dev-dependencies]
 proptest.workspace = true
 
+[features]
+# No-op: allows ci-mutants.yml to pass --features comprehensive-tests uniformly
+comprehensive-tests = []
+
 [lints]
 workspace = true

--- a/crates/copybook-record-io/Cargo.toml
+++ b/crates/copybook-record-io/Cargo.toml
@@ -29,5 +29,9 @@ copybook-rdw.workspace = true
 [dev-dependencies]
 proptest.workspace = true
 
+[features]
+# No-op: allows ci-mutants.yml to pass --features comprehensive-tests uniformly
+comprehensive-tests = []
+
 [lints]
 workspace = true

--- a/mutants.toml
+++ b/mutants.toml
@@ -25,13 +25,20 @@ cap_lints = true
 features = ["comprehensive-tests"]
 
 # --- Source file targeting ---
-# Focus mutation testing on the most critical crates
+# Focus mutation testing on production-critical crates
 examine_globs = [
     "crates/copybook-core/src/**/*.rs",
     "crates/copybook-codec/src/**/*.rs",
     "crates/copybook-error/src/**/*.rs",
     "crates/copybook-overpunch/src/**/*.rs",
     "crates/copybook-overflow/src/**/*.rs",
+    "crates/copybook-lexer/src/**/*.rs",
+    "crates/copybook-rdw/src/**/*.rs",
+    "crates/copybook-fixed/src/**/*.rs",
+    "crates/copybook-charset/src/**/*.rs",
+    "crates/copybook-codepage/src/**/*.rs",
+    "crates/copybook-dialect/src/**/*.rs",
+    "crates/copybook-record-io/src/**/*.rs",
 ]
 
 # Exclude non-production code even within targeted crates


### PR DESCRIPTION
## What changed

Expanded mutation testing from 5 crates to 12, covering all production-critical data processing crates.

### New crates added
| Crate | Threshold | Role |
|-------|-----------|------|
| copybook-lexer | 70% | Fundamental COBOL tokenization |
| copybook-rdw | 75% | RDW record framing |
| copybook-fixed | 75% | Fixed-length record handling |
| copybook-charset | 70% | EBCDIC/ASCII conversion |
| copybook-codepage | 70% | Code page type contracts |
| copybook-dialect | 75% | ODO dialect semantics |
| copybook-record-io | 70% | Record format dispatch |

### Root cause of scheduled run failures
Two pre-existing test bugs caused the last 2 scheduled runs (Feb 22, Mar 1) to fail:
1. \	est_cli_roundtrip_cmp_validation\ — binary not found (fixed in PR #323)
2. \dd_scenario_enterprise_sign_separate\ — SIGN SEPARATE promoted to stable (v0.4.3)

Both are already fixed on main. Next scheduled run should pass.

### Files changed
- \mutants.toml\: 7 new examine_globs
- \ci-mutants.yml\: 7 new matrix entries + path triggers
- 7 \Cargo.toml\ files: no-op \comprehensive-tests\ feature

## Receipt
- **What I ran locally**: \cargo check --workspace --features comprehensive-tests\ ✅
- **Determinism impact**: None
- **Taxonomy impact**: None
- **Perf impact**: None
- **Docs touched**: None

## Recommended disposition: MERGE