### PR TITLE
fix: replace allow(dead_code) with cfg(test) in copybook-overpunch

### DIFF
--- a/crates/copybook-overpunch/src/lib.rs
+++ b/crates/copybook-overpunch/src/lib.rs
@@ -25,8 +25,7 @@ use copybook_codepage::Codepage;
 use copybook_error::{Error, ErrorCode, Result};
 use std::convert::TryFrom;
 
-// Visible in tests; harmless in non-test builds. Keep pedantic quiet.
-#[allow(dead_code)]
+#[cfg(test)]
 const DEFAULT_PROPTEST_CASE_COUNT: u32 = 512;
 
 /// Policy for the sign zone nibble when the numeric value is exactly zero.


### PR DESCRIPTION
## What changed
Replace `#[allow(dead_code)]` with `#[cfg(test)]` for `DEFAULT_PROPTEST_CASE_COUNT` in `copybook-overpunch`.

The constant is only used in test code (line 284), so gating it behind `#[cfg(test)]` is cleaner than suppressing the dead_code lint.

## What I ran locally
- `cargo clippy -p copybook-overpunch -- -D warnings -W clippy::pedantic` — ✅ clean
- `cargo test -p copybook-overpunch --no-fail-fast` — ✅ 141 passed

## CI truth: CI Quick on PR
## Determinism impact: none
## Taxonomy impact: none
## Docs touched: none
## Recommended disposition: MERGE
