### PR TITLE
feat(facade): add copybook-rs umbrella crate and copybook alias

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -50,7 +50,11 @@ jobs:
           copybook-codepage \
           copybook-contracts \
           copybook-support-matrix \
-          copybook-sequence-ring; do
+          copybook-sequence-ring \
+          copybook-corruption-predicates \
+          copybook-rdw-predicates \
+          copybook-zoned-format \
+          copybook-lexer; do
           echo "Testing ${crate}..."
           cargo publish -p "${crate}" --dry-run
           echo "  ${crate} dry-run successful"
@@ -58,7 +62,7 @@ jobs:
 
     - name: Package manifest check (all publishable crates)
       run: |
-        echo "=== Package manifest check for all 25 publishable crates ==="
+        echo "=== Package manifest check for all 38 publishable crates ==="
 
         # All publishable crates in dependency order
         for crate in \
@@ -69,24 +73,37 @@ jobs:
           copybook-contracts \
           copybook-support-matrix \
           copybook-sequence-ring \
+          copybook-corruption-predicates \
+          copybook-rdw-predicates \
+          copybook-zoned-format \
+          copybook-lexer \
           copybook-overflow \
           copybook-error-reporter \
           copybook-charset \
           copybook-governance-contracts \
           copybook-codec-memory \
           copybook-overpunch \
-          copybook-utils \
+          copybook-safe-index \
+          copybook-safe-text \
           copybook-governance-grid \
           copybook-options \
+          copybook-safe-ops \
           copybook-governance-runtime \
+          copybook-utils \
           copybook-core \
           copybook-governance \
           copybook-fixed \
           copybook-rdw \
+          copybook-corruption-detectors \
+          copybook-corruption-rdw \
           copybook-record-io \
+          copybook-corruption \
           copybook-codec \
           copybook-arrow \
-          copybook-cli; do
+          copybook-cli-determinism \
+          copybook-rs \
+          copybook-cli \
+          copybook; do
           echo "Checking ${crate}..."
           cargo package -p "${crate}" --list > /dev/null
           echo "  ${crate} package file list OK"
@@ -97,18 +114,24 @@ jobs:
       run: |
         echo "Publish preflight checks passed!"
         echo ""
-        echo "Validated 25 publishable crates:"
-        echo "  Level 0 (7): copybook-error, copybook-determinism, copybook-dialect,"
-        echo "               copybook-codepage, copybook-contracts, copybook-support-matrix,"
-        echo "               copybook-sequence-ring"
-        echo "  Level 1 (6): copybook-overflow, copybook-error-reporter, copybook-charset,"
-        echo "               copybook-governance-contracts, copybook-codec-memory, copybook-overpunch"
-        echo "  Level 2 (3): copybook-utils, copybook-governance-grid, copybook-options"
-        echo "  Level 3 (2): copybook-governance-runtime, copybook-core"
-        echo "  Level 4 (3): copybook-governance, copybook-fixed, copybook-rdw"
-        echo "  Level 5 (1): copybook-record-io"
-        echo "  Level 6 (1): copybook-codec"
-        echo "  Level 7 (2): copybook-arrow, copybook-cli"
+        echo "Validated 38 publishable crates:"
+        echo "  Level 0 (11): copybook-error, copybook-determinism, copybook-dialect,"
+        echo "                copybook-codepage, copybook-contracts, copybook-support-matrix,"
+        echo "                copybook-sequence-ring, copybook-corruption-predicates,"
+        echo "                copybook-rdw-predicates, copybook-zoned-format, copybook-lexer"
+        echo "  Level 1 (8): copybook-overflow, copybook-error-reporter, copybook-charset,"
+        echo "               copybook-governance-contracts, copybook-codec-memory, copybook-overpunch,"
+        echo "               copybook-safe-index, copybook-safe-text"
+        echo "  Level 2 (3): copybook-governance-grid, copybook-options, copybook-safe-ops"
+        echo "  Level 3 (2): copybook-governance-runtime, copybook-utils"
+        echo "  Level 4 (2): copybook-core, copybook-governance"
+        echo "  Level 5 (4): copybook-fixed, copybook-rdw, copybook-corruption-detectors,"
+        echo "               copybook-corruption-rdw"
+        echo "  Level 6 (2): copybook-record-io, copybook-corruption"
+        echo "  Level 7 (1): copybook-codec"
+        echo "  Level 8 (2): copybook-arrow, copybook-cli-determinism"
+        echo "  Level 9 (2): copybook-rs, copybook-cli"
+        echo "  Level 10 (1): copybook"
         echo ""
         echo "Downstream publish dry-runs are run just-in-time in .github/workflows/publish.yml"
         echo "after upstream crates exist on crates.io."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -258,12 +258,18 @@ jobs:
         publish_crate copybook-cli-determinism
         wait_for_index 60
 
-        # Level 9: Depends on Level 0-8 (1 crate)
-        echo "=== Level 9: CLI ==="
+        # Level 9: Depends on Level 0-8 (2 crates)
+        echo "=== Level 9: Facade + CLI ==="
+        publish_crate copybook-rs
         publish_crate copybook-cli
+        wait_for_index 60
+
+        # Level 10: Depends on Level 9 (1 crate)
+        echo "=== Level 10: Alias facade ==="
+        publish_crate copybook
 
         echo ""
-        echo "All 36 publishable crates published successfully!"
+        echo "All 38 publishable crates published successfully!"
 
     - name: Create GitHub Release
       env:
@@ -283,7 +289,7 @@ jobs:
         cargo install copybook-cli@${version}
         \`\`\`
 
-        **Published Crates (36):**
+        **Published Crates (38):**
 
         | Crate | crates.io | docs.rs |
         |-------|-----------|---------|
@@ -322,7 +328,9 @@ jobs:
         | copybook-codec | [${version}](https://crates.io/crates/copybook-codec/${version}) | [docs](https://docs.rs/copybook-codec/${version}) |
         | copybook-arrow | [${version}](https://crates.io/crates/copybook-arrow/${version}) | [docs](https://docs.rs/copybook-arrow/${version}) |
         | copybook-cli-determinism | [${version}](https://crates.io/crates/copybook-cli-determinism/${version}) | [docs](https://docs.rs/copybook-cli-determinism/${version}) |
+        | copybook-rs | [${version}](https://crates.io/crates/copybook-rs/${version}) | [docs](https://docs.rs/copybook-rs/${version}) |
         | copybook-cli | [${version}](https://crates.io/crates/copybook-cli/${version}) | [docs](https://docs.rs/copybook-cli/${version}) |
+        | copybook | [${version}](https://crates.io/crates/copybook/${version}) | [docs](https://docs.rs/copybook/${version}) |
 
         See [CHANGELOG.md](${repo_url}/blob/${tag}/CHANGELOG.md) for details.
         EOF
@@ -378,7 +386,7 @@ jobs:
         sleep 300
 
         # Check if docs are available (docs.rs builds asynchronously)
-        for crate in copybook-core copybook-codec copybook-arrow copybook-cli; do
+        for crate in copybook-core copybook-codec copybook-arrow copybook-rs copybook copybook-cli; do
           url="https://docs.rs/${crate}/${VERSION}"
           echo "Docs will be available at: ${url}"
         done
@@ -404,10 +412,14 @@ jobs:
         echo "   https://docs.rs/copybook-core/${VERSION}"
         echo "   https://docs.rs/copybook-codec/${VERSION}"
         echo "   https://docs.rs/copybook-arrow/${VERSION}"
+        echo "   https://docs.rs/copybook-rs/${VERSION}"
+        echo "   https://docs.rs/copybook/${VERSION}"
         echo "   https://docs.rs/copybook-cli/${VERSION}"
         echo ""
         echo "Crates.io:"
         echo "   https://crates.io/crates/copybook-core"
         echo "   https://crates.io/crates/copybook-codec"
         echo "   https://crates.io/crates/copybook-arrow"
+        echo "   https://crates.io/crates/copybook-rs"
+        echo "   https://crates.io/crates/copybook"
         echo "   https://crates.io/crates/copybook-cli"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **audit**: Implement `Display` for `AuditEventType` and `AuditSeverity` enums
 - **audit**: Add additional Clippy lint enforcement to audit module
 - **feature-flags**: Promote COMP-1/COMP-2 and SIGN SEPARATE features to stable
+- **facade**: Add published `copybook-rs` umbrella crate and `copybook` alias crate
 - **test**: Add e2e tests for `support` CLI subcommand (8 tests covering table/JSON/filter/governance)
 - **test**: Add e2e tests for `inspect` CLI flags (8 tests: codepage, strict, strict-comments, stdin)
 - **test**: Add e2e tests for `--strict-comments` and `--emit-filler` flags (6 tests)
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **core**: Refactor `PicToken` methods for clarity and consistency
 - **codec**: Improve JSON writer functionality
+- **docs**: Promote facade crates as the default Rust entrypoint while preserving granular `copybook-core` / `copybook-codec` packages
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,6 +738,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "copybook"
+version = "0.4.3"
+dependencies = [
+ "copybook-rs",
+]
+
+[[package]]
 name = "copybook-arrow"
 version = "0.4.3"
 dependencies = [
@@ -1190,6 +1197,15 @@ dependencies = [
  "copybook-options",
  "copybook-rdw",
  "proptest",
+]
+
+[[package]]
+name = "copybook-rs"
+version = "0.4.3"
+dependencies = [
+ "copybook-arrow",
+ "copybook-codec",
+ "copybook-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ members = [
     "crates/copybook-corruption-predicates",
     "crates/copybook-dialect",
     "crates/copybook-codec",
+    "crates/copybook-rs",
+    "crates/copybook",
     "crates/copybook-codec-memory",
     "crates/copybook-sequence-ring",
     "crates/copybook-safe-ops",
@@ -89,6 +91,8 @@ copybook-corruption-rdw = { version = "=0.4.3", path = "crates/copybook-corrupti
 copybook-corruption-predicates = { version = "=0.4.3", path = "crates/copybook-corruption-predicates" }
 copybook-dialect = { version = "=0.4.3", path = "crates/copybook-dialect" }
 copybook-codec = { version = "=0.4.3", path = "crates/copybook-codec" }
+copybook-rs = { version = "=0.4.3", path = "crates/copybook-rs" }
+copybook = { version = "=0.4.3", path = "crates/copybook" }
 copybook-codec-memory = { version = "=0.4.3", path = "crates/copybook-codec-memory" }
 copybook-cli-determinism = { version = "=0.4.3", path = "crates/copybook-cli-determinism" }
 copybook-sequence-ring = { version = "=0.4.3", path = "crates/copybook-sequence-ring" }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Rust toolkit for COBOL copybook parsing and fixed-record data conversion. Determ
 
 Engineering Preview (v0.4.3). Stable CLI and library APIs; feature completeness is preview-level. See [ROADMAP.md](docs/ROADMAP.md) for adoption guidance and known limitations.
 
+## Rust Library Crates
+
+- `copybook-rs`: canonical umbrella facade crate; import it as `copybook_rs`
+- `copybook`: short alias package with the same facade API
+- `copybook-core` + `copybook-codec`: granular crates for teams that want tighter dependency boundaries
+
 ## Try It Now
 
 The repo includes test fixtures. After building, run this to see it work:
@@ -71,6 +77,9 @@ See [COBOL_SUPPORT_MATRIX.md](docs/reference/COBOL_SUPPORT_MATRIX.md) for the fu
 | [Stability Guarantees](docs/STABILITY_GUARANTEES.md) | API stability contract and versioning policy |
 | [Support Policy](docs/SUPPORT_POLICY.md) | Release support windows and response times |
 | [Roadmap](docs/ROADMAP.md) | Project status and what's next |
+
+Library users can start with either `copybook-rs` or `copybook` and drop down to
+`copybook-core` / `copybook-codec` only when they want the more granular split.
 
 ## Exit Codes
 

--- a/crates/copybook-rs/Cargo.toml
+++ b/crates/copybook-rs/Cargo.toml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+[package]
+name = "copybook-rs"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Umbrella facade crate for COBOL copybook parsing and deterministic fixed-record conversion."
+documentation = "https://docs.rs/copybook-rs"
+readme = "README.md"
+keywords = ["cobol", "copybook", "mainframe", "ebcdic", "etl"]
+categories = ["encoding", "parsing", "data-structures"]
+
+include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE"]
+
+[package.metadata.docs.rs]
+all-features = false
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+copybook-core.workspace = true
+copybook-codec.workspace = true
+copybook-arrow = { workspace = true, optional = true }
+
+[features]
+default = []
+arrow = ["dep:copybook-arrow"]
+audit = ["copybook-core/audit", "copybook-codec/audit"]
+metrics = ["copybook-codec/metrics"]
+comprehensive-tests = ["copybook-core/comprehensive-tests", "copybook-codec/comprehensive-tests"]
+
+[lints]
+workspace = true

--- a/crates/copybook-rs/LICENSE
+++ b/crates/copybook-rs/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/crates/copybook-rs/README.md
+++ b/crates/copybook-rs/README.md
@@ -1,0 +1,38 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# copybook-rs
+
+Umbrella facade crate for the copybook-rs library surface.
+
+`copybook-rs` is imported as `copybook_rs` in Rust code and re-exports the
+public APIs from `copybook-core` and `copybook-codec` behind a single
+dependency.
+
+## Quick start
+
+```toml
+[dependencies]
+copybook-rs = "0.4.3"
+```
+
+```rust
+use copybook_rs::{Codepage, DecodeOptions, JsonNumberMode, RecordFormat, decode_record, parse_copybook};
+
+let schema = parse_copybook("01 REC.\n   05 FLAG PIC X(1).\n")?;
+let options = DecodeOptions::new()
+    .with_codepage(Codepage::ASCII)
+    .with_format(RecordFormat::Fixed)
+    .with_json_number_mode(JsonNumberMode::Lossless);
+
+let json = decode_record(&schema, b"A", &options)?;
+assert_eq!(json["FLAG"], "A");
+```
+
+## What it re-exports
+
+- `copybook-core` at the crate root and under `copybook_rs::core`
+- `copybook-codec` at the crate root and under `copybook_rs::codec`
+- `copybook-arrow` under `copybook_rs::arrow` when the `arrow` feature is enabled
+
+## License
+
+Licensed under **AGPL-3.0-or-later**.

--- a/crates/copybook-rs/src/lib.rs
+++ b/crates/copybook-rs/src/lib.rs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Umbrella facade for the copybook-rs library surface.
+//!
+//! Add `copybook-rs` to `Cargo.toml` and import it as `copybook_rs` in Rust code.
+//! This crate re-exports `copybook-core` and `copybook-codec` so consumers can
+//! start with a single dependency and still opt into the granular crates later.
+//!
+//! # Example
+//!
+//! ```rust
+//! use copybook_rs::{
+//!     Codepage, DecodeOptions, JsonNumberMode, RecordFormat, decode_record, parse_copybook,
+//! };
+//!
+//! let schema = parse_copybook("01 REC.\n   05 FLAG PIC X(1).\n")?;
+//! let options = DecodeOptions::new()
+//!     .with_codepage(Codepage::ASCII)
+//!     .with_format(RecordFormat::Fixed)
+//!     .with_json_number_mode(JsonNumberMode::Lossless);
+//!
+//! let json = decode_record(&schema, b"A", &options)?;
+//! assert_eq!(json["FLAG"], "A");
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+
+/// Namespaced re-export of the parsing and schema layer.
+pub mod core {
+    pub use copybook_core::*;
+}
+
+/// Namespaced re-export of the decode/encode layer.
+pub mod codec {
+    pub use copybook_codec::*;
+}
+
+/// Optional namespaced re-export of the Arrow and Parquet integration crate.
+#[cfg(feature = "arrow")]
+pub mod arrow {
+    pub use copybook_arrow::*;
+}
+
+pub use copybook_codec::*;
+pub use copybook_core::*;

--- a/crates/copybook-rs/tests/facade_api.rs
+++ b/crates/copybook-rs/tests/facade_api.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use copybook_rs::{
+    Codepage, DecodeOptions, JsonNumberMode, RecordFormat, decode_record, parse_copybook,
+};
+
+#[test]
+fn facade_reexports_core_and_codec_at_crate_root() {
+    let schema = parse_copybook("01 REC.\n   05 FLAG PIC X(1).\n").expect("schema should parse");
+    let options = DecodeOptions::new()
+        .with_codepage(Codepage::ASCII)
+        .with_format(RecordFormat::Fixed)
+        .with_json_number_mode(JsonNumberMode::Lossless);
+
+    let json = decode_record(&schema, b"A", &options).expect("decode should succeed");
+    assert_eq!(json["FLAG"], "A");
+}
+
+#[test]
+fn facade_keeps_namespaced_modules_available() {
+    let schema = copybook_rs::core::parse_copybook("01 REC.\n   05 FLAG PIC X(1).\n")
+        .expect("schema should parse");
+    let options = copybook_rs::codec::DecodeOptions::new()
+        .with_codepage(copybook_rs::codec::Codepage::ASCII)
+        .with_format(copybook_rs::codec::RecordFormat::Fixed);
+
+    let json =
+        copybook_rs::codec::decode_record(&schema, b"B", &options).expect("decode should succeed");
+    assert_eq!(json["FLAG"], "B");
+}

--- a/crates/copybook/Cargo.toml
+++ b/crates/copybook/Cargo.toml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+[package]
+name = "copybook"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Short alias facade for the copybook-rs umbrella crate."
+documentation = "https://docs.rs/copybook"
+readme = "README.md"
+keywords = ["cobol", "copybook", "mainframe", "ebcdic", "etl"]
+categories = ["encoding", "parsing", "data-structures"]
+
+include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE"]
+
+[package.metadata.docs.rs]
+all-features = false
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+copybook-rs.workspace = true
+
+[features]
+default = []
+arrow = ["copybook-rs/arrow"]
+audit = ["copybook-rs/audit"]
+metrics = ["copybook-rs/metrics"]
+comprehensive-tests = ["copybook-rs/comprehensive-tests"]
+
+[lints]
+workspace = true

--- a/crates/copybook/LICENSE
+++ b/crates/copybook/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/crates/copybook/README.md
+++ b/crates/copybook/README.md
@@ -1,0 +1,30 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# copybook
+
+Short alias package for [`copybook-rs`](https://docs.rs/copybook-rs).
+
+Use this crate if you want the umbrella facade with the shorter import path
+`copybook::...` instead of `copybook_rs::...`.
+
+## Quick start
+
+```toml
+[dependencies]
+copybook = "0.4.3"
+```
+
+```rust
+use copybook::{Codepage, DecodeOptions, RecordFormat, decode_record, parse_copybook};
+
+let schema = parse_copybook("01 REC.\n   05 FLAG PIC X(1).\n")?;
+let options = DecodeOptions::new()
+    .with_codepage(Codepage::ASCII)
+    .with_format(RecordFormat::Fixed);
+
+let json = decode_record(&schema, b"A", &options)?;
+assert_eq!(json["FLAG"], "A");
+```
+
+## License
+
+Licensed under **AGPL-3.0-or-later**.

--- a/crates/copybook/src/lib.rs
+++ b/crates/copybook/src/lib.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Short alias facade for [`copybook-rs`](https://docs.rs/copybook-rs).
+//!
+//! This crate re-exports the exact same public API as `copybook-rs`, but with
+//! the shorter `copybook` import path.
+
+pub use copybook_rs::*;

--- a/crates/copybook/tests/alias_api.rs
+++ b/crates/copybook/tests/alias_api.rs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use copybook::{Codepage, DecodeOptions, RecordFormat, decode_record, parse_copybook};
+
+#[test]
+fn alias_package_reexports_facade_api() {
+    let schema = parse_copybook("01 REC.\n   05 FLAG PIC X(1).\n").expect("schema should parse");
+    let options = DecodeOptions::new()
+        .with_codepage(Codepage::ASCII)
+        .with_format(RecordFormat::Fixed);
+
+    let json = decode_record(&schema, b"Z", &options).expect("decode should succeed");
+    assert_eq!(json["FLAG"], "Z");
+}

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -20,9 +20,11 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-copybook-arrow = { version = "0.4.2" }
-copybook-codec = { version = "0.4.2" }
-copybook-core = { version = "0.4.2" }
+copybook-rs = { version = "0.4.3", features = ["arrow"] }
+# or keep the granular split:
+# copybook-arrow = { version = "0.4.3" }
+# copybook-codec = { version = "0.4.3" }
+# copybook-core = { version = "0.4.3" }
 ```
 
 ### Basic Usage
@@ -30,9 +32,8 @@ copybook-core = { version = "0.4.2" }
 #### Decode to Arrow
 
 ```rust
-use copybook_arrow::{json_to_record_batch, json_to_schema, ArrowWriter};
-use copybook_codec::{DecodeOptions, RecordFormat, Codepage, JsonNumberMode, UnmappablePolicy};
-use copybook_core::parse_copybook;
+use copybook_rs::arrow::{ArrowWriter, json_to_record_batch, json_to_schema};
+use copybook_rs::{Codepage, DecodeOptions, JsonNumberMode, RecordFormat, parse_copybook};
 
 // Parse copybook
 let copybook = r#"
@@ -49,7 +50,7 @@ let options = DecodeOptions::new()
     .with_codepage(Codepage::CP037)
     .with_json_number_mode(JsonNumberMode::Lossless);
 
-let json_value = copybook_codec::decode_record(&schema, binary_data, &options)?;
+let json_value = copybook_rs::decode_record(&schema, binary_data, &options)?;
 
 // Convert to Arrow
 let arrow_schema = json_to_schema(&json_value)?;
@@ -61,7 +62,7 @@ writer.add_batch(batch);
 #### Write to Parquet
 
 ```rust
-use copybook_arrow::{json_to_schema, ParquetFileWriter};
+use copybook_rs::arrow::{ParquetFileWriter, json_to_schema};
 use parquet::file::properties::{Compression, WriterProperties};
 
 // Create Arrow schema

--- a/docs/API_FREEZE.md
+++ b/docs/API_FREEZE.md
@@ -18,6 +18,8 @@ API freeze is a development phase where:
 ## Public API Scope
 
 The following crates have frozen public APIs:
+- **copybook-rs**: Umbrella facade crate
+- **copybook**: Short alias facade crate
 - **copybook-core**: Core parsing and schema types
 - **copybook-codec**: Encoding and decoding codecs
 - **copybook-cli**: Command-line interface (binary crate)
@@ -220,6 +222,8 @@ cargo semver-checks check-release \
 
 5. **Publish**:
    ```bash
+   cargo publish -p copybook-rs
+   cargo publish -p copybook
    cargo publish -p copybook-core
    cargo publish -p copybook-codec
    ```

--- a/docs/BDD_TESTING.md
+++ b/docs/BDD_TESTING.md
@@ -304,7 +304,7 @@ Check CI logs for detailed errors. The quick lane and the dedicated `bdd-tests` 
 - [Gherkin Syntax](https://cucumber.io/docs/gherkin/)
 - [BDD Best Practices](https://cucumber.io/docs/bdd/)
 - [copybook-rs BDD README](../tests/bdd/README.md)
-- [copybook-rs Documentation](https://docs.rs/copybook-core)
+- [copybook-rs Documentation](https://docs.rs/copybook-rs)
 ## License
 
 Licensed under **AGPL-3.0-or-later**. See [LICENSE](LICENSE).

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -833,8 +833,7 @@ copybook verify \
 #### Programmatic Verification
 
 ```rust
-use copybook_codec::{decode_file_to_jsonl, DecodeOptions};
-use copybook_core::parse_copybook;
+use copybook_rs::{decode_file_to_jsonl, DecodeOptions, parse_copybook};
 
 fn verify_determinism(
     copybook: &str,
@@ -848,7 +847,9 @@ fn verify_determinism(
 
     for i in 0..runs {
         let output = format!("output_{}.jsonl", i);
-        decode_file_to_jsonl(&schema, input, std::path::Path::new(&output), &options)?;
+        let input_file = std::fs::File::open(input)?;
+        let output_file = std::fs::File::create(&output)?;
+        decode_file_to_jsonl(&schema, input_file, output_file, &options)?;
 
         let content = std::fs::read_to_string(&output)?;
         results.push(content);

--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -82,7 +82,7 @@ copybook parse --feature-flags-config /path/to/config.toml
 Feature flags can be controlled programmatically:
 
 ```rust
-use copybook_core::{Feature, FeatureFlags, FeatureFlagsHandle};
+use copybook_rs::{Feature, FeatureFlags, FeatureFlagsHandle};
 
 // Get global feature flags
 let flags = FeatureFlags::global();
@@ -291,7 +291,7 @@ Stage 3: Full rollout (remove flag once stable)
 ### Example 4: Library Integration
 
 ```rust
-use copybook_core::{Feature, FeatureFlags};
+use copybook_rs::{Feature, FeatureFlags, Result, Schema, parse_copybook};
 
 fn process_copybook(text: &str) -> Result<Schema> {
     let flags = FeatureFlags::global();
@@ -338,7 +338,7 @@ If tests fail with feature flags:
 ## Related Documentation
 
 - [CLI Reference](CLI_REFERENCE.md) - Complete CLI command reference
-- [Library API](https://docs.rs/copybook-core) - Rust library documentation
+- [Library API](https://docs.rs/copybook-rs) - Rust library documentation
 - [ROADMAP](ROADMAP.md) - Project roadmap and feature status
 - [CONTRIBUTING](CONTRIBUTING.md) - Contribution guidelines
 

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -230,23 +230,20 @@ copybook decode customer.cpy data.bin \
 
 **After (copybook-rs Rust API):**
 ```rust
-use copybook_core::parse_copybook;
-use copybook_codec::{RecordDecoder, DecodeOptions, Codepage};
+use copybook_rs::{Codepage, DecodeOptions, JsonNumberMode, RecordFormat, decode_file_to_jsonl, parse_copybook};
 
 let copybook_text = std::fs::read_to_string("customer.cpy")?;
 let schema = parse_copybook(&copybook_text)?;
 
-let opts = DecodeOptions {
-    codepage: Codepage::Cp037,
-    strict: true,
-    ..Default::default()
-};
+let opts = DecodeOptions::new()
+    .with_codepage(Codepage::CP037)
+    .with_format(RecordFormat::Fixed)
+    .with_json_number_mode(JsonNumberMode::Lossless)
+    .with_strict_mode(true);
 
-let mut decoder = RecordDecoder::new(&schema, &opts)?;
-for record_result in decoder.decode_file("data.bin")? {
-    let json = record_result?;
-    println!("{}", serde_json::to_string(&json)?);
-}
+let input = std::fs::File::open("data.bin")?;
+let output = std::fs::File::create("data.jsonl")?;
+decode_file_to_jsonl(&schema, input, output, &opts)?;
 ```
 
 ## Migration from Python Tools
@@ -469,21 +466,16 @@ copybook encode customer.cpy transformed.jsonl \
 
 ```rust
 // Rust streaming integration
-use copybook_codec::RecordDecoder;
-use tokio::io::{AsyncBufReadExt, BufReader};
+use copybook_rs::{DecodeOptions, RecordFormat, iter_records_from_file};
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut decoder = RecordDecoder::new(&schema, &opts)?;
-    let file = tokio::fs::File::open("data.bin").await?;
-    let reader = BufReader::new(file);
-    
-    let mut lines = reader.lines();
-    while let Some(line) = lines.next_line().await? {
-        let json = decoder.decode_record(line.as_bytes())?;
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let opts = DecodeOptions::new().with_format(RecordFormat::Fixed);
+
+    for record in iter_records_from_file("data.bin", &schema, &opts)? {
+        let json = record?;
         // Process record
     }
-    
+
     Ok(())
 }
 ```

--- a/docs/PROPERTY_TESTING.md
+++ b/docs/PROPERTY_TESTING.md
@@ -169,8 +169,7 @@ These tests verify REDEFINES clause handling:
 #![allow(clippy::expect_used)]
 #![allow(clippy::unwrap_used)]
 
-use copybook_core::parse_copybook;
-use copybook_codec::{Codepage, DecodeOptions, EncodeOptions, RecordFormat};
+use copybook_rs::{Codepage, DecodeOptions, EncodeOptions, RecordFormat, parse_copybook};
 use proptest::prelude::*;
 
 proptest! {

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -217,8 +217,10 @@ If you see version mismatch errors, ensure all workspace crates use exact versio
 
 ```toml
 # In Cargo.toml workspace.dependencies
-copybook-core = { version = "=0.4.2", path = "copybook-core" }
-copybook-codec = { version = "=0.4.2", path = "copybook-codec" }
+copybook-core = { version = "=0.4.3", path = "crates/copybook-core" }
+copybook-codec = { version = "=0.4.3", path = "crates/copybook-codec" }
+copybook-rs = { version = "=0.4.3", path = "crates/copybook-rs" }
+copybook = { version = "=0.4.3", path = "crates/copybook" }
 ```
 
 ## Manual Changelog Update

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -144,11 +144,11 @@ copybook-rs automatically detects zoned decimal encoding by analyzing digit zone
 ### Library API Usage
 
 ```rust
-use copybook_codec::{DecodeOptions, EncodeOptions, ZonedEncodingFormat};
+use copybook_rs::{Codepage, DecodeOptions, EncodeOptions, ZonedEncodingFormat, decode_record, encode_record};
 
 // Configure decode with encoding preservation
 let decode_opts = DecodeOptions::new()
-    .with_codepage(Codepage::Cp037)
+    .with_codepage(Codepage::CP037)
     .with_preserve_zoned_encoding(true) // Enable format detection
     .with_preferred_zoned_encoding(ZonedEncodingFormat::Ebcdic); // Fallback
 
@@ -158,7 +158,7 @@ let json_value = decode_record(&schema, &record_data, &decode_opts)?;
 
 // Configure encode to respect preserved formats
 let encode_opts = EncodeOptions::new()
-    .with_codepage(Codepage::Cp037)
+    .with_codepage(Codepage::CP037)
     .with_zoned_encoding_override(None); // Use preserved formats
 
 // Encode with original format preservation
@@ -259,13 +259,12 @@ diff original.bin roundtrip.bin  # Should be identical
 
 ### Library API for Custom Applications
 ```rust
-use copybook_core::parse_copybook;
-use copybook_codec::{decode_file_to_jsonl, DecodeOptions, Codepage};
+use copybook_rs::{Codepage, DecodeOptions, JsonNumberMode, decode_file_to_jsonl, parse_copybook};
 
 // Production-ready processing
 let schema = parse_copybook(&copybook_text)?;
 let opts = DecodeOptions::new()
-    .with_codepage(Codepage::Cp037)
+    .with_codepage(Codepage::CP037)
     .with_json_number_mode(JsonNumberMode::Lossless);
 
 let summary = decode_file_to_jsonl(&schema, input, output, &opts)?;

--- a/docs/how-to/error-handling-production.md
+++ b/docs/how-to/error-handling-production.md
@@ -25,9 +25,9 @@ copybook-rs provides structured error codes in four main categories:
 **Solution**: Implement comprehensive parse error handling:
 
 ```rust
-use copybook_core::{parse_copybook, Error, ErrorCode};
+use copybook_rs::{Error, ErrorCode, parse_copybook};
 
-fn load_schema_safely(copybook_path: &str) -> Result<copybook_core::Schema, ProcessingError> {
+fn load_schema_safely(copybook_path: &str) -> Result<copybook_rs::Schema, ProcessingError> {
     let copybook_text = std::fs::read_to_string(copybook_path)
         .map_err(|e| ProcessingError::FileAccess {
             path: copybook_path.to_string(),
@@ -38,7 +38,7 @@ fn load_schema_safely(copybook_path: &str) -> Result<copybook_core::Schema, Proc
         Ok(schema) => {
             tracing::info!(
                 fields = %schema.fields.len(),
-                fixed_length = ?schema.fixed_record_length,
+                fixed_length = ?schema.lrecl_fixed,
                 "Schema loaded successfully"
             );
             Ok(schema)
@@ -131,10 +131,10 @@ enum ProcessingError {
 **Solution**: Implement graceful data error recovery:
 
 ```rust
-use copybook_codec::{decode_record, DecodeOptions, Error as CodecError};
+use copybook_rs::{DecodeOptions, ErrorCode, decode_record};
 
 fn process_record_safely(
-    schema: &copybook_core::Schema,
+    schema: &copybook_rs::Schema,
     record_data: &[u8],
     options: &DecodeOptions,
     record_number: u64,
@@ -144,57 +144,33 @@ fn process_record_safely(
             RecordResult::Success(json_value)
         }
         Err(error) => {
-            match &error {
-                CodecError::DataError { code, message, field_path, .. } => {
-                    tracing::warn!(
-                        record_number = %record_number,
-                        error_code = ?code,
-                        field_path = ?field_path,
-                        message = %message,
-                        "Data validation error - record skipped"
-                    );
+            tracing::warn!(
+                record_number = %record_number,
+                error_code = ?error.code,
+                field_path = ?error.context.as_ref().and_then(|ctx| ctx.field_path.as_ref()),
+                message = %error.message,
+                "Data validation error - record skipped"
+            );
 
-                    // Categorize data errors for different handling
-                    match code {
-                        copybook_codec::ErrorCode::CBKD101_INVALID_FIELD_TYPE => {
-                            RecordResult::DataError {
-                                record_number,
-                                field: field_path.clone().unwrap_or_default(),
-                                issue: "Invalid field type".to_string(),
-                                action: "Record skipped - verify data format".to_string(),
-                            }
-                        }
-
-                        copybook_codec::ErrorCode::CBKD201_TRUNCATED_RECORD => {
-                            RecordResult::DataError {
-                                record_number,
-                                field: "record_length".to_string(),
-                                issue: "Record truncated".to_string(),
-                                action: "Record skipped - check file integrity".to_string(),
-                            }
-                        }
-
-                        _ => RecordResult::DataError {
-                            record_number,
-                            field: field_path.clone().unwrap_or_default(),
-                            issue: message.clone(),
-                            action: "Record skipped".to_string(),
-                        }
-                    }
-                }
-
-                _ => {
-                    tracing::error!(
-                        record_number = %record_number,
-                        error = %error,
-                        "Unexpected decode error"
-                    );
-
-                    RecordResult::UnexpectedError {
-                        record_number,
-                        error: error.to_string(),
-                    }
-                }
+            match error.code {
+                ErrorCode::CBKD101_INVALID_FIELD_TYPE => RecordResult::DataError {
+                    record_number,
+                    field: error.context.as_ref().and_then(|ctx| ctx.field_path.clone()).unwrap_or_default(),
+                    issue: "Invalid field type".to_string(),
+                    action: "Record skipped - verify data format".to_string(),
+                },
+                ErrorCode::CBKD201_TRUNCATED_RECORD => RecordResult::DataError {
+                    record_number,
+                    field: "record_length".to_string(),
+                    issue: "Record truncated".to_string(),
+                    action: "Record skipped - check file integrity".to_string(),
+                },
+                _ => RecordResult::DataError {
+                    record_number,
+                    field: error.context.as_ref().and_then(|ctx| ctx.field_path.clone()).unwrap_or_default(),
+                    issue: error.message.clone(),
+                    action: "Record skipped".to_string(),
+                },
             }
         }
     }
@@ -536,12 +512,11 @@ pub async fn process_production_batch(
     };
 
     // 3. Configure processing options
-    let options = copybook_codec::DecodeOptions::new()
-        .with_codepage(copybook_codec::Codepage::CP037)
-        .with_format(copybook_codec::RecordFormat::Fixed)
-        .with_json_number_mode(copybook_codec::JsonNumberMode::Lossless)
-        .with_emit_meta(true)
-        .with_validate_structure(true);
+    let options = copybook_rs::DecodeOptions::new()
+        .with_codepage(copybook_rs::Codepage::CP037)
+        .with_format(copybook_rs::RecordFormat::Fixed)
+        .with_json_number_mode(copybook_rs::JsonNumberMode::Lossless)
+        .with_emit_meta(true);
 
     // 4. Process files with error handling and monitoring
     let mut successful_files = 0;
@@ -562,8 +537,9 @@ pub async fn process_production_batch(
 
         // Process file with timeout and monitoring
         let result = resource_monitor.process_with_timeout(|| {
+            let input = std::fs::File::open(input_file)?;
             let output = std::fs::File::create(&output_file)?;
-            copybook_codec::decode_file_to_jsonl(&schema, input_file, output, &options)
+            copybook_rs::decode_file_to_jsonl(&schema, input, output, &options)
                 .map_err(|e| e.into())
         });
 

--- a/docs/how-to/performance-optimization.md
+++ b/docs/how-to/performance-optimization.md
@@ -172,14 +172,13 @@ impl WorkloadProfile {
     pub fn get_optimized_options(&self) -> DecodeOptions {
         let mut options = DecodeOptions::new()
             .with_codepage(copybook_codec::Codepage::CP037)
-            .with_format(copybook_codec::RecordFormat::Fixed)
-            .with_validate_structure(true); // Always enable validation for safety
+            .with_format(copybook_codec::RecordFormat::Fixed);
 
         match self.optimization_strategy {
             OptimizationStrategy::DisplayOptimized => {
                 // Optimize for high-speed string processing
                 options = options
-                    .with_json_number_mode(copybook_codec::JsonNumberMode::Number) // Faster for DISPLAY
+                    .with_json_number_mode(copybook_codec::JsonNumberMode::Native) // Faster for DISPLAY
                     .with_emit_meta(false); // Reduce output size
 
                 tracing::info!(
@@ -716,7 +715,7 @@ pub fn validate_enterprise_performance(
     tracing::info!("Starting enterprise performance validation");
 
     let display_options = DecodeOptions::new()
-        .with_json_number_mode(copybook_codec::JsonNumberMode::Number)
+        .with_json_number_mode(copybook_codec::JsonNumberMode::Native)
         .with_emit_meta(false);
 
     let comp3_options = DecodeOptions::new()

--- a/docs/reference/LIBRARY_API.md
+++ b/docs/reference/LIBRARY_API.md
@@ -20,20 +20,19 @@ Encoding and decoding logic for converting between binary data and structured va
 
 ## Quick Start
 
-Add copybook-rs to your `Cargo.toml`:
+Add either facade crate to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-copybook-core = "0.1"
-copybook-codec = "0.1"
+copybook-rs = "0.4.3"
+# or: copybook = "0.4.3"
 ```
 
 Basic usage:
 
 ```rust
-use copybook_core::parse_copybook;
-use copybook_codec::{decode_file_to_jsonl, DecodeOptions, Codepage, RecordFormat};
-use std::path::Path;
+use copybook_rs::{parse_copybook, decode_file_to_jsonl, DecodeOptions, Codepage, RecordFormat};
+use std::fs::File;
 
 // Parse copybook
 let copybook_text = std::fs::read_to_string("customer.cpy")?;
@@ -41,17 +40,22 @@ let schema = parse_copybook(&copybook_text)?;
 
 // Configure decode options
 let opts = DecodeOptions {
-    codepage: Codepage::Cp037,
+    codepage: Codepage::CP037,
     format: RecordFormat::Fixed,
     ..Default::default()
 };
 
 // Decode to JSONL
-let output = std::fs::File::create("output.jsonl")?;
-let summary = decode_file_to_jsonl(&schema, Path::new("data.bin"), &opts, output)?;
+let input = File::open("data.bin")?;
+let output = File::create("output.jsonl")?;
+let summary = decode_file_to_jsonl(&schema, input, output, &opts)?;
 ```
 
 ## Core Types
+
+The facade crates re-export the `copybook-core` and `copybook-codec` public API
+at the crate root. Granular packages remain available when you need to depend on
+only one layer.
 
 ### Schema
 
@@ -130,17 +134,19 @@ pub enum Occurs {
 
 ```rust
 pub struct DecodeOptions {
-    pub codepage: Codepage,
     pub format: RecordFormat,
-    pub strict: bool,
-    pub max_errors: Option<u32>,
+    pub codepage: Codepage,
+    pub json_number_mode: JsonNumberMode,
     pub emit_filler: bool,
     pub emit_meta: bool,
     pub emit_raw: RawMode,
-    pub json_number: JsonNumberMode,
+    pub strict_mode: bool,
+    pub max_errors: Option<u64>,
     pub on_decode_unmappable: UnmappablePolicy,
+    pub threads: usize,
     pub preserve_zoned_encoding: bool,
     pub preferred_zoned_encoding: ZonedEncodingFormat,
+    pub float_format: FloatFormat,
 }
 ```
 
@@ -153,14 +159,19 @@ pub struct DecodeOptions {
 
 ```rust
 pub struct EncodeOptions {
-    pub codepage: Codepage,
     pub format: RecordFormat,
-    pub strict: bool,
-    pub max_errors: Option<u32>,
+    pub codepage: Codepage,
+    pub preferred_zoned_encoding: ZonedEncodingFormat,
     pub use_raw: bool,
     pub bwz_encode: bool,
-    pub preferred_zoned_encoding: ZonedEncodingFormat,
+    pub strict_mode: bool,
+    pub max_errors: Option<u64>,
+    pub threads: usize,
+    pub coerce_numbers: bool,
+    pub on_encode_unmappable: UnmappablePolicy,
+    pub json_number_mode: JsonNumberMode,
     pub zoned_encoding_override: Option<ZonedEncodingFormat>,
+    pub float_format: FloatFormat,
 }
 ```
 
@@ -338,7 +349,7 @@ Parse a COBOL copybook into a schema with **panic-safe operations**.
 
 **Example:**
 ```rust
-use copybook_core::{parse_copybook, parse_copybook_with_options, ParseOptions};
+use copybook_rs::{ParseOptions, parse_copybook, parse_copybook_with_options};
 
 let copybook = r#"
 01 CUSTOMER-RECORD.
@@ -366,10 +377,10 @@ let schema_custom = parse_copybook_with_options(copybook, &parse_options)?;
 
 ### Enhanced Safe Operations Module
 
-The copybook-core crate provides comprehensive panic-safe operations in the `utils::safe_ops` module:
+The facade re-exports the panic-safe operations in the `utils::safe_ops` module:
 
 ```rust
-use copybook_core::utils::safe_ops;
+use copybook_rs::utils::safe_ops;
 
 // Safe integer conversions with overflow checking
 let safe_u32 = safe_ops::safe_u64_to_u32(large_value, "field offset calculation")?;
@@ -402,14 +413,13 @@ safe_ops::safe_write_str(&mut json_buffer, ",\n")?;
 copybook-rs provides enterprise-grade encoding/decoding with comprehensive panic-safe operations:
 
 ```rust
-use copybook_codec::{decode_record_with_scratch, memory::ScratchBuffers};
+use copybook_rs::{decode_record_with_scratch, iter_records_from_file, memory::ScratchBuffers};
 
 // High-performance decoding with scratch buffer optimization
 let mut scratch = ScratchBuffers::new();
 let json_value = decode_record_with_scratch(&schema, &record_data, &options, &mut scratch)?;
 
 // Panic-safe iteration over large files
-use copybook_codec::iter_records_from_file;
 let iterator = iter_records_from_file("data.bin", &schema, &options)?;
 
 for (record_num, record_result) in iterator.enumerate() {
@@ -452,9 +462,9 @@ Decode an entire file to JSONL format with **enterprise reliability**.
 
 **Parameters:**
 - `schema` - Parsed copybook schema
-- `data_path` - Path to binary data file
-- `opts` - Decode configuration options
-- `output` - Writer for JSONL output
+- `input` - Any `Read` implementation containing binary records
+- `output` - Any `Write` implementation that receives JSONL output
+- `options` - Decode configuration options
 
 **Returns:**
 - `Ok(RunSummary)` - Processing statistics
@@ -462,8 +472,10 @@ Decode an entire file to JSONL format with **enterprise reliability**.
 
 **Example:**
 ```rust
+use std::fs::File;
+
 let opts = DecodeOptions {
-    codepage: Codepage::Cp037,
+    codepage: Codepage::CP037,
     format: RecordFormat::Fixed,
     emit_meta: true,
     preserve_zoned_encoding: true, // Enable encoding preservation
@@ -471,8 +483,9 @@ let opts = DecodeOptions {
     ..Default::default()
 };
 
-let output = std::fs::File::create("output.jsonl")?;
-let summary = decode_file_to_jsonl(&schema, Path::new("data.bin"), &opts, output)?;
+let input = File::open("data.bin")?;
+let output = File::create("output.jsonl")?;
+let summary = decode_file_to_jsonl(&schema, input, output, &opts)?;
 
 println!("Processed {} records with {} errors",
          summary.records_processed, summary.records_with_errors);
@@ -480,11 +493,11 @@ println!("Processed {} records with {} errors",
 
 ### Telemetry & Metrics (opt-in)
 
-Enable the `metrics` cargo feature on `copybook-codec` when you want the decoder to emit counters and gauges that can be scraped by any [`metrics`](https://crates.io/crates/metrics) compatible recorder:
+Enable the `metrics` cargo feature on `copybook-rs` when you want the decoder to emit counters and gauges that can be scraped by any [`metrics`](https://crates.io/crates/metrics) compatible recorder:
 
 ```toml
 [dependencies]
-copybook-codec = { version = "0.3", features = ["metrics"] }
+copybook-rs = { version = "0.4.3", features = ["metrics"] }
 ```
 
 The CLI forwards the same feature:
@@ -514,9 +527,9 @@ Even without the feature, the library emits an `INFO` log with target `copybook:
 ```rust
 pub fn encode_jsonl_to_file(
     schema: &Schema,
-    jsonl_path: &Path,
-    opts: &EncodeOptions,
-    out_path: &Path,
+    input: impl Read,
+    output: impl Write,
+    options: &EncodeOptions,
 ) -> Result<RunSummary, Error>
 ```
 
@@ -524,9 +537,9 @@ Encode JSONL data to binary format.
 
 **Parameters:**
 - `schema` - Parsed copybook schema
-- `jsonl_path` - Path to JSONL input file
-- `opts` - Encode configuration options
-- `out_path` - Path for binary output file
+- `input` - Any `Read` implementation that yields JSONL input
+- `output` - Any `Write` implementation that receives encoded binary records
+- `options` - Encode configuration options
 
 **Returns:**
 - `Ok(RunSummary)` - Processing statistics
@@ -534,8 +547,10 @@ Encode JSONL data to binary format.
 
 **Example:**
 ```rust
+use std::fs::File;
+
 let opts = EncodeOptions {
-    codepage: Codepage::Cp037,
+    codepage: Codepage::CP037,
     format: RecordFormat::Fixed,
     use_raw: true,
     zoned_encoding_override: None, // Respect preserved formats
@@ -544,52 +559,51 @@ let opts = EncodeOptions {
 
 // Or with explicit format override:
 let opts_override = EncodeOptions {
-    codepage: Codepage::Cp037,
+    codepage: Codepage::CP037,
     format: RecordFormat::Fixed,
     zoned_encoding_override: Some(ZonedEncodingFormat::Ascii), // Force ASCII zones
     ..Default::default()
 };
 
+let input = File::open("input.jsonl")?;
+let output = File::create("output.bin")?;
 let summary = encode_jsonl_to_file(
     &schema,
-    Path::new("input.jsonl"),
+    input,
+    output,
     &opts,
-    Path::new("output.bin"),
 )?;
 ```
 
 ### Record-Level Processing
 
 ```rust
-pub struct RecordDecoder {
-    // Internal fields
+use copybook_rs::{
+    DecodeOptions, RecordIterator, RecordFormat, decode_record, decode_record_with_scratch,
+    iter_records_from_file, memory::ScratchBuffers,
+};
+use std::io::Cursor;
+
+let options = DecodeOptions::new().with_format(RecordFormat::Fixed);
+
+// Decode a single record directly
+let json_value = decode_record(&schema, b"HELLO", &options)?;
+
+// Reuse scratch buffers on hot paths
+let mut scratch = ScratchBuffers::new();
+let json_value = decode_record_with_scratch(&schema, b"WORLD", &options, &mut scratch)?;
+
+// Iterate records from any reader
+let iter = RecordIterator::new(Cursor::new(b"HELLOWORLD"), &schema, &options)?;
+for record in iter {
+    let json_value = record?;
+    println!("{json_value}");
 }
 
-impl RecordDecoder {
-    pub fn new(schema: &Schema, opts: &DecodeOptions) -> Result<Self, Error>;
-    
-    pub fn decode_record(&mut self, data: &[u8]) -> Result<serde_json::Value, Error>;
-    
-    pub fn decode_file<P: AsRef<Path>>(&mut self, path: P) -> Result<RecordIterator, Error>;
-}
-
-// Enhanced RecordIterator with truncated record detection
-pub struct RecordIterator<R: Read> {
-    // Internal fields
-}
-
-impl<R: Read> RecordIterator<R> {
-    /// Create new RecordIterator with enhanced validation
-    /// 
-    /// For fixed-format processing, requires schema.lrecl_fixed to be set
-    /// for proper truncated record detection.
-    pub fn new(reader: R, schema: &Schema, options: &DecodeOptions) -> Result<Self>;
-}
-
-impl<R: Read> Iterator for RecordIterator<R> {
-    type Item = Result<serde_json::Value, Error>;
-    
-    fn next(&mut self) -> Option<Self::Item>;
+// Or iterate directly from a file path
+for record in iter_records_from_file("data.bin", &schema, &options)? {
+    let json_value = record?;
+    println!("{json_value}");
 }
 ```
 
@@ -638,7 +652,7 @@ impl<W: Write> JsonWriter<W> {
 
 **Example:**
 ```rust
-use copybook_codec::{JsonWriter, DecodeOptions};
+use copybook_rs::{DecodeOptions, JsonWriter};
 use std::io::Cursor;
 
 // Create JsonWriter with schema access
@@ -659,24 +673,18 @@ let json_output = cursor.into_inner();
 ```
 
 ```rust
-let mut decoder = RecordDecoder::new(&schema, &opts)?;
+use copybook_rs::{RecordIterator, decode_record};
 
-// Decode single record
 let record_data = &[0x01, 0x02, 0x03, /* ... */];
-let json_value = decoder.decode_record(record_data)?;
+let json_value = decode_record(&schema, record_data, &opts)?;
 
-// Enhanced iterator with truncation detection
 let file = std::fs::File::open("data.bin")?;
-let mut iter = RecordIterator::new(file, &schema, &opts)?;
+let iter = RecordIterator::new(file, &schema, &opts)?;
 
 for record_result in iter {
     match record_result {
         Ok(json_value) => println!("{}", serde_json::to_string(&json_value)?),
-        Err(e) => {
-            // Enhanced error messages for truncated records:
-            // "Record 15 too short: expected 120 bytes, got 85 bytes"
-            eprintln!("Record error: {}", e);
-        }
+        Err(e) => eprintln!("Record error: {}", e),
     }
 }
 ```
@@ -750,15 +758,15 @@ pub struct ErrorContext {
 ### Panic-Safe Error Handling Patterns
 
 ```rust
-use copybook_core::{parse_copybook, Error, ErrorCode};
-use copybook_core::utils::{OptionExt, VecExt};
+use copybook_rs::{Error, ErrorCode, parse_copybook};
+use copybook_rs::utils::{OptionExt, VecExt};
 
 // Enhanced error handling with panic safety
 match parse_copybook(text) {
     Ok(schema) => {
         tracing::info!(
             fields = %schema.fields.len(),
-            fixed_length = ?schema.fixed_record_length,
+            fixed_length = ?schema.lrecl_fixed,
             "Schema parsed successfully with panic-safe operations"
         );
     },
@@ -801,7 +809,7 @@ match parse_copybook(text) {
 }
 
 // Using panic-safe extension traits
-use copybook_core::utils::{OptionExt, VecExt, SliceExt};
+use copybook_rs::utils::{OptionExt, SliceExt, VecExt};
 
 // Safe option unwrapping with structured errors
 let field = schema.fields
@@ -830,16 +838,17 @@ let token = tokens
 
 // Collect errors during processing
 let mut errors = Vec::new();
-let opts = DecodeOptions {
-    strict: false,
-    max_errors: Some(100),
-    ..Default::default()
-};
+let opts = DecodeOptions::new()
+    .with_strict_mode(false)
+    .with_max_errors(Some(100));
 
-match decode_file_to_jsonl(&schema, path, &opts, output) {
+let input = std::fs::File::open("data.bin")?;
+let output = std::fs::File::create("output.jsonl")?;
+
+match decode_file_to_jsonl(&schema, input, output, &opts) {
     Ok(summary) => {
-        if summary.error_count > 0 {
-            println!("Completed with {} errors", summary.error_count);
+        if summary.records_with_errors > 0 {
+            println!("Completed with {} record errors", summary.records_with_errors);
         }
     },
     Err(e) => {
@@ -1052,6 +1061,7 @@ if schema.fields.iter().any(|f| f.redefines_of.is_some()) {
 ### Parallel Processing
 
 ```rust
+use copybook_rs::decode_record;
 use std::sync::Arc;
 use std::thread;
 
@@ -1062,9 +1072,10 @@ let handles: Vec<_> = (0..num_threads).map(|i| {
     let schema = Arc::clone(&schema);
     let opts = Arc::clone(&opts);
     
-    thread::spawn(move || {
-        let mut decoder = RecordDecoder::new(&schema, &opts)?;
-        // Process chunk of data
+    thread::spawn(move || -> Result<(), copybook_rs::Error> {
+        for record_data in records_for_thread(i) {
+            let _json = decode_record(&schema, &record_data, &opts)?;
+        }
         Ok(())
     })
 }).collect();
@@ -1074,18 +1085,13 @@ for handle in handles {
 }
 ```
 
-### Custom Codepage Support
+### Codepage Selection
 
 ```rust
-// Extend with custom codepage (requires feature flag)
-#[cfg(feature = "custom-codepage")]
-use copybook_codec::CustomCodepage;
+use copybook_rs::{Codepage, DecodeOptions, EncodeOptions};
 
-let custom_cp = CustomCodepage::from_table(&conversion_table)?;
-let opts = DecodeOptions {
-    codepage: Codepage::Custom(custom_cp),
-    ..Default::default()
-};
+let decode_opts = DecodeOptions::new().with_codepage(Codepage::CP037);
+let encode_opts = EncodeOptions::new().with_codepage(Codepage::ASCII);
 ```
 
 ## Integration Examples
@@ -1147,10 +1153,8 @@ fn streaming_decode(
     let (output_tx, output_rx) = bounded(100);
     
     thread::spawn(move || {
-        let mut decoder = RecordDecoder::new(&schema, &opts).unwrap();
-        
         while let Ok(data) = input_rx.recv() {
-            match decoder.decode_record(&data) {
+            match decode_record(&schema, &data, &opts) {
                 Ok(json) => output_tx.send(json).unwrap(),
                 Err(e) => eprintln!("Decode error: {}", e),
             }
@@ -1167,14 +1171,16 @@ fn streaming_decode(
 
 ```rust
 // Reuse buffers for better performance
+use copybook_rs::{decode_record_with_scratch, memory::ScratchBuffers};
+
 let mut buffer = Vec::with_capacity(1024);
-let mut decoder = RecordDecoder::new(&schema, &opts)?;
+let mut scratch = ScratchBuffers::new();
 
 for record_data in record_iterator {
     buffer.clear();
     buffer.extend_from_slice(record_data);
     
-    let json_value = decoder.decode_record(&buffer)?;
+    let json_value = decode_record_with_scratch(&schema, &buffer, &opts, &mut scratch)?;
     // Process json_value
 }
 ```
@@ -1219,10 +1225,9 @@ mod tests {
         
         let schema = parse_copybook(copybook).unwrap();
         let opts = DecodeOptions::default().with_emit_meta(true);
-        let mut decoder = RecordDecoder::new(&schema, &opts).unwrap();
 
         let data = b"1234JOHN      ";
-        let json = decoder.decode_record(data).unwrap();
+        let json = decode_record(&schema, data, &opts).unwrap();
 
         assert_eq!(json["ID"], "1234");
         assert_eq!(json["NAME"], "JOHN      ");
@@ -1264,7 +1269,7 @@ copybook-rs provides comprehensive support for preserving zoned decimal encoding
 ### Core API
 
 ```rust
-use copybook_codec::{DecodeOptions, EncodeOptions, ZonedEncodingFormat};
+use copybook_rs::{Codepage, DecodeOptions, EncodeOptions, RecordFormat, ZonedEncodingFormat};
 
 // Configure encoding preservation during decode
 let decode_opts = DecodeOptions::new()
@@ -1298,7 +1303,7 @@ impl ZonedEncodingFormat {
 ```rust
 // Decode with encoding preservation
 let decode_opts = DecodeOptions::new()
-    .with_codepage(Codepage::Cp037)
+    .with_codepage(Codepage::CP037)
     .with_format(RecordFormat::Fixed)
     .with_preserve_zoned_encoding(true)
     .with_preferred_zoned_encoding(ZonedEncodingFormat::Ebcdic)
@@ -1306,7 +1311,7 @@ let decode_opts = DecodeOptions::new()
 
 // Encode with format override
 let encode_opts = EncodeOptions::new()
-    .with_codepage(Codepage::Cp037)
+    .with_codepage(Codepage::CP037)
     .with_format(RecordFormat::Fixed)
     .with_zoned_encoding_override(Some(ZonedEncodingFormat::Ascii));
 ```
@@ -1314,10 +1319,9 @@ let encode_opts = EncodeOptions::new()
 ### Round-Trip Example
 
 ```rust
-use copybook_core::parse_copybook;
-use copybook_codec::{
-    decode_record, encode_record, DecodeOptions, EncodeOptions,
-    ZonedEncodingFormat, Codepage, RecordFormat
+use copybook_rs::{
+    Codepage, DecodeOptions, EncodeOptions, RecordFormat, ZonedEncodingFormat, decode_record,
+    encode_record, parse_copybook,
 };
 
 // Parse schema
@@ -1336,7 +1340,7 @@ let original_data = &[
 
 // Step 1: Decode with encoding preservation
 let decode_opts = DecodeOptions::new()
-    .with_codepage(Codepage::Cp037)
+    .with_codepage(Codepage::CP037)
     .with_format(RecordFormat::Fixed)
     .with_preserve_zoned_encoding(true)
     .with_emit_meta(true);
@@ -1355,7 +1359,7 @@ let json_value = decode_record(&schema, original_data, &decode_opts)?;
 
 // Step 2: Encode preserving original format
 let encode_opts = EncodeOptions::new()
-    .with_codepage(Codepage::Cp037)
+    .with_codepage(Codepage::CP037)
     .with_format(RecordFormat::Fixed)
     .with_zoned_encoding_override(None); // Use preserved formats
 
@@ -1384,7 +1388,7 @@ let preserved_opts = EncodeOptions::new()
 ### Error Handling
 
 ```rust
-use copybook_core::{Error, ErrorCode};
+use copybook_rs::{Error, ErrorCode};
 
 match decode_record(&schema, &data, &opts) {
     Ok(json) => {
@@ -1454,12 +1458,10 @@ let customer_id = json["CUSTOMER_ID"].as_str().unwrap();
 // CobolDecoder decoder = new CobolDecoder(schema, "CP037", true);
 
 // copybook-rs equivalent
-let opts = DecodeOptions {
-    codepage: Codepage::Cp037,
-    strict: true,
-    ..Default::default()
-};
-let decoder = RecordDecoder::new(&schema, &opts)?;
+let opts = DecodeOptions::new()
+    .with_codepage(Codepage::CP037)
+    .with_strict_mode(true);
+let json = decode_record(&schema, data, &opts)?;
 ```
 
 ## API Stability

--- a/docs/tutorials/enterprise-deployment.md
+++ b/docs/tutorials/enterprise-deployment.md
@@ -37,9 +37,8 @@ Configure your build for enterprise deployment:
 ```toml
 # Cargo.toml for production deployment
 [dependencies]
-copybook-core = "0.1"
-copybook-codec = "0.1"
-copybook-cli = "0.1"
+copybook-rs = "0.4.3"
+copybook-cli = "0.4.3"
 
 # Production features
 tracing = "0.1"
@@ -73,8 +72,7 @@ cargo clippy --workspace -- -D warnings -W clippy::pedantic
 Implement comprehensive error handling for production monitoring:
 
 ```rust
-use copybook_core::{Error, ErrorCode};
-use copybook_codec::DecodeOptions;
+use copybook_rs::{DecodeOptions, Error, ErrorCode};
 use tracing::{error, warn, info, debug};
 use std::collections::HashMap;
 
@@ -178,8 +176,7 @@ pub enum ErrorSeverity {
 Design a robust enterprise processing pipeline:
 
 ```rust
-use copybook_core::parse_copybook;
-use copybook_codec::{DecodeOptions, Codepage, JsonNumberMode, RecordFormat};
+use copybook_rs::{Codepage, DecodeOptions, JsonNumberMode, RecordFormat, parse_copybook};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::fs;
@@ -187,7 +184,7 @@ use tracing::{info, error, instrument};
 
 /// Enterprise data processing pipeline with reliability features
 pub struct EnterpriseProcessor {
-    schema: Arc<copybook_core::Schema>,
+    schema: Arc<copybook_rs::Schema>,
     options: DecodeOptions,
     error_handler: EnterpriseErrorHandler,
 }
@@ -203,7 +200,7 @@ impl EnterpriseProcessor {
 
         info!(
             fields_count = %schema.fields.len(),
-            fixed_length = ?schema.fixed_record_length,
+            fixed_length = ?schema.lrecl_fixed,
             has_tail_odo = %schema.tail_odo.is_some(),
             "Schema loaded successfully"
         );
@@ -213,8 +210,7 @@ impl EnterpriseProcessor {
             .with_codepage(Codepage::CP037)
             .with_format(RecordFormat::Fixed)
             .with_json_number_mode(JsonNumberMode::Lossless)
-            .with_emit_meta(true)
-            .with_validate_structure(true);
+            .with_emit_meta(true);
 
         Ok(Self {
             schema: Arc::new(schema),
@@ -240,12 +236,13 @@ impl EnterpriseProcessor {
         let start_time = std::time::Instant::now();
 
         // Use high-performance file processing
+        let input_std = std::fs::File::open(input_path)?;
         let output_file = tokio::fs::File::create(output_path).await?;
         let output_std = output_file.into_std().await;
 
-        let summary = copybook_codec::decode_file_to_jsonl(
+        let summary = copybook_rs::decode_file_to_jsonl(
             &self.schema,
-            input_path,
+            input_std,
             output_std,
             &self.options,
         )?;
@@ -317,10 +314,11 @@ impl EnterpriseProcessor {
 
             let task = tokio::spawn(async move {
                 let _permit = permit;
+                let input_std = std::fs::File::open(&input_file)?;
 
-                let result = copybook_codec::decode_file_to_jsonl(
+                let result = copybook_rs::decode_file_to_jsonl(
                     &schema,
-                    &input_file,
+                    input_std,
                     std::fs::File::create(&output_file)?,
                     &options,
                 );

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -30,8 +30,8 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-copybook-core = { path = "../copybook-core" }
-copybook-codec = { path = "../copybook-codec" }
+copybook-rs = "0.4.3"
+# or: copybook = "0.4.3"
 ```
 
 ## Step 2: Your First COBOL Copybook
@@ -54,7 +54,7 @@ Create a simple COBOL copybook file `customer.cpy`:
 copybook-rs uses panic-safe operations throughout. Here's how to parse a copybook with proper error handling:
 
 ```rust
-use copybook_core::{parse_copybook, parse_copybook_with_options, ParseOptions};
+use copybook_rs::{parse_copybook, parse_copybook_with_options, ParseOptions};
 use std::fs;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -87,7 +87,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 copybook-rs provides comprehensive options for enterprise data processing:
 
 ```rust
-use copybook_codec::{DecodeOptions, Codepage, JsonNumberMode, RecordFormat};
+use copybook_rs::{Codepage, DecodeOptions, JsonNumberMode, RecordFormat};
 
 fn configure_decoder() -> DecodeOptions {
     DecodeOptions::new()
@@ -95,7 +95,6 @@ fn configure_decoder() -> DecodeOptions {
         .with_format(RecordFormat::Fixed)         // Fixed-length records
         .with_json_number_mode(JsonNumberMode::Lossless)  // Preserve precision
         .with_emit_meta(true)                     // Include metadata
-        .with_validate_structure(true)           // Enable validation
 }
 ```
 
@@ -110,13 +109,13 @@ fn configure_decoder() -> DecodeOptions {
 Process binary data with enterprise reliability:
 
 ```rust
-use copybook_codec::{decode_record, decode_record_with_scratch, memory::ScratchBuffers};
+use copybook_rs::{decode_record, decode_record_with_scratch, memory::ScratchBuffers};
 
 fn decode_customer_data(
-    schema: &copybook_core::Schema,
+    schema: &copybook_rs::Schema,
     record_data: &[u8],
     options: &DecodeOptions,
-) -> Result<serde_json::Value, copybook_codec::Error> {
+) -> copybook_rs::Result<serde_json::Value> {
 
     // Method 1: Simple decoding (suitable for small volumes)
     let json_value = decode_record(schema, record_data, options)?;
@@ -145,11 +144,11 @@ fn decode_customer_data(
 For production workloads, use streaming APIs:
 
 ```rust
-use copybook_codec::{iter_records_from_file, decode_file_to_jsonl};
-use std::path::Path;
+use copybook_rs::{decode_file_to_jsonl, iter_records_from_file};
+use std::{fs::File, path::Path};
 
 fn process_mainframe_file(
-    schema: &copybook_core::Schema,
+    schema: &copybook_rs::Schema,
     input_path: &Path,
     output_path: &Path,
     options: &DecodeOptions,
@@ -166,12 +165,13 @@ fn process_mainframe_file(
     }
 
     // Method 2: Direct file conversion with metrics
+    let input_file = File::open(input_path)?;
     let output_file = std::fs::File::create(output_path)?;
-    let summary = decode_file_to_jsonl(schema, input_path, output_file, options)?;
+    let summary = decode_file_to_jsonl(schema, input_file, output_file, options)?;
 
-    println!("Processed {} records in {:?}",
+    println!("Processed {} records in {:.3} seconds",
              summary.records_processed,
-             summary.processing_time);
+             summary.processing_time_seconds());
 
     Ok(())
 }
@@ -188,9 +188,9 @@ fn process_mainframe_file(
 copybook-rs provides a comprehensive error taxonomy for production monitoring:
 
 ```rust
-use copybook_core::{Error, ErrorCode};
+use copybook_rs::{Error, ErrorCode};
 
-fn handle_parsing_errors(result: Result<copybook_core::Schema, Error>) {
+fn handle_parsing_errors(result: Result<copybook_rs::Schema, Error>) {
     match result {
         Ok(schema) => {
             println!("Successfully parsed schema");
@@ -229,9 +229,10 @@ fn handle_parsing_errors(result: Result<copybook_core::Schema, Error>) {
 Here's a complete example that demonstrates enterprise-safe COBOL processing:
 
 ```rust
-use copybook_core::parse_copybook;
-use copybook_codec::{DecodeOptions, Codepage, JsonNumberMode, RecordFormat, decode_file_to_jsonl};
-use std::{path::Path, fs::File};
+use copybook_rs::{
+    Codepage, DecodeOptions, JsonNumberMode, RecordFormat, decode_file_to_jsonl, parse_copybook,
+};
+use std::fs::File;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // 1. Parse copybook with error handling
@@ -243,19 +244,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_codepage(Codepage::CP037)
         .with_format(RecordFormat::Fixed)
         .with_json_number_mode(JsonNumberMode::Lossless)
-        .with_emit_meta(true)
-        .with_validate_structure(true);
+        .with_emit_meta(true);
 
     // 3. Process data with streaming and metrics
-    let input_path = Path::new("customer_data.bin");
+    let input_file = File::open("customer_data.bin")?;
     let output_file = File::create("customer_data.jsonl")?;
 
-    let summary = decode_file_to_jsonl(&schema, input_path, output_file, &options)?;
+    let summary = decode_file_to_jsonl(&schema, input_file, output_file, &options)?;
 
     // 4. Report results
     println!("✅ Processing complete!");
     println!("📊 Records processed: {}", summary.records_processed);
-    println!("⏱️  Processing time: {:?}", summary.processing_time);
+    println!("⏱️  Processing time: {:.3} seconds", summary.processing_time_seconds());
     println!("💾 Memory usage: <256 MiB (bounded)");
 
     Ok(())


### PR DESCRIPTION
## Summary
- add a canonical `copybook-rs` umbrella facade crate and a thin `copybook` alias crate
- wire both new packages into workspace publishing and dry-run release automation
- update top-level Rust docs to default to the facade crates and fix stale API examples/signatures

## Validation
- `cargo test -p copybook-rs -p copybook`
- `cargo check -p copybook-rs --all-features && cargo check -p copybook --all-features`
- `cargo package -p copybook-rs --list --allow-dirty > $null; cargo package -p copybook --list --allow-dirty > $null`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced unified library entry points: `copybook-rs` (umbrella facade) and `copybook` (short-name alias) for streamlined imports and simplified API access.
  * Both facade crates re-export core functionality while maintaining backward compatibility with granular crates.

* **Documentation**
  * Updated all guides, tutorials, and API references to recommend the new facade crates as the primary entry point.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->