### PR TITLE
fix(ci): exclude copybook-bdd from nextest in perf and pr-insights workflows

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -71,7 +71,7 @@ jobs:
             -A clippy::duplicated_attributes \
             -A deprecated
           cargo build --workspace --release
-          cargo nextest run --workspace
+          cargo nextest run --workspace --exclude copybook-bench --exclude copybook-bdd
 
       - name: Property tests (fast deterministic)
         env:

--- a/.github/workflows/pr-insights.yml
+++ b/.github/workflows/pr-insights.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: taiki-e/install-action@nextest
       
       - name: Run Tests (Generate junit.xml)
-        run: cargo nextest run --workspace --profile ci
+        run: cargo nextest run --workspace --exclude copybook-bench --exclude copybook-bdd --profile ci
         continue-on-error: true
 
       - name: Generate PR Insights


### PR DESCRIPTION
## What changed

Excluded \copybook-bdd\ and \copybook-bench\ from \cargo nextest run\ in two CI workflows:
- **perf.yml**: The \perf\ job was failing because Cucumber BDD exits with code 104 when scenarios are skipped
- **pr-insights.yml**: Same potential issue (currently masked by \continue-on-error: true\)

### Root cause
Cucumber BDD runner uses exit code 104 to indicate skipped scenarios. Nextest interprets this as a test failure. \ci.yml\ and \scripts/ci/quick.sh\ already exclude \copybook-bdd\ from nextest and run BDD separately via \governance-bdd-smoke.sh\.

### Fixes
- PR #333 \perf\ check failure (exit code 104 from BDD in nextest)

## Receipt
- **What I ran locally**: N/A (CI workflow change only)
- **CI relied on**: CI Quick on this PR
- **Determinism impact**: None
- **Taxonomy impact**: None
- **Perf impact**: None (fixes perf workflow, no perf claim change)
- **Docs touched**: None
- **Unblocks**: PR #333 \perf\ check

## Recommended disposition: MERGE