### PR TITLE
fix(ci): remove paths-ignore so docs-only PRs get testExpected check

### DIFF
--- a/.github/workflows/ci-quick.yml
+++ b/.github/workflows/ci-quick.yml
@@ -3,10 +3,6 @@ name: CI Quick
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
-      - '.github/ISSUE_TEMPLATE/**'
   push:
     branches: [main]
 
@@ -35,6 +31,8 @@ jobs:
             rust:
               - 'crates/**'
               - 'copybook-*/**'
+              - 'tools/**'
+              - 'tests/**'
               - 'Cargo.*'
               - 'rust-toolchain*'
               - 'scripts/ci/**'


### PR DESCRIPTION
## What changed

Removed \paths-ignore\ from CI Quick workflow trigger. Previously, docs-only PRs (changing only \docs/**\ or \**/*.md\) skipped CI Quick entirely, which meant the \	estExpected\ required check never ran, blocking merge.

### How it works now
1. Every PR triggers CI Quick
2. The \changes\ job uses \dorny/paths-filter\ to detect Rust changes
3. For docs-only PRs: no Rust changes detected → \	est\ job skipped → \	estExpected\ sees \skipped\ → reports success
4. For code PRs: normal path — full test suite runs

### Also
- Added \	ests/**\ and \	ools/**\ to the Rust path filter (these contain workspace member crates)

## Receipt
- **What I ran locally**: N/A (CI workflow change only)
- **CI relied on**: CI Quick on this PR (should pass as it's a CI change, not docs-only)
- **Determinism impact**: None
- **Taxonomy impact**: None
- **Perf impact**: None
- **Docs touched**: None
- **Unblocks**: PR #334 (docs-only ROADMAP pass)

## Recommended disposition: MERGE