### PR TITLE
perf(support-matrix): optimize feature lookup

### DIFF
--- a/crates/copybook-support-matrix/src/lib.rs
+++ b/crates/copybook-support-matrix/src/lib.rs
@@ -167,9 +167,9 @@ pub fn find_feature_by_id(id: FeatureId) -> Option<&'static FeatureSupport> {
 #[inline]
 #[must_use]
 pub fn find_feature(id: &str) -> Option<&'static FeatureSupport> {
-    all_features()
-        .iter()
-        .find(|f| serde_plain::to_string(&f.id).ok().as_deref() == Some(id))
+    serde_plain::from_str::<FeatureId>(id)
+        .ok()
+        .and_then(find_feature_by_id)
 }
 
 #[cfg(test)]
@@ -195,6 +195,12 @@ mod tests {
     #[test]
     fn test_find_feature_unknown() {
         let feature = find_feature("no-such-feature");
+        assert!(feature.is_none());
+    }
+
+    #[test]
+    fn test_find_feature_rejects_non_kebab_variant_name() {
+        let feature = find_feature("Level88Conditions");
         assert!(feature.is_none());
     }
 


### PR DESCRIPTION
### Motivation
- Simplify and harden the hot-path string lookup for support-matrix features by avoiding per-entry serialization and registry scanning and by enforcing the kebab-case ID contract.

### Description
- Replace `find_feature` implementation in `crates/copybook-support-matrix/src/lib.rs` to parse incoming kebab-case IDs via `serde_plain::from_str::<FeatureId>` and then resolve with `find_feature_by_id`, and add a regression test `test_find_feature_rejects_non_kebab_variant_name` to ensure non-kebab names are rejected.

### Testing
- Ran `cargo test -p copybook-support-matrix` and all unit tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e957fdce648333b432d9f1c3ac8f97)