### PR TITLE
ci: add doc link validation to PR quick gate

### DIFF
--- a/scripts/ci/quick.sh
+++ b/scripts/ci/quick.sh
@@ -49,4 +49,8 @@ bash scripts/ci/governance-bdd-smoke.sh
 echo "==> Running doc tests"
 RUSTDOCFLAGS="--deny warnings" "$CARGO_BIN" test --doc --workspace --exclude copybook-bench
 
+# Doc link validation (catch broken intra-doc links)
+echo "==> Checking doc links"
+RUSTDOCFLAGS="-D warnings" "$CARGO_BIN" doc --workspace --no-deps
+
 echo "✅ Quick gates passed"


### PR DESCRIPTION
## What changed

Added `cargo doc --workspace --no-deps` with `RUSTDOCFLAGS="-D warnings"` to `scripts/ci/quick.sh`.

## Why

Previously, `quick.sh` only ran `cargo test --doc` (doc-tests), which validates code examples but does **not** check intra-doc link resolution. This is how PR #361's 14 broken intra-doc links in `numeric.rs` slipped through the PR gate undetected.

The full CI workflow (`ci.yml`) already had a Documentation job with `RUSTDOCFLAGS: -D warnings`, but that runs on the broader matrix, not the PR quick gate.

## What was validated

- `cargo doc --workspace --no-deps` with warnings-as-errors passes locally (0 warnings)
- Does not duplicate the existing doc-test step (different purpose: link checking vs code example validation)
- Adds ~30s to the quick gate

## Receipt

- **What changed**: Added doc link validation step to `scripts/ci/quick.sh`
- **Commands run locally**: doc build with warnings-as-errors: clean
- **CI jobs as truth**: CI Quick on this PR
- **Determinism impact**: None
- **Taxonomy impact**: None
- **Perf impact**: N/A
- **Docs touched**: None (CI script only)
- **Risks**: Adds ~30s to PR gate; worth it to prevent broken-link regressions
- **Disposition**: MERGE
