### PR TITLE
Extract CLI panic/stdio safety logic into new copybook-safe-io microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,6 +822,7 @@ dependencies = [
  "copybook-codec",
  "copybook-core",
  "copybook-governance",
+ "copybook-safe-io",
  "md5",
  "metrics",
  "metrics-exporter-prometheus",
@@ -1199,6 +1200,10 @@ dependencies = [
  "copybook-error",
  "proptest",
 ]
+
+[[package]]
+name = "copybook-safe-io"
+version = "0.4.3"
 
 [[package]]
 name = "copybook-safe-ops"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "crates/copybook-rdw-predicates",
     "crates/copybook-safe-index",
     "crates/copybook-safe-text",
+    "crates/copybook-safe-io",
     "crates/copybook-cli",
     "crates/copybook-cli-determinism",
     "crates/copybook-governance",
@@ -75,6 +76,7 @@ copybook-overpunch = { version = "=0.4.3", path = "crates/copybook-overpunch" }
 copybook-determinism = { version = "=0.4.3", path = "crates/copybook-determinism" }
 copybook-safe-ops = { version = "=0.4.3", path = "crates/copybook-safe-ops" }
 copybook-safe-text = { version = "=0.4.3", path = "crates/copybook-safe-text" }
+copybook-safe-io = { version = "=0.4.3", path = "crates/copybook-safe-io" }
 copybook-safe-index = { version = "=0.4.3", path = "crates/copybook-safe-index" }
 copybook-rdw-predicates = { version = "=0.4.3", path = "crates/copybook-rdw-predicates" }
 copybook-codepage = { version = "=0.4.3", path = "crates/copybook-codepage" }

--- a/crates/copybook-cli/Cargo.toml
+++ b/crates/copybook-cli/Cargo.toml
@@ -41,6 +41,7 @@ anyhow.workspace = true
 copybook-core = { workspace = true }
 copybook-codec = { workspace = true }
 copybook-governance = { workspace = true }
+copybook-safe-io = { workspace = true }
 copybook-arrow = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 metrics = { workspace = true, optional = true }

--- a/crates/copybook-cli/src/main.rs
+++ b/crates/copybook-cli/src/main.rs
@@ -13,10 +13,12 @@ use copybook_codec::{
     Codepage, FloatFormat, JsonNumberMode, RawMode, RecordFormat, UnmappablePolicy,
 };
 use copybook_core::{Error as CoreError, Feature, FeatureCategory, FeatureFlags};
-use std::borrow::Cow;
+use copybook_safe_io::{
+    extract_panic_message, is_consumer_closed, panic_caused_by_std_pipe, write_all_ignoring_closed,
+};
 use std::convert::TryFrom;
 use std::error::Error as StdError;
-use std::io::{self, ErrorKind, Write};
+use std::io::{self, Write};
 use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode as ProcessExitCode;
@@ -1475,41 +1477,6 @@ fn env_flag(name: &str) -> bool {
     })
 }
 
-fn panic_caused_by_std_pipe(panic_payload: &dyn std::any::Any) -> bool {
-    let message = if let Some(&msg) = panic_payload.downcast_ref::<&str>() {
-        msg
-    } else if let Some(msg) = panic_payload.downcast_ref::<String>() {
-        msg.as_str()
-    } else {
-        return false;
-    };
-
-    let lower = message.to_ascii_lowercase();
-    let is_std_stream =
-        lower.contains("failed printing to stdout") || lower.contains("failed printing to stderr");
-    if !is_std_stream {
-        return false;
-    }
-
-    let is_broken_pipe = lower.contains("broken pipe")
-        || lower.contains("os error 32")
-        || lower.contains("error_broken_pipe")
-        || lower.contains("error_no_data");
-    let is_write_zero = lower.contains("write zero") || lower.contains("writezero");
-
-    is_broken_pipe || is_write_zero
-}
-
-fn extract_panic_message(panic_payload: &dyn std::any::Any) -> Cow<'_, str> {
-    if let Some(&msg) = panic_payload.downcast_ref::<&str>() {
-        return Cow::Borrowed(msg);
-    }
-    if let Some(msg) = panic_payload.downcast_ref::<String>() {
-        return Cow::Borrowed(msg.as_str());
-    }
-    Cow::Borrowed("unknown panic")
-}
-
 #[cfg(feature = "audit")]
 pub(crate) fn write_stdout_line(line: &str) -> Result<(), io::Error> {
     let mut buffer = String::with_capacity(line.len() + 1);
@@ -1528,27 +1495,12 @@ pub(crate) fn write_stderr_line(line: &str) -> Result<(), io::Error> {
 
 pub(crate) fn write_stdout_all(bytes: &[u8]) -> Result<(), io::Error> {
     let mut stdout = io::stdout().lock();
-    match stdout.write_all(bytes) {
-        Ok(()) => Ok(()),
-        Err(err) if is_consumer_closed(&err) => Ok(()),
-        Err(err) => Err(err),
-    }
+    write_all_ignoring_closed(&mut stdout, bytes)
 }
 
 pub(crate) fn write_stderr_all(bytes: &[u8]) -> Result<(), io::Error> {
     let mut stderr = io::stderr().lock();
-    match stderr.write_all(bytes) {
-        Ok(()) => Ok(()),
-        Err(err) if is_consumer_closed(&err) => Ok(()),
-        Err(err) => Err(err),
-    }
-}
-
-#[inline]
-fn is_consumer_closed(err: &io::Error) -> bool {
-    matches!(err.kind(), ErrorKind::BrokenPipe | ErrorKind::WriteZero)
-        || err.raw_os_error() == Some(109)
-        || err.raw_os_error() == Some(232)
+    write_all_ignoring_closed(&mut stderr, bytes)
 }
 
 mod commands {

--- a/crates/copybook-safe-io/Cargo.toml
+++ b/crates/copybook-safe-io/Cargo.toml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+[package]
+name = "copybook-safe-io"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Panic-safe stdio and panic-payload helpers for CLI and tooling surfaces."
+documentation = "https://docs.rs/copybook-safe-io"
+readme = "README.md"
+keywords = ["cli", "io", "panic", "safety"]
+categories = ["command-line-utilities"]
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/copybook-safe-io/README.md
+++ b/crates/copybook-safe-io/README.md
@@ -1,0 +1,8 @@
+# copybook-safe-io
+
+Single-responsibility microcrate for panic-safe stdio writes and panic payload classification.
+
+This crate centralizes:
+- consumer-closed detection for stdout/stderr writes (`BrokenPipe`, `WriteZero`, Windows pipe closures)
+- panic payload extraction into displayable text
+- panic classification for stdio pipeline shutdowns

--- a/crates/copybook-safe-io/src/lib.rs
+++ b/crates/copybook-safe-io/src/lib.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Panic-safe stdio helpers.
+
+use std::any::Any;
+use std::borrow::Cow;
+use std::io::{self, ErrorKind, Write};
+
+/// Return true when an `io::Error` indicates the downstream consumer closed.
+#[must_use]
+pub fn is_consumer_closed(err: &io::Error) -> bool {
+    matches!(err.kind(), ErrorKind::BrokenPipe | ErrorKind::WriteZero)
+        || err.raw_os_error() == Some(109)
+        || err.raw_os_error() == Some(232)
+}
+
+/// Write bytes while treating consumer-close conditions as success.
+pub fn write_all_ignoring_closed<W: Write>(writer: &mut W, bytes: &[u8]) -> io::Result<()> {
+    match writer.write_all(bytes) {
+        Ok(()) => Ok(()),
+        Err(err) if is_consumer_closed(&err) => Ok(()),
+        Err(err) => Err(err),
+    }
+}
+
+/// Return true when the panic payload indicates stdout/stderr pipeline shutdown.
+#[must_use]
+pub fn panic_caused_by_std_pipe(panic_payload: &dyn Any) -> bool {
+    let message = if let Some(&msg) = panic_payload.downcast_ref::<&str>() {
+        msg
+    } else if let Some(msg) = panic_payload.downcast_ref::<String>() {
+        msg.as_str()
+    } else {
+        return false;
+    };
+
+    let lower = message.to_ascii_lowercase();
+    let is_std_stream =
+        lower.contains("failed printing to stdout") || lower.contains("failed printing to stderr");
+    if !is_std_stream {
+        return false;
+    }
+
+    let is_broken_pipe = lower.contains("broken pipe")
+        || lower.contains("os error 32")
+        || lower.contains("error_broken_pipe")
+        || lower.contains("error_no_data");
+    let is_write_zero = lower.contains("write zero") || lower.contains("writezero");
+
+    is_broken_pipe || is_write_zero
+}
+
+/// Extract a panic payload as a user-displayable string.
+#[must_use]
+pub fn extract_panic_message(panic_payload: &dyn Any) -> Cow<'_, str> {
+    if let Some(&msg) = panic_payload.downcast_ref::<&str>() {
+        return Cow::Borrowed(msg);
+    }
+    if let Some(msg) = panic_payload.downcast_ref::<String>() {
+        return Cow::Borrowed(msg.as_str());
+    }
+    Cow::Borrowed("unknown panic")
+}

--- a/crates/copybook-safe-io/tests/safe_io_contract.rs
+++ b/crates/copybook-safe-io/tests/safe_io_contract.rs
@@ -1,0 +1,40 @@
+use copybook_safe_io::{extract_panic_message, panic_caused_by_std_pipe};
+
+#[test]
+fn detects_broken_pipe_stdout_panic_message() {
+    let payload = "thread panicked: failed printing to stdout: Broken pipe (os error 32)";
+    assert!(panic_caused_by_std_pipe(&payload));
+}
+
+#[test]
+fn ignores_non_stdio_panic_messages() {
+    let payload = "something else failed";
+    assert!(!panic_caused_by_std_pipe(&payload));
+}
+
+#[test]
+fn extracts_string_payloads() {
+    let payload = String::from("boom");
+    assert_eq!(extract_panic_message(&payload), "boom");
+}
+
+use std::io::{self, Write};
+
+struct BrokenPipeWriter;
+
+impl Write for BrokenPipeWriter {
+    fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+        Err(io::Error::new(io::ErrorKind::BrokenPipe, "broken"))
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn write_all_ignoring_closed_swallows_broken_pipe() {
+    let mut writer = BrokenPipeWriter;
+    let result = copybook_safe_io::write_all_ignoring_closed(&mut writer, b"data");
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
### Motivation
- Centralize panic-payload extraction and stdio consumer-closed detection so CLI-specific code no longer owns low-level IO safety logic.
- Provide a single-responsibility microcrate for reuse by other binaries and to simplify `copybook-cli` internals.

### Description
- Added a new crate `crates/copybook-safe-io` that exposes `is_consumer_closed`, `write_all_ignoring_closed`, `panic_caused_by_std_pipe`, and `extract_panic_message`.
- Replaced the duplicate in-file helpers in `crates/copybook-cli/src/main.rs` with imports from `copybook-safe-io` and delegated `write_stdout_all`/`write_stderr_all` to `write_all_ignoring_closed`.
- Wired the new crate into the workspace `Cargo.toml` and `crates/copybook-cli/Cargo.toml`, and updated `Cargo.lock` to reflect the addition.
- Added contract tests in `crates/copybook-safe-io/tests/safe_io_contract.rs` covering panic classification, message extraction, and broken-pipe swallowing.

### Testing
- Ran `cargo test -p copybook-safe-io` and all tests passed (4 passed).
- Ran `cargo test -p copybook-cli --test broken_pipe` and the broken-pipe tests passed (2 passed).
- Ran `cargo fmt` to normalize formatting before committing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a97d0577f0833396b4884408d800e1)