### PR TITLE
Resolve tail ODO names to canonical schema paths for nested ODO encoding

### DIFF
--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -1946,27 +1946,32 @@ fn validate_lib_api_odo_encoding(
         return Ok(());
     }
 
+    let array_schema_path = resolve_schema_path(schema, &tail_odo.array_path)
+        .unwrap_or_else(|| tail_odo.array_path.clone());
+    let counter_schema_path = resolve_schema_path(schema, &tail_odo.counter_path)
+        .unwrap_or_else(|| tail_odo.counter_path.clone());
+
     if let Some(array) = json_lookup_array(fields_value, &tail_odo.array_path) {
-        let array_field = schema.find_field(&tail_odo.array_path).ok_or_else(|| {
+        let array_field = schema.find_field(&array_schema_path).ok_or_else(|| {
             Error::new(
                 ErrorCode::CBKS121_COUNTER_NOT_FOUND,
                 format!(
                     "ODO array field '{}' not found in schema",
-                    tail_odo.array_path
+                    array_schema_path
                 ),
             )
             .with_context(crate::odo_redefines::create_comprehensive_error_context(
                 0,
-                &tail_odo.array_path,
+                &array_schema_path,
                 0,
                 None,
             ))
         })?;
 
-        let counter_field = schema.find_field(&tail_odo.counter_path).ok_or_else(|| {
+        let counter_field = schema.find_field(&counter_schema_path).ok_or_else(|| {
             crate::odo_redefines::handle_missing_counter_field(
-                &tail_odo.counter_path,
-                &tail_odo.array_path,
+                &counter_schema_path,
+                &array_schema_path,
                 schema,
                 0,
                 0,
@@ -1975,8 +1980,8 @@ fn validate_lib_api_odo_encoding(
 
         if json_lookup_value(fields_value, &tail_odo.counter_path).is_none() {
             return Err(crate::odo_redefines::handle_missing_counter_field(
-                &tail_odo.counter_path,
-                &tail_odo.array_path,
+                &counter_schema_path,
+                &array_schema_path,
                 schema,
                 0,
                 u64::from(counter_field.offset),
@@ -1984,8 +1989,8 @@ fn validate_lib_api_odo_encoding(
         }
 
         let context = crate::odo_redefines::OdoValidationContext {
-            field_path: tail_odo.array_path.clone(),
-            counter_path: tail_odo.counter_path.clone(),
+            field_path: array_schema_path,
+            counter_path: counter_schema_path,
             record_index: 0,
             byte_offset: u64::from(array_field.offset),
         };
@@ -2003,11 +2008,24 @@ fn validate_lib_api_odo_encoding(
 }
 
 fn json_lookup_value<'a>(value: &'a Value, field_path: &str) -> Option<&'a Value> {
-    let mut current = value;
-    for segment in field_path.split('.') {
-        current = current.as_object()?.get(segment)?;
+    let segments: Vec<&str> = field_path.split('.').collect();
+    for start_idx in 0..segments.len() {
+        let mut current = value;
+        let mut found = true;
+        for segment in &segments[start_idx..] {
+            match current.as_object().and_then(|obj| obj.get(*segment)) {
+                Some(next) => current = next,
+                None => {
+                    found = false;
+                    break;
+                }
+            }
+        }
+        if found {
+            return Some(current);
+        }
     }
-    Some(current)
+    None
 }
 
 fn json_lookup_array<'a>(value: &'a Value, field_path: &str) -> Option<&'a Vec<Value>> {
@@ -2022,6 +2040,24 @@ fn json_lookup_array<'a>(value: &'a Value, field_path: &str) -> Option<&'a Vec<V
             }
         }
     }
+}
+
+fn resolve_schema_path(schema: &Schema, path_or_name: &str) -> Option<String> {
+    if schema.find_field(path_or_name).is_some() {
+        return Some(path_or_name.to_string());
+    }
+
+    let needle = path_or_name.rsplit('.').next().unwrap_or(path_or_name);
+    let mut matches = schema
+        .all_fields()
+        .into_iter()
+        .filter(|field| field.name.eq_ignore_ascii_case(needle));
+
+    let first = matches.next()?;
+    if matches.next().is_some() {
+        return None;
+    }
+    Some(first.path.clone())
 }
 
 /// Helper function to encode JSON fields to binary payload

--- a/crates/copybook-codec/src/processor.rs
+++ b/crates/copybook-codec/src/processor.rs
@@ -1118,6 +1118,10 @@ impl EncodeProcessor {
     ) -> Result<(), Error> {
         // Check if schema has tail ODO
         if let Some(ref tail_odo) = schema.tail_odo {
+            let array_schema_path = resolve_schema_path(schema, &tail_odo.array_path)
+                .unwrap_or_else(|| tail_odo.array_path.clone());
+            let counter_schema_path = resolve_schema_path(schema, &tail_odo.counter_path)
+                .unwrap_or_else(|| tail_odo.counter_path.clone());
             let fields_object = if let Some(fields_value) = json_value.get("fields") {
                 fields_value
             } else {
@@ -1125,28 +1129,28 @@ impl EncodeProcessor {
             };
 
             if let Some(array) = json_lookup_array(fields_object, &tail_odo.array_path) {
-                let array_field = schema.find_field(&tail_odo.array_path).ok_or_else(|| {
+                let array_field = schema.find_field(&array_schema_path).ok_or_else(|| {
                     Error::new(
                         ErrorCode::CBKS121_COUNTER_NOT_FOUND,
                         format!(
                             "ODO array field '{}' not found in schema",
-                            tail_odo.array_path
+                            array_schema_path
                         ),
                     )
                     .with_context(
                         crate::odo_redefines::create_comprehensive_error_context(
                             record_index,
-                            &tail_odo.array_path,
+                            &array_schema_path,
                             0,
                             None,
                         ),
                     )
                 })?;
 
-                let counter_field = schema.find_field(&tail_odo.counter_path).ok_or_else(|| {
+                let counter_field = schema.find_field(&counter_schema_path).ok_or_else(|| {
                     crate::odo_redefines::handle_missing_counter_field(
-                        &tail_odo.counter_path,
-                        &tail_odo.array_path,
+                        &counter_schema_path,
+                        &array_schema_path,
                         schema,
                         record_index,
                         0,
@@ -1155,8 +1159,8 @@ impl EncodeProcessor {
 
                 if json_lookup_value(fields_object, &tail_odo.counter_path).is_none() {
                     return Err(crate::odo_redefines::handle_missing_counter_field(
-                        &tail_odo.counter_path,
-                        &tail_odo.array_path,
+                        &counter_schema_path,
+                        &array_schema_path,
                         schema,
                         record_index,
                         counter_field.offset as u64,
@@ -1164,8 +1168,8 @@ impl EncodeProcessor {
                 }
 
                 let validation_context = crate::odo_redefines::OdoValidationContext {
-                    field_path: tail_odo.array_path.clone(),
-                    counter_path: tail_odo.counter_path.clone(),
+                    field_path: array_schema_path,
+                    counter_path: counter_schema_path,
                     record_index,
                     byte_offset: array_field.offset as u64,
                 };
@@ -1185,11 +1189,24 @@ impl EncodeProcessor {
     }
 
 fn json_lookup_value(value: &serde_json::Value, field_path: &str) -> Option<&serde_json::Value> {
-    let mut current = value;
-    for segment in field_path.split('.') {
-        current = current.as_object()?.get(segment)?;
+    let segments: Vec<&str> = field_path.split('.').collect();
+    for start_idx in 0..segments.len() {
+        let mut current = value;
+        let mut found = true;
+        for segment in &segments[start_idx..] {
+            match current.as_object().and_then(|obj| obj.get(*segment)) {
+                Some(next) => current = next,
+                None => {
+                    found = false;
+                    break;
+                }
+            }
+        }
+        if found {
+            return Some(current);
+        }
     }
-    Some(current)
+    None
 }
 
 fn json_lookup_array(value: &serde_json::Value, field_path: &str) -> Option<&Vec<Value>> {
@@ -1204,6 +1221,24 @@ fn json_lookup_array(value: &serde_json::Value, field_path: &str) -> Option<&Vec
             }
         }
     }
+}
+
+fn resolve_schema_path(schema: &Schema, path_or_name: &str) -> Option<String> {
+    if schema.find_field(path_or_name).is_some() {
+        return Some(path_or_name.to_string());
+    }
+
+    let needle = path_or_name.rsplit('.').next().unwrap_or(path_or_name);
+    let mut matches = schema
+        .all_fields()
+        .into_iter()
+        .filter(|field| field.name.eq_ignore_ascii_case(needle));
+
+    let first = matches.next()?;
+    if matches.next().is_some() {
+        return None;
+    }
+    Some(first.path.clone())
 }
 
     /// Enhance encode error with comprehensive context information

--- a/crates/copybook-codec/tests/odo_comprehensive.rs
+++ b/crates/copybook-codec/tests/odo_comprehensive.rs
@@ -125,6 +125,42 @@ fn test_valid_odo_configuration() {
 }
 
 #[test]
+fn test_nested_tail_odo_encode_uses_schema_path_resolution() {
+    let copybook = r#"
+01 RECORD-LAYOUT.
+   05 HEADER.
+      10 ITEM-COUNT PIC 9(2).
+   05 DETAIL.
+      10 ITEMS OCCURS 1 TO 5 TIMES DEPENDING ON ITEM-COUNT.
+         15 ITEM-CODE PIC X(2).
+"#;
+
+    let schema = parse_copybook(copybook).unwrap();
+    let payload = json!({
+        "HEADER": { "ITEM-COUNT": "02" },
+        "DETAIL": {
+            "ITEMS": [
+                { "ITEM-CODE": "A1" },
+                { "ITEM-CODE": "B2" }
+            ]
+        }
+    });
+
+    let options = EncodeOptions::new()
+        .with_format(RecordFormat::Fixed)
+        .with_codepage(Codepage::ASCII);
+
+    let encoded = copybook_codec::encode_record(&schema, &payload, &options)
+        .expect("nested ODO encode should resolve schema paths from tail metadata");
+
+    assert_eq!(&encoded[..2], b"02");
+    assert_eq!(
+        encoded.len(),
+        usize::try_from(schema.lrecl_fixed.unwrap()).unwrap()
+    );
+}
+
+#[test]
 fn test_odo_strict_mode_clamp_fatal() {
     let copybook = r#"
 01 RECORD-LAYOUT.


### PR DESCRIPTION
### Motivation
- Tail ODO metadata sometimes stores short field names (e.g., `ITEMS` / `ITEM-COUNT`) while `Schema::find_field` expects full paths, causing encode-time "field not found" failures for nested/grouped layouts.
- JSON payloads may omit the top-level record qualifier (e.g., `REC.DETAIL.ITEMS` vs `DETAIL.ITEMS`), breaking strict segment-wise lookups.

### Description
- Added `resolve_schema_path` helper to map a `tail_odo` `array_path`/`counter_path` to a canonical schema path by either using the provided path or resolving a unique field-name match via `schema.all_fields()`; returns `None` when ambiguous.
- Updated encode validation in `crates/copybook-codec/src/lib_api.rs` to resolve `tail_odo` paths (`array_schema_path` / `counter_schema_path`) before calling `schema.find_field` and constructing validation contexts; adjusted error messages and contexts to use resolved paths.
- Applied the same schema-path resolution changes to the streaming/processor encode validation in `crates/copybook-codec/src/processor.rs` for consistent behavior across encode flows.
- Made JSON path lookup tolerant to optional leading segments by changing `json_lookup_value` (in both `lib_api` and `processor`) to try progressive sub-path matches (tries full path, then path without leading segments) to support payloads that omit top-level qualifiers.
- Added a regression test `test_nested_tail_odo_encode_uses_schema_path_resolution` in `crates/copybook-codec/tests/odo_comprehensive.rs` that encodes a nested ODO (grouped `HEADER.ITEM-COUNT` and `DETAIL.ITEMS`) and asserts successful encoding and correct LRECL and counter bytes.

### Testing
- Ran `cargo fmt --all` (succeeded).
- Ran the new regression test: `cargo test -q -p copybook-codec --features comprehensive-tests --test odo_comprehensive test_nested_tail_odo_encode_uses_schema_path_resolution` and it passed (1 passed; 0 failed).
- Re-ran an existing ODO test: `cargo test -q -p copybook-codec --features comprehensive-tests --test odo_comprehensive test_valid_odo_configuration` and it passed (1 passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e957fdce648333b432d9f1c3ac8f97)