### PR TITLE
fix: deny unwrap/expect in production code for all publishable crates

### DIFF
--- a/crates/copybook-arrow/src/lib.rs
+++ b/crates/copybook-arrow/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! Typed Arrow and Parquet output for copybook-rs
 //!

--- a/crates/copybook-charset/src/lib.rs
+++ b/crates/copybook-charset/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! Character set conversion utilities for EBCDIC ↔ UTF-8.
 //!

--- a/crates/copybook-cli-determinism/src/lib.rs
+++ b/crates/copybook-cli-determinism/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! Determinism command execution for copybook CLI workflows.
 //!

--- a/crates/copybook-codec-memory/src/lib.rs
+++ b/crates/copybook-codec-memory/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! Memory management utilities for streaming record processing
 //!

--- a/crates/copybook-codepage/src/lib.rs
+++ b/crates/copybook-codepage/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! Codepage domain types and helpers.
 //!

--- a/crates/copybook-contracts/src/lib.rs
+++ b/crates/copybook-contracts/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! Shared contracts for feature-flag governance.
 

--- a/crates/copybook-corruption-detectors/src/lib.rs
+++ b/crates/copybook-corruption-detectors/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! Focused field-level corruption detectors.
 //!

--- a/crates/copybook-corruption-predicates/src/lib.rs
+++ b/crates/copybook-corruption-predicates/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! Pure predicate helpers for transfer-corruption heuristics used by higher-level
 //! codec error reporting.

--- a/crates/copybook-corruption-rdw/src/lib.rs
+++ b/crates/copybook-corruption-rdw/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! RDW corruption heuristics.
 //!

--- a/crates/copybook-corruption/src/lib.rs
+++ b/crates/copybook-corruption/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! Transfer-corruption detection façade.
 //!

--- a/crates/copybook-dialect/src/lib.rs
+++ b/crates/copybook-dialect/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! Dialect types for ODO (OCCURS DEPENDING ON) `min_count` behavior.
 //!

--- a/crates/copybook-error-reporter/src/lib.rs
+++ b/crates/copybook-error-reporter/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! Structured error reporting and handling system
 //!

--- a/crates/copybook-error/src/lib.rs
+++ b/crates/copybook-error/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! Error types and taxonomy for copybook-rs
 //!

--- a/crates/copybook-lexer/src/lib.rs
+++ b/crates/copybook-lexer/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 #![allow(clippy::must_use_candidate)]
 
 //! COBOL lexer microcrate.

--- a/crates/copybook-options/src/lib.rs
+++ b/crates/copybook-options/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! Configuration option types shared across copybook-rs crates.
 //!

--- a/crates/copybook-overflow/src/lib.rs
+++ b/crates/copybook-overflow/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! Overflow-safe numeric guards for copybook-rs.
 //!

--- a/crates/copybook-rdw-predicates/src/lib.rs
+++ b/crates/copybook-rdw-predicates/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! RDW header ASCII-digit detection helper.
 //!

--- a/crates/copybook-safe-index/src/lib.rs
+++ b/crates/copybook-safe-index/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! Panic-safe helpers for low-level indexing and arithmetic operations.
 //!

--- a/crates/copybook-safe-ops/src/lib.rs
+++ b/crates/copybook-safe-ops/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! Panic-safe conversion and arithmetic helper functions.
 //!

--- a/crates/copybook-safe-text/src/lib.rs
+++ b/crates/copybook-safe-text/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! Panic-safe parsing and string helper functions.
 //!

--- a/crates/copybook-support-matrix/src/lib.rs
+++ b/crates/copybook-support-matrix/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! COBOL feature support matrix registry.
 

--- a/crates/copybook-utils/src/lib.rs
+++ b/crates/copybook-utils/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! Panic-safe utility functions and extension traits
 //!

--- a/crates/copybook-zoned-format/src/lib.rs
+++ b/crates/copybook-zoned-format/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! Zoned-decimal encoding detection helpers used by codec options and framing logic.
 #![allow(clippy::missing_inline_in_public_items)]


### PR DESCRIPTION
## What changed
Added \#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]\ to 23 crates that were missing the safety lint. This brings the **entire workspace** to uniform enforcement of the no-unwrap/no-expect policy in production code.

Previously only 12 crates had this deny rule. Now all 35 publishable crates enforce it.

The \cfg_attr(not(test))\ guard allows tests to continue using unwrap/expect freely, matching the existing pattern used by established crates.

## What I ran locally
\\\ash
cargo clippy --workspace --exclude copybook-bench --exclude copybook-bdd -- -D warnings -W clippy::pedantic  # Clean
cargo test --workspace --exclude copybook-bench --exclude copybook-bdd  # All passing
\\\

## CI truth
- CI Quick on this PR

## Determinism impact: none
## Taxonomy impact: none
## Perf impact: none
## Docs touched: none

## What remains
- None — one-line addition to each crate's lib.rs

## Recommended disposition: MERGE