### PR TITLE
fix: consistent nextest exclusions in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -18,11 +18,11 @@ build-release:
 
 # Run all tests using cargo-nextest (preferred)
 test:
-    cargo nextest run --workspace --exclude copybook-bdd
+    cargo nextest run --workspace --exclude copybook-bdd --exclude copybook-bench
 
 # Run all tests, including long-running and ignored tests
 test-all:
-    cargo nextest run --workspace --run-ignored all
+    cargo nextest run --workspace --exclude copybook-bdd --exclude copybook-bench --run-ignored all
 
 # Run tests with legacy cargo test (fallback)
 test-legacy:
@@ -389,7 +389,7 @@ coverage:
 
 # Watch for changes and run tests
 watch:
-    cargo watch -x "nextest run --workspace"
+    cargo watch -x "nextest run --workspace --exclude copybook-bdd --exclude copybook-bench"
 
 # Watch for changes and run tests for specific crate
 watch-crate crate:


### PR DESCRIPTION
## What changed
Added \--exclude copybook-bdd --exclude copybook-bench\ to all workspace-wide
nextest commands in the justfile:
- \	est\ recipe: added \--exclude copybook-bench\
- \	est-all\ recipe: added both excludes (was missing both)
- \watch\ recipe: added both excludes (was missing both)

### Why
- \copybook-bdd\ exits with code 104 on skipped scenarios, which nextest treats as failure
- \copybook-bench\ should be run separately via \just bench\
- \just ci-quick\ (scripts/ci/quick.sh) already had the correct exclusions; this aligns the rest

## What I ran locally
- Verified justfile syntax is valid
- Verified the \	est\ recipe matches CI Quick script exclusions

## CI truth: CI Quick on this PR
## Determinism impact: none
## Taxonomy impact: none
## Perf impact: none
## Docs touched: none
## What remains: none
## Recommended disposition: MERGE