### PR TITLE
docs: add doc comments for 10 undocumented pub mod declarations

### DIFF
--- a/crates/copybook-arrow/src/lib.rs
+++ b/crates/copybook-arrow/src/lib.rs
@@ -5,16 +5,24 @@
 //! Converts COBOL binary data directly to Apache Arrow columnar format,
 //! preserving COBOL type precision (Decimal128 for COMP-3/Zoned, proper int widths, etc.)
 
+/// Columnar `RecordBatch` construction from decoded COBOL records.
 pub mod batch_builder;
+/// Per-column accumulator trait and typed column builders.
 pub mod builders;
+/// Direct binary → Arrow decoding (bypasses JSON intermediate).
 pub mod decode_direct;
+/// Arrow IPC (Feather) file writer.
 pub mod ipc;
+/// Arrow/Parquet output configuration (compression, edited-PIC handling).
 pub mod options;
+/// Apache Parquet file writer with configurable compression.
 pub mod parquet_writer;
+/// COBOL schema → Arrow schema conversion (type mapping).
 pub mod schema_convert;
+/// Streaming record-by-record Arrow output for large files.
 pub mod streaming;
 
-// Legacy API (deprecated)
+/// Legacy JSONL-to-Arrow API (deprecated; prefer `decode_direct`).
 #[allow(deprecated)]
 pub mod legacy;
 

--- a/crates/copybook-contracts/src/lib.rs
+++ b/crates/copybook-contracts/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! Shared contracts for feature-flag governance.
 
+/// Feature flag definitions, lifecycle states, and governance builder.
 pub mod feature_flags;
 
 pub use feature_flags::{


### PR DESCRIPTION
## Summary

Add missing doc comments to all public module declarations in copybook-arrow (9) and copybook-contracts (1).

### Changes
- **copybook-arrow/src/lib.rs**: Doc comments for batch_builder, builders, decode_direct, ipc, options, parquet_writer, schema_convert, streaming, legacy
- **copybook-contracts/src/lib.rs**: Doc comment for feature_flags

### Receipt
- **What changed**: 2 files, doc comments only
- **Local validation**: \cargo doc -p copybook-arrow -p copybook-contracts --no-deps\ with RUSTDOCFLAGS='-D warnings' — zero warnings
- **Determinism impact**: None
- **Taxonomy impact**: None
- **Perf impact**: None
- **Docs touched**: Intra-crate rustdoc only