### PR TITLE
fix: add dbg_macro lint to workspace-wide clippy config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,6 +178,9 @@ unreachable = "warn"
 todo = "warn"
 unimplemented = "warn"
 
+# Debug cruft prevention (no dbg! in shipped code; tests are allowed via CI)
+dbg_macro = "warn"
+
 # Performance lints
 missing_inline_in_public_items = "warn"
 cast_lossless = "allow"


### PR DESCRIPTION
## What changed
Added `clippy::dbg_macro = "warn"` to workspace lints in Cargo.toml.

This prevents accidental `dbg!()` calls from shipping in production code. Test code is already allowed via the CI clippy relaxation (`-A clippy::dbg_macro` in `scripts/ci/quick.sh`).

No violations exist in the codebase — this is a preventive lint only.

## What I ran locally
- `cargo clippy --workspace --lib --bins --examples --all-features -- -D warnings -W clippy::pedantic` — 0 warnings
- `cargo clippy --workspace --tests --all-features -- -D warnings (with test relaxations)` — 0 warnings

## CI truth
CI Quick on this PR

## Determinism impact: none
## Taxonomy impact: none
## Perf impact: none
## Docs touched: none
## What remains: none
## Recommended disposition: MERGE
