### PR TITLE
fix: remove unnecessary duplicate skip entries in deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -68,9 +68,6 @@ deny = [
 # Certain crates/versions that will be skipped when doing duplicate detection
 skip = [
     { name = "windows-sys", reason = "transitive, multiple versions unavoidable" },
-    { name = "windows-targets", reason = "transitive, multiple versions unavoidable" },
-    { name = "windows_x86_64_gnu", reason = "transitive, multiple versions unavoidable" },
-    { name = "windows_x86_64_msvc", reason = "transitive, multiple versions unavoidable" },
 ]
 # Similarly to `skip` allows you to skip certain crates from being checked
 skip-tree = []


### PR DESCRIPTION
## What changed
Remove 3 unnecessary duplicate-skip entries from `deny.toml`:
- `windows_x86_64_msvc`
- `windows-targets`
- `windows_x86_64_gnu`

These crates now have only one version in the dependency tree, so the skip entries
were producing `warning[unnecessary-skip]` diagnostics. Only `windows-sys` remains
(still has multiple transitive versions).

## What I ran locally
- `cargo deny check` — ✅ advisories ok, bans ok, licenses ok, sources ok
- No more `unnecessary-skip` warnings

## CI truth: CI Quick on PR
## Determinism impact: none
## Taxonomy impact: none
## Docs touched: none
## Recommended disposition: MERGE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency analysis configuration to enable duplicate detection for three crates previously excluded from the analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->