### PR TITLE
fix: format e2e_cli_support.rs (cargo fmt)

### DIFF
--- a/tests/e2e/e2e_cli_support.rs
+++ b/tests/e2e/e2e_cli_support.rs
@@ -35,7 +35,10 @@ fn support_table_default() {
 
 #[test]
 fn support_json_format() {
-    let assert = cmd().args(["support", "--format", "json"]).assert().success();
+    let assert = cmd()
+        .args(["support", "--format", "json"])
+        .assert()
+        .success();
     let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
     // Should be valid JSON
     let parsed: serde_json::Value = serde_json::from_str(&stdout)


### PR DESCRIPTION
## What changed
Fix cargo fmt failure introduced by PR #348 (e2e_cli_support.rs).

A long chained method call on line 35 needs to be broken across multiple lines per rustfmt rules.

## CI truth: CI Quick on this PR
## Recommended disposition: MERGE
