### PR TITLE
fix: align justfile lint recipe with CI Quick

### DIFF
--- a/justfile
+++ b/justfile
@@ -67,6 +67,7 @@ lint:
       -A clippy::dbg_macro \
       -A clippy::print_stdout \
       -A clippy::print_stderr \
+      -A clippy::missing_inline_in_public_items \
       -A clippy::duplicated_attributes \
       -A deprecated
 


### PR DESCRIPTION
## What changed
Added `-A clippy::missing_inline_in_public_items` to the test clippy command
in the justfile `lint` recipe to match `scripts/ci/quick.sh` line 30.

Without this, `just lint` was stricter than CI Quick for test code, causing
false positives when running locally.

## CI truth: CI Quick on this PR
## Recommended disposition: MERGE
