### PR TITLE
fix: harden security.sh SHA validation logic

### DIFF
--- a/scripts/ci/security.sh
+++ b/scripts/ci/security.sh
@@ -14,14 +14,16 @@ echo "==> Running cargo deny check"
 "$CARGO_BIN" deny check
 
 # cargo-audit is networky: run only when Cargo.lock changes or on schedule
-DIFF_OK=true
-git diff --name-only "${BASE_SHA:-}"..."${HEAD_SHA:-}" >/dev/null 2>&1 || DIFF_OK=false
-if $DIFF_OK && git diff --name-only "${BASE_SHA}"..."${HEAD_SHA}" | grep -q '^Cargo\.lock$'; then
-  echo "==> Cargo.lock changed, running cargo audit"
-  "$CARGO_BIN" install --locked cargo-audit >/dev/null 2>&1 || true
-  "$CARGO_BIN" audit
+if [[ -n "${BASE_SHA:-}" && -n "${HEAD_SHA:-}" ]]; then
+  if git diff --name-only "${BASE_SHA}...${HEAD_SHA}" 2>/dev/null | grep -q '^Cargo\.lock$'; then
+    echo "==> Cargo.lock changed, running cargo audit"
+    "$CARGO_BIN" install --locked cargo-audit >/dev/null 2>&1 || true
+    "$CARGO_BIN" audit
+  else
+    echo "==> Cargo.lock unchanged – skipping cargo-audit (policy)"
+  fi
 else
-  echo "==> No Cargo.lock diff (or base not available) – skipping cargo-audit (policy)"
+  echo "==> No base/head SHA available – skipping cargo-audit (policy)"
 fi
 
 echo "✅ Security gates passed"


### PR DESCRIPTION
## What changed
Replaced fragile DIFF_OK boolean pattern in security.sh with explicit empty-string
checks for BASE_SHA and HEAD_SHA before attempting git diff.

### Before
git diff with empty SHAs would fail, setting DIFF_OK=false, then the script would
silently skip cargo-audit with a generic message.

### After
Explicit null checks on BASE_SHA/HEAD_SHA with clear diagnostic messages for each case:
- Both SHAs present + Cargo.lock changed: run cargo-audit
- Both SHAs present + no Cargo.lock change: skip with clear reason
- Missing SHAs: skip with explicit explanation

## What I ran locally
Verified bash syntax with shellcheck-style review.

## CI truth: CI Quick on this PR
## Determinism impact: none
## Taxonomy impact: none
## Perf impact: none
## Docs touched: none
## What remains: none
## Recommended disposition: MERGE
