### PR TITLE
fix: remove dead_code in ReportSectionFile (audit.rs)

### DIFF
--- a/crates/copybook-cli/src/commands/audit.rs
+++ b/crates/copybook-cli/src/commands/audit.rs
@@ -687,9 +687,6 @@ struct HealthEventRecord {
 #[derive(Deserialize)]
 struct ReportSectionFile {
     #[serde(default)]
-    #[allow(dead_code)]
-    audit_report: Option<Value>,
-    #[serde(default)]
     compliance_validation: Option<Value>,
     #[serde(default)]
     lineage_analysis: Option<Value>,
@@ -697,9 +694,6 @@ struct ReportSectionFile {
     performance_audit: Option<Value>,
     #[serde(default)]
     security_audit: Option<Value>,
-    #[serde(default)]
-    #[allow(dead_code)]
-    audit_health: Option<Value>,
 }
 
 fn parse_health_events(path: &Path) -> AuditResult<(Vec<HealthEventRecord>, Vec<String>)> {


### PR DESCRIPTION
## What changed
Removed unused \udit_report\ and \udit_health\ fields from \ReportSectionFile\ struct in \udit.rs\. These fields were deserialized but never read, requiring \#[allow(dead_code)]\ suppressions.

Since the struct doesn't use \serde(deny_unknown_fields)\, removing these fields is backward-compatible — extra JSON keys are silently ignored by serde.

## What I ran locally
\\\
cargo clippy -p copybook-cli -- -D warnings -W clippy::pedantic  # 0 warnings
\\\

## CI truth: CI Quick on this PR
## Determinism impact: none
## Taxonomy impact: none
## Perf impact: none
## Docs touched: none
## What remains: none
## Recommended disposition: MERGE