### PR TITLE
fix: add missing SPDX license headers to 7 source files

### DIFF
--- a/crates/copybook-core/src/lexer.rs
+++ b/crates/copybook-core/src/lexer.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::must_use_candidate)]
-
+// SPDX-License-Identifier: AGPL-3.0-or-later
 //! COBOL copybook lexer shim.
 //!
 //! The tokenizer implementation now lives in `copybook-lexer`. This module

--- a/crates/copybook-governance-contracts/src/lib.rs
+++ b/crates/copybook-governance-contracts/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
-
+// SPDX-License-Identifier: AGPL-3.0-or-later
 //! Contract façade for governance interoperability.
 //!
 //! This crate keeps the cross-cutting governance contract imports small and stable

--- a/crates/copybook-governance-grid/src/governance_grid.rs
+++ b/crates/copybook-governance-grid/src/governance_grid.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 //! Governance grid linking COBOL support-matrix entries to feature flags.
 //!
 //! The grid is intentionally explicit so changes in parser capability, runtime feature flags,

--- a/crates/copybook-governance-grid/src/lib.rs
+++ b/crates/copybook-governance-grid/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
-
+// SPDX-License-Identifier: AGPL-3.0-or-later
 //! Governance feature mapping contracts for copybook-rs.
 //!
 //! This crate provides a stable interoperability surface that maps documented COBOL

--- a/crates/copybook-governance-runtime/src/lib.rs
+++ b/crates/copybook-governance-runtime/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
-
+// SPDX-License-Identifier: AGPL-3.0-or-later
 //! Runtime governance evaluation for copybook-rs feature controls.
 //!
 //! This crate turns static governance mappings into runtime state by evaluating

--- a/crates/copybook-governance/src/lib.rs
+++ b/crates/copybook-governance/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
-
+// SPDX-License-Identifier: AGPL-3.0-or-later
 //! Governance contracts and runtime interoperability for copybook-rs feature controls.
 //!
 //! This crate is the canonical compatibility façade for:

--- a/crates/copybook-lexer/src/lib.rs
+++ b/crates/copybook-lexer/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 #![allow(clippy::must_use_candidate)]
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 //! COBOL lexer microcrate.
 //!


### PR DESCRIPTION
## What changed
Added missing `SPDX-License-Identifier: AGPL-3.0-or-later` header to 7 Rust source files in publishable crates:

- `copybook-core/src/lexer.rs`
- `copybook-governance/src/lib.rs`
- `copybook-governance-contracts/src/lib.rs`
- `copybook-governance-grid/src/lib.rs`
- `copybook-governance-grid/src/governance_grid.rs`
- `copybook-governance-runtime/src/lib.rs`
- `copybook-lexer/src/lib.rs`

Per `LICENSE_SCOPE.md`, all source files should carry per-file SPDX headers (except `.claude/`, `.kiro/`, and similar tooling dirs).

## What I ran locally
- `cargo clippy -p copybook-core -p copybook-lexer -p copybook-governance -p copybook-governance-contracts -p copybook-governance-grid -p copybook-governance-runtime -- -D warnings -W clippy::pedantic` — ✅ clean

## CI truth: CI Quick on PR
## Determinism impact: none
## Taxonomy impact: none
## Docs touched: none
## Recommended disposition: MERGE
