### PR TITLE
fix(ci): add workflow_dispatch trigger to CI Quick and Feature Flags

### DIFF
--- a/.github/workflows/ci-quick.yml
+++ b/.github/workflows/ci-quick.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}

--- a/.github/workflows/feature-flags.yml
+++ b/.github/workflows/feature-flags.yml
@@ -14,6 +14,7 @@ on:
       - 'docs/**'
       - '**/*.md'
       - '.github/ISSUE_TEMPLATE/**'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}


### PR DESCRIPTION
## What changed
Added \workflow_dispatch\ trigger to CI Quick and Feature Flags CI workflows,
allowing manual re-runs from the Actions UI when needed (e.g., after rapid
merges where push events get debounced/cancelled).

## What I ran locally
- Verified YAML syntax is valid
- CI Quick will validate itself on this PR

## CI truth
- CI Quick on this PR

## Determinism impact: none
## Taxonomy impact: none
## Perf impact: none
## Docs touched: none

## What remains
- None — two-line config change across two workflow files

## Recommended disposition: MERGE