### PR TITLE
docs: update README test count — 15 ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ See [SECURITY.md](SECURITY.md) for security scanning infrastructure and vulnerab
 
 ### Current Reliability Snapshot
 <!-- TEST_STATUS:BEGIN -->
-- **Tests**: `cargo test --workspace` reports 10,000+ tests passing (9 ignored) with comprehensive coverage across COBOL parsing, data encoding, and CLI integration
+- **Tests**: `cargo test --workspace` reports 10,000+ tests passing (15 ignored) with comprehensive coverage across COBOL parsing, data encoding, and CLI integration
 - **CI Mode**: Full CI pipeline active (CI Quick PR gate + CI Full matrix). See [`docs/internal/state-and-path.md`](docs/internal/state-and-path.md) for current state.
 <!-- TEST_STATUS:END -->
 - **Benchmarks**: Performance validated with CI receipts and baseline tracking. See [BASELINE_METHODOLOGY.md](tools/copybook-bench/BASELINE_METHODOLOGY.md) for measurement procedures, [HARDWARE_SPECS.md](tools/copybook-bench/HARDWARE_SPECS.md) for reference hardware specifications, and `scripts/bench/perf.json` artifact for current measurements (policy: accuracy-first).


### PR DESCRIPTION
## What changed
Updated README test count: 9 ignored -> 15 ignored.

Verified with `cargo test --workspace` on main (commit 1d6cd4a): 10,109 passed, 0 failed, 15 ignored.

## What I ran locally
`cargo test --workspace` — 10,109 passed, 0 failed, 15 ignored

## CI truth: n/a (docs only)
## Determinism impact: none
## Taxonomy impact: none
## Perf impact: none
## Docs touched: README.md
## What remains: none
## Recommended disposition: MERGE
