### PR TITLE
fix(bench): make SLO validation idempotent

### DIFF
--- a/tools/copybook-bench/src/reporting.rs
+++ b/tools/copybook-bench/src/reporting.rs
@@ -51,6 +51,11 @@ impl PerformanceReport {
 
     /// Validate against SLO thresholds
     pub fn validate_slos(&mut self, display_slo: f64, comp3_slo: f64) {
+        // Recompute validation from current metrics each time to keep behavior idempotent.
+        self.status = default_status();
+        self.warnings.clear();
+        self.errors.clear();
+
         if let Some(display) = self.display_gibs {
             if display < display_slo {
                 self.status = "failure".to_string();
@@ -144,6 +149,25 @@ mod tests {
         report.validate_slos(4.1, 560.0);
         assert_eq!(report.status, "failure");
         assert!(!report.errors.is_empty());
+    }
+
+    #[test]
+    fn test_slo_validation_recomputes_without_stale_messages() {
+        let mut report = PerformanceReport::new();
+        report.display_gibs = Some(3.0);
+        report.comp3_mibs = Some(500.0);
+
+        report.validate_slos(4.1, 560.0);
+        assert_eq!(report.status, "failure");
+        assert!(!report.errors.is_empty());
+
+        report.display_gibs = Some(5.0);
+        report.comp3_mibs = Some(700.0);
+        report.validate_slos(4.1, 560.0);
+
+        assert_eq!(report.status, "success");
+        assert!(report.errors.is_empty());
+        assert!(report.warnings.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- `PerformanceReport::validate_slos` previously accumulated `warnings`/`errors` and could preserve a failing `status` across subsequent validations, causing stale diagnostic state after metrics improved.

### Description
- Reset the report validation state at the start of `validate_slos` by setting `status` to `default_status()` and clearing `warnings` and `errors` in `tools/copybook-bench/src/reporting.rs` so behavior is idempotent.
- Add a regression test `test_slo_validation_recomputes_without_stale_messages` that verifies a report can transition from failure to success when metrics improve and `validate_slos` is re-run.

### Testing
- Ran `cargo test -p copybook-bench reporting::tests -- --nocapture`, and the reporting tests passed (`5 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e957fcd5948333973e14822b930dc7)