### PR TITLE
fix(governance): harden summary coverage accounting

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -190,7 +190,7 @@ jobs:
 
     - name: Comment PR with benchmark results
       if: github.event_name == 'pull_request'
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       with:
         script: |
           const fs = require('fs');

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -14,6 +14,7 @@ on:
       - 'tests/**'
       - 'Cargo.*'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches: [ main, develop ]
     paths:
       - 'crates/**'
@@ -30,9 +31,13 @@ env:
 
 jobs:
   coverage:
-    name: Code Coverage
+    name: Tarpaulin Coverage
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'coverage') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -87,7 +87,7 @@ jobs:
         fi
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         file: ./coverage/cobertura.xml
         flags: unittests
@@ -187,7 +187,7 @@ jobs:
         echo "PR branch: ${{ github.head_ref }}"
 
     - name: Comment coverage on PR
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       with:
         script: |
           const fs = require('fs');

--- a/.github/workflows/ci-mutants.yml
+++ b/.github/workflows/ci-mutants.yml
@@ -314,7 +314,7 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/ci-quick.yml
+++ b/.github/workflows/ci-quick.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,7 +423,7 @@ jobs:
     # Make upload non-blocking and always run
     - name: Upload coverage to Codecov
       if: always()
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         files: lcov.info
         flags: unit

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload coverage to Codecov (main)
         if: ${{ always() && github.event_name == 'push' && hashFiles('lcov.info') != '' && steps.codecov-token.outputs.present == 'true' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
@@ -122,7 +122,7 @@ jobs:
 
       - name: Upload coverage to Codecov (advisory)
         if: ${{ always() && github.event_name != 'push' && hashFiles('lcov.info') != '' && steps.codecov-token.outputs.present == 'true' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+name: Coverage
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "crates/**"
+      - "copybook-*/**"
+      - "tools/**"
+      - "tests/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain*"
+      - ".github/workflows/coverage.yml"
+      - "codecov.yml"
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches: [main]
+    paths:
+      - "crates/**"
+      - "copybook-*/**"
+      - "tools/**"
+      - "tests/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain*"
+      - ".github/workflows/coverage.yml"
+      - "codecov.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: coverage-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  RUSTFLAGS: "-C debuginfo=0"
+
+jobs:
+  coverage:
+    name: Codecov Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'coverage') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.92"
+          components: llvm-tools-preview
+
+      - name: Use larger target dir
+        run: echo "CARGO_TARGET_DIR=${RUNNER_TEMP}/target" >> "$GITHUB_ENV"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-directories: ${{ runner.temp }}/target
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov,cargo-nextest
+
+      - name: Generate coverage
+        env:
+          CI: true
+        run: |
+          set -euo pipefail
+          cargo llvm-cov clean --workspace
+
+          cargo llvm-cov nextest \
+            --workspace \
+            --locked \
+            --no-report
+
+          cargo llvm-cov report --json --output-path coverage.json
+          cargo llvm-cov report --lcov --output-path lcov.info
+          cargo llvm-cov report --text | tee coverage.txt
+
+      - name: Validate coverage output
+        run: |
+          set -euo pipefail
+          test -s coverage.json
+          test -s coverage.txt
+          test -s lcov.info
+
+      - name: Detect Codecov token
+        id: codecov-token
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          if [ -n "${CODECOV_TOKEN:-}" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload coverage to Codecov (main)
+        if: ${{ always() && github.event_name == 'push' && hashFiles('lcov.info') != '' && steps.codecov-token.outputs.present == 'true' }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust-core
+          name: copybook-rs-rust-core
+          fail_ci_if_error: true
+
+      - name: Upload coverage to Codecov (advisory)
+        if: ${{ always() && github.event_name != 'push' && hashFiles('lcov.info') != '' && steps.codecov-token.outputs.present == 'true' }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust-core
+          name: copybook-rs-rust-core
+          fail_ci_if_error: false
+
+      - name: Upload coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-report
+          path: |
+            coverage.json
+            coverage.txt
+            lcov.info
+          retention-days: 14

--- a/.github/workflows/docs-truth.yml
+++ b/.github/workflows/docs-truth.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 2 }
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/enterprise-perf.yml
+++ b/.github/workflows/enterprise-perf.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Post PR comment
         if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           AUDIT_OVERHEAD: ${{ steps.overhead.outputs.audit_overhead }}
           COMPLIANCE_OVERHEAD: ${{ steps.overhead.outputs.compliance_overhead }}
@@ -235,7 +235,7 @@ jobs:
 
       - name: Publish enterprise overhead check
         id: check
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           AUDIT_OVERHEAD: ${{ steps.overhead.outputs.audit_overhead }}
           COMPLIANCE_OVERHEAD: ${{ steps.overhead.outputs.compliance_overhead }}

--- a/.github/workflows/feature-flags.yml
+++ b/.github/workflows/feature-flags.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/leak-detection.yml
+++ b/.github/workflows/leak-detection.yml
@@ -6,6 +6,7 @@ on:
   schedule:
     - cron: "0 4 * * 0"  # Weekly on Sunday at 04:00 UTC
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - "crates/copybook-codec/**"
       - "crates/copybook-core/**"
@@ -24,6 +25,10 @@ jobs:
     name: Memory Leak Detection (LSAN)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'leak-check') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/perf-container.yml
+++ b/.github/workflows/perf-container.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}/bench
           tags: |
@@ -55,7 +55,7 @@ jobs:
 
       - name: Build benchmark container
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile
@@ -95,7 +95,7 @@ jobs:
 
       - name: Push to GHCR (main branch only)
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -346,7 +346,7 @@ jobs:
 
       - name: Post PR comment
         if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           BASELINE_FOUND: ${{ steps.baseline.outputs.baseline_found }}
           BASE_DISPLAY: ${{ steps.compare.outputs.base_display }}
@@ -509,7 +509,7 @@ jobs:
 
       - name: Publish Throughput badge (neutral on fail)
         id: throughput
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           DISPLAY_MIB: ${{ steps.slo.outputs.display }}
           COMP3_MIB: ${{ steps.slo.outputs.comp3 }}
@@ -557,7 +557,7 @@ jobs:
 
       - name: Label perf success
         if: ${{ success() && steps.throughput.outputs.ok == 'true' && github.event.pull_request.number }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const label = 'ready:perf-ok';

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -44,7 +44,7 @@ jobs:
           cargo audit -q --json > target/security.audit.json || true
 
       - name: Open/update roll-up issue on findings
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -78,7 +78,7 @@ jobs:
           retention-days: 90
 
       - name: Publish soak check-run
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,6 +738,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "copybook"
+version = "0.4.3"
+dependencies = [
+ "copybook-charset",
+ "copybook-codec",
+ "copybook-codepage",
+ "copybook-contracts",
+ "copybook-core",
+ "copybook-determinism",
+ "copybook-error",
+ "copybook-error-reporter",
+ "copybook-fixed",
+ "copybook-governance-contracts",
+ "copybook-options",
+ "copybook-overflow",
+ "copybook-overpunch",
+ "copybook-rdw",
+ "copybook-record-io",
+ "copybook-support-matrix",
+ "copybook-utils",
+]
+
+[[package]]
 name = "copybook-arrow"
 version = "0.4.3"
 dependencies = [
@@ -932,7 +955,7 @@ dependencies = [
  "hex",
  "logos",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "serde_plain",
@@ -1049,7 +1072,7 @@ dependencies = [
  "copybook-codec",
  "copybook-core",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "sha2",
@@ -1156,7 +1179,7 @@ dependencies = [
  "copybook-support-matrix",
  "crossbeam-channel",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
 ]
@@ -1190,6 +1213,13 @@ dependencies = [
  "copybook-options",
  "copybook-rdw",
  "proptest",
+]
+
+[[package]]
+name = "copybook-rs"
+version = "0.4.3"
+dependencies = [
+ "copybook",
 ]
 
 [[package]]
@@ -2502,7 +2532,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "metrics",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -2950,7 +2980,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -3002,15 +3032,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3059,9 +3089,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -3069,9 +3099,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -3364,9 +3394,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -93,9 +93,9 @@ checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -347,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.1.2"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5bcfa8749ac45dd12cb11055aeeb6b27a3895560d60d71e3c23bf979e60514"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
  "anstyle",
  "bstr",
@@ -362,12 +362,11 @@ dependencies = [
 
 [[package]]
 name = "assert_fs"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a652f6cb1f516886fcfee5e7a5c078b9ade62cfcb889524efe5a64d682dd27a9"
+checksum = "6ecf5c70ca07b7f80220bce936f0556a960ca6fb00fc2bd4125b5e581b218137"
 dependencies = [
  "anstyle",
- "doc-comment",
  "globwalk",
  "predicates",
  "predicates-core",
@@ -458,16 +457,16 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -579,14 +578,14 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -625,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -635,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -648,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1553,12 +1552,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "doc-comment"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1599,6 +1592,17 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "evmap"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8874945f036109c72242964c1174cf99434e30cfa45bf45fedc983f50046f8"
+dependencies = [
+ "hashbag",
+ "left-right",
+ "smallvec",
 ]
 
 [[package]]
@@ -1764,6 +1768,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1809,7 +1828,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1887,6 +1906,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbag"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7040a10f52cba493ddb09926e15d10a9d8a28043708a405931fe4c6f19fac064"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1903,6 +1928,12 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -2188,12 +2219,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2318,6 +2349,17 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "left-right"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0c21e4c8ff95f487fb34e6f9182875f42c84cef966d29216bf115d9bba835a"
+dependencies = [
+ "crossbeam-utils",
+ "loom",
+ "slab",
+]
 
 [[package]]
 name = "lexical-core"
@@ -2454,6 +2496,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2491,21 +2546,22 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metrics"
-version = "0.24.3"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
- "ahash",
  "portable-atomic",
+ "rapidhash",
 ]
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.18.1"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
+checksum = "1db0d8f1fc9e62caebd0319e11eaec5822b0186c171568f0480b46a0137f9108"
 dependencies = [
  "base64",
+ "evmap",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -2972,9 +3028,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -3105,7 +3161,7 @@ checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3129,9 +3185,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -3149,6 +3205,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -3240,9 +3305,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -3438,15 +3503,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3456,16 +3512,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sealed"
@@ -3545,9 +3601,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap",
  "itoa",
@@ -3577,24 +3633,23 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
  "futures-executor",
  "futures-util",
  "log",
  "once_cell",
  "parking_lot",
- "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3805,9 +3860,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
@@ -4127,9 +4182,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 [workspace]
 members = [
+    "crates/copybook",
+    "crates/copybook-rs",
     "crates/copybook-error",
     "crates/copybook-error-reporter",
     "crates/copybook-utils",
@@ -64,6 +66,7 @@ categories = ["parsing", "encoding", "command-line-utilities"]
 
 [workspace.dependencies]
 # Internal workspace crates (pin exact versions for publish)
+copybook = { version = "=0.4.3", path = "crates/copybook" }
 copybook-error = { version = "=0.4.3", path = "crates/copybook-error" }
 copybook-error-reporter = { version = "=0.4.3", path = "crates/copybook-error-reporter" }
 copybook-utils = { version = "=0.4.3", path = "crates/copybook-utils" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,24 +106,24 @@ copybook-support-matrix = { version = "=0.4.3", path = "crates/copybook-support-
 
 # Core dependencies
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = { version = "1.0.149", features = ["preserve_order"] }
+serde_json = { version = "1.0.150", features = ["preserve_order"] }
 serde_plain = "1.0.2"
 thiserror = "2.0.18"
 tracing = "0.1.44"
-tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 
 # Memory management dependencies
 smallvec = "1.15.1"
 crossbeam-channel = "0.5.15"
-indexmap = { version = "2.13.0", features = ["serde"] }
+indexmap = { version = "2.14.0", features = ["serde"] }
 
 # CLI dependencies
-clap = { version = "4.5.60", features = ["derive"] }
+clap = { version = "4.6.1", features = ["derive"] }
 tokio = { version = "1.50.0", features = ["full"] }
-tempfile = "3.26.0"
+tempfile = "3.27.0"
 
 # Telemetry dependencies
-metrics = "0.24.3"
+metrics = "0.24.6"
 
 # Parsing dependencies
 logos = "0.16.1"
@@ -132,13 +132,13 @@ regex = "1.12.3"
 # Crypto dependencies
 sha2 = "0.10.9"
 base64 = "0.22.1"
-blake3 = "1.8.3"
+blake3 = "1.8.5"
 
 # Testing dependencies
-proptest = "1.10.0"
+proptest = "1.11.0"
 criterion = { version = "0.8.2", features = ["html_reports"] }
 hex = "0.4.3"
-assert_cmd = "2.1.2"
+assert_cmd = "2.2.2"
 predicates = "3.1.4"
 num_cpus = "1.17.0"
 roxmltree = "0.21.1"
@@ -152,11 +152,11 @@ anyhow = "1.0.102"
 
 # Random number generation dependencies
 rand = "0.10.0"
-rand_core = "0.10.0"
+rand_core = "0.10.1"
 
 # Enterprise audit dependencies
 async-trait = "0.1.89"
-chrono = { version = "0.4.44", features = ["serde"] }
+chrono = { version = "0.4.45", features = ["serde"] }
 
 # TOML parsing
 toml = "0.9.8"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,17 +1,31 @@
-# Codecov configuration for copybook-rs
-# Prevents codecov/patch status checks from blocking PRs due to narrow
-# threshold misses (e.g., 77.27% vs 77.53% target).
 coverage:
+  precision: 2
+  round: down
+  range: "50...85"
+
   status:
     project:
       default:
-        informational: true
+        target: auto
+        threshold: 3%
+        informational: false
+        flags:
+          - rust-core
+
     patch:
       default:
+        target: 60%
+        threshold: 20%
         informational: true
+        flags:
+          - rust-core
+
+comment: false
+
+github_checks:
+  annotations: false
 
 ignore:
-  - "tools/**"
-  - "tests/**"
-  - "fuzz/**"
-  - "examples/**"
+  - "target/**"
+  - "tools/copybook-bench/**"
+  - "examples/kafka_pipeline/**"

--- a/crates/copybook-cli/Cargo.toml
+++ b/crates/copybook-cli/Cargo.toml
@@ -44,7 +44,7 @@ copybook-governance = { workspace = true }
 copybook-arrow = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 metrics = { workspace = true, optional = true }
-metrics-exporter-prometheus = { version = "0.18.1", optional = true, features = ["http-listener"] }
+metrics-exporter-prometheus = { version = "0.18.3", optional = true, features = ["http-listener"] }
 toml.workspace = true
 
 [features]
@@ -64,10 +64,10 @@ metrics = [
 [dev-dependencies]
 proptest.workspace = true
 assert_cmd.workspace = true
-assert_fs = "1.1.3"
+assert_fs = "1.1.4"
 predicates.workspace = true
-reqwest = { version = "0.13.2", features = ["blocking"] }
-serial_test = "3.4.0"
+reqwest = { version = "0.13.4", features = ["blocking"] }
+serial_test = "3.5.0"
 os_pipe = "1.2.3"
 
 [lints]

--- a/crates/copybook-cli/src/commands/audit.rs
+++ b/crates/copybook-cli/src/commands/audit.rs
@@ -2585,8 +2585,7 @@ fn run_audit_health_check_impl(
             if let Some(window) = retention_limit {
                 let old_records = health_events.iter().filter(|record| {
                     DateTime::parse_from_rfc3339(&record.timestamp)
-                        .map(|timestamp| timestamp.with_timezone(&chrono::Utc) < window)
-                        .unwrap_or(false)
+                        .is_ok_and(|timestamp| timestamp.with_timezone(&chrono::Utc) < window)
                 });
                 if old_records.clone().count() > 0 {
                     retention_compliant = false;
@@ -2701,12 +2700,12 @@ fn run_audit_health_check_impl(
         );
     }
 
-    let overall_health_score = if checks_executed == 0 {
-        0
-    } else {
-        let failed_penalty = (checks_failed * 100) / checks_executed;
-        (100u32.saturating_sub(failed_penalty)).min(100)
-    };
+    let overall_health_score = checks_failed
+        .saturating_mul(100)
+        .checked_div(checks_executed)
+        .map_or(0, |failed_penalty| {
+            (100u32.saturating_sub(failed_penalty)).min(100)
+        });
 
     let status_code = if checks_failed > 0 || !parse_issues.is_empty() {
         ExitCode::Data

--- a/crates/copybook-cli/src/main.rs
+++ b/crates/copybook-cli/src/main.rs
@@ -554,13 +554,10 @@ fn main() -> ProcessExitCode {
 
 #[allow(clippy::too_many_lines)]
 fn run() -> anyhow::Result<ExitCode> {
-    #[allow(clippy::panic)]
-    if std::env::var("COPYBOOK_TEST_PANIC")
-        .map(|v| v == "1")
-        .unwrap_or(false)
-    {
-        panic!("COPYBOOK_TEST_PANIC triggered");
-    }
+    assert!(
+        !std::env::var("COPYBOOK_TEST_PANIC").is_ok_and(|v| v == "1"),
+        "COPYBOOK_TEST_PANIC triggered"
+    );
 
     let cli = match Cli::try_parse() {
         Ok(cli) => cli,

--- a/crates/copybook-codec/src/fidelity.rs
+++ b/crates/copybook-codec/src/fidelity.rs
@@ -948,11 +948,9 @@ pub mod utils {
             .map(|p| p.validation_time_ms)
             .sum();
         let total_records_u64 = u64::try_from(total_records).unwrap_or(u64::MAX);
-        let average_validation_time = if total_records_u64 == 0 {
-            0
-        } else {
-            total_validation_time / total_records_u64
-        };
+        let average_validation_time = total_validation_time
+            .checked_div(total_records_u64)
+            .unwrap_or(0);
 
         BatchFidelityMetrics {
             total_records,

--- a/crates/copybook-contracts/src/feature_flags.rs
+++ b/crates/copybook-contracts/src/feature_flags.rs
@@ -530,8 +530,7 @@ impl FeatureFlagsHandle {
     pub fn is_enabled(&self, feature: Feature) -> bool {
         self.flags
             .read()
-            .map(|flags| flags.is_enabled(feature))
-            .unwrap_or(false)
+            .is_ok_and(|flags| flags.is_enabled(feature))
     }
 
     /// Enable a feature flag through the handle.

--- a/crates/copybook-core/Cargo.toml
+++ b/crates/copybook-core/Cargo.toml
@@ -39,7 +39,7 @@ copybook-governance-contracts.workspace = true
 
 # Audit system dependencies (only when audit feature is enabled)
 async-trait = { workspace = true, optional = true }
-chrono = { version = "0.4.43", features = ["serde"], optional = true }
+chrono = { version = "0.4.45", features = ["serde"], optional = true }
 hex = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 

--- a/crates/copybook-core/src/audit/security.rs
+++ b/crates/copybook-core/src/audit/security.rs
@@ -421,8 +421,7 @@ impl SecurityMonitor {
         let priority = 16 * 8 + 4; // 132
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_secs());
         format!(
             "<{}>1 {} copybook-rs SecurityMonitor - {} - {}",
             priority, timestamp, violation.violation_id, violation.description

--- a/crates/copybook-governance-grid/src/governance_grid.rs
+++ b/crates/copybook-governance-grid/src/governance_grid.rs
@@ -5,6 +5,7 @@
 //! and docs can be tracked as a first-class compatibility surface.
 
 use crate::{feature_flags::Feature, support_matrix::FeatureId};
+use std::collections::HashSet;
 
 /// A single link between a support-matrix entry and its runtime feature flags.
 #[derive(Debug, Clone, Copy)]
@@ -103,24 +104,31 @@ impl GovernanceSummary {
     }
 }
 
+fn summarize_governance_from_bindings(
+    support_ids: impl Iterator<Item = FeatureId>,
+    bindings: &[GovernedFeatureBinding],
+) -> GovernanceSummary {
+    let support_id_set: HashSet<_> = support_ids.collect();
+    let bound_support_ids: HashSet<_> = bindings.iter().map(|b| b.support_id).collect();
+
+    let linked_flags = bindings.iter().map(|b| b.feature_flags.len()).sum();
+    let mapped_count = support_id_set.intersection(&bound_support_ids).count();
+
+    GovernanceSummary {
+        total_support_features: support_id_set.len(),
+        mapped_support_features: mapped_count,
+        total_linked_feature_flags: linked_flags,
+    }
+}
+
 /// Summarize governance mapping health for the current set of support and feature entries.
 #[inline]
 #[must_use]
 pub fn summarize_governance() -> GovernanceSummary {
-    let support_count = crate::support_matrix::all_features().len();
-    let mut mapped_count = 0usize;
-    let mut linked_flags = 0usize;
-
-    for binding in &GOVERNANCE_BINDINGS {
-        mapped_count += 1;
-        linked_flags += binding.feature_flags.len();
-    }
-
-    GovernanceSummary {
-        total_support_features: support_count,
-        mapped_support_features: mapped_count,
-        total_linked_feature_flags: linked_flags,
-    }
+    summarize_governance_from_bindings(
+        crate::support_matrix::all_features().iter().map(|f| f.id),
+        &GOVERNANCE_BINDINGS,
+    )
 }
 
 #[cfg(test)]
@@ -264,4 +272,49 @@ mod tests {
         assert!(flags.contains(&Feature::Comp1));
         assert!(flags.contains(&Feature::Comp2));
     }
+
+    #[test]
+    fn test_summarize_governance_ignores_duplicate_bindings_for_mapped_count() {
+        let duplicate_bindings = [
+            GovernedFeatureBinding {
+                support_id: FeatureId::Level88Conditions,
+                feature_flags: &[],
+                rationale: "dup-1",
+            },
+            GovernedFeatureBinding {
+                support_id: FeatureId::Level88Conditions,
+                feature_flags: &[],
+                rationale: "dup-2",
+            },
+        ];
+
+        let summary = summarize_governance_from_bindings(
+            [FeatureId::Level88Conditions, FeatureId::Level66Renames].into_iter(),
+            &duplicate_bindings,
+        );
+
+        assert_eq!(summary.total_support_features, 2);
+        assert_eq!(summary.mapped_support_features, 1);
+        assert!(!summary.all_features_known());
+    }
+
+    #[test]
+    fn test_summarize_governance_excludes_unknown_binding_ids() {
+        let bindings = [GovernedFeatureBinding {
+            support_id: FeatureId::SignSeparate,
+            feature_flags: &SIGN_SEPARATE_MAPPING,
+            rationale: "known",
+        }];
+
+        let summary = summarize_governance_from_bindings(
+            [FeatureId::Level88Conditions, FeatureId::Level66Renames].into_iter(),
+            &bindings,
+        );
+
+        assert_eq!(summary.total_support_features, 2);
+        assert_eq!(summary.mapped_support_features, 0);
+        assert!(!summary.all_features_known());
+        assert_eq!(summary.explicit_bindings(), 1);
+    }
+
 }

--- a/crates/copybook-governance-grid/src/governance_grid.rs
+++ b/crates/copybook-governance-grid/src/governance_grid.rs
@@ -316,5 +316,4 @@ mod tests {
         assert!(!summary.all_features_known());
         assert_eq!(summary.explicit_bindings(), 1);
     }
-
 }

--- a/crates/copybook-rdw/src/lib.rs
+++ b/crates/copybook-rdw/src/lib.rs
@@ -693,6 +693,8 @@ impl<W: Write> RDWRecordWriter<W> {
     #[inline]
     #[must_use = "Handle the Result or propagate the error"]
     pub fn write_record(&mut self, record: &RDWRecord) -> Result<()> {
+        self.validate_record(record)?;
+
         self.output.write_all(&record.header).map_err(|e| {
             Error::new(
                 ErrorCode::CBKF104_RDW_SUSPECT_ASCII,
@@ -727,6 +729,46 @@ impl<W: Write> RDWRecordWriter<W> {
             self.record_count,
             record.payload.len()
         );
+        Ok(())
+    }
+
+    #[inline]
+    fn validate_record(&self, record: &RDWRecord) -> Result<()> {
+        let header_len = usize::from(record.length());
+        let payload_len = record.payload.len();
+
+        if payload_len > RDW_MAX_PAYLOAD_LEN {
+            return Err(Error::new(
+                ErrorCode::CBKF102_RECORD_LENGTH_INVALID,
+                format!(
+                    "RDW payload too large: {payload_len} bytes exceeds maximum of {RDW_MAX_PAYLOAD_LEN}"
+                ),
+            )
+            .with_context(ErrorContext {
+                record_index: Some(self.record_count + 1),
+                field_path: None,
+                byte_offset: None,
+                line_number: None,
+                details: Some("RDW length field is 16-bit".to_string()),
+            }));
+        }
+
+        if header_len != payload_len {
+            return Err(Error::new(
+                ErrorCode::CBKF102_RECORD_LENGTH_INVALID,
+                format!(
+                    "RDW header length mismatch: header declares {header_len} bytes, payload has {payload_len} bytes"
+                ),
+            )
+            .with_context(ErrorContext {
+                record_index: Some(self.record_count + 1),
+                field_path: None,
+                byte_offset: Some(0),
+                line_number: None,
+                details: Some("RDW header length must match payload length before writing".to_string()),
+            }));
+        }
+
         Ok(())
     }
 
@@ -885,6 +927,57 @@ mod tests {
         writer.write_record(&record).unwrap();
         assert_eq!(writer.record_count(), 1);
         assert_eq!(output, vec![0, 4, 0, 0, b't', b'e', b's', b't']);
+    }
+
+    #[test]
+    fn rdw_writer_rejects_header_shorter_than_payload() {
+        let mut output = Vec::new();
+        let mut writer = RDWRecordWriter::new(&mut output);
+        let record = RDWRecord {
+            header: [0, 2, 0, 0],
+            payload: b"toolong".to_vec(),
+        };
+
+        let error = writer.write_record(&record).unwrap_err();
+
+        assert_eq!(error.code, ErrorCode::CBKF102_RECORD_LENGTH_INVALID);
+        assert!(error.message.contains("header declares 2 bytes"));
+        assert_eq!(writer.record_count(), 0);
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn rdw_writer_rejects_header_longer_than_payload() {
+        let mut output = Vec::new();
+        let mut writer = RDWRecordWriter::new(&mut output);
+        let record = RDWRecord {
+            header: [0, 4, 0, 0],
+            payload: b"hi".to_vec(),
+        };
+
+        let error = writer.write_record(&record).unwrap_err();
+
+        assert_eq!(error.code, ErrorCode::CBKF102_RECORD_LENGTH_INVALID);
+        assert!(error.message.contains("payload has 2 bytes"));
+        assert_eq!(writer.record_count(), 0);
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn rdw_writer_rejects_manual_oversize_record() {
+        let mut output = Vec::new();
+        let mut writer = RDWRecordWriter::new(&mut output);
+        let record = RDWRecord {
+            header: [0xFF, 0xFF, 0, 0],
+            payload: vec![0u8; RDW_MAX_PAYLOAD_LEN + 1],
+        };
+
+        let error = writer.write_record(&record).unwrap_err();
+
+        assert_eq!(error.code, ErrorCode::CBKF102_RECORD_LENGTH_INVALID);
+        assert!(error.message.contains("exceeds maximum"));
+        assert_eq!(writer.record_count(), 0);
+        assert!(output.is_empty());
     }
 
     #[test]

--- a/crates/copybook-rs/Cargo.toml
+++ b/crates/copybook-rs/Cargo.toml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+[package]
+name = "copybook-rs"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Search alias for the canonical copybook crate."
+documentation = "https://docs.rs/copybook-rs"
+readme = "README.md"
+keywords = ["copybook", "cobol", "mainframe", "ebcdic", "fixed-width"]
+categories = ["parsing", "encoding", "data-structures"]
+
+# Redirect package only; do not ship unrelated workspace material.
+include = ["src/**", "Cargo.toml", "README.md"]
+
+[package.metadata.docs.rs]
+all-features = false
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+copybook.workspace = true
+
+[lints]
+workspace = true

--- a/crates/copybook-rs/README.md
+++ b/crates/copybook-rs/README.md
@@ -1,0 +1,15 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# copybook-rs
+
+The canonical crate is [`copybook`](https://crates.io/crates/copybook).
+
+This package exists so crates.io searches for the project name `copybook-rs`
+land on the correct project. It is a thin redirect package and does not define
+an independent API surface.
+
+Use `copybook` directly in new projects:
+
+```toml
+[dependencies]
+copybook = "0.4.3"
+```

--- a/crates/copybook-rs/src/lib.rs
+++ b/crates/copybook-rs/src/lib.rs
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#![doc = include_str!("../README.md")]
+#![forbid(unsafe_code)]
+
+pub use copybook::*;

--- a/crates/copybook-safe-text/src/lib.rs
+++ b/crates/copybook-safe-text/src/lib.rs
@@ -6,9 +6,23 @@
 //! be delegated to arithmetic-focused crates.
 
 use copybook_error::{Error, ErrorCode};
+use std::str::FromStr;
 
 /// Result type alias using `copybook-error`.
 pub type Result<T> = std::result::Result<T, Error>;
+
+#[inline]
+fn parse_numeric<T>(s: &str, context: &str, value_kind: &str) -> Result<T>
+where
+    T: FromStr,
+{
+    s.parse().map_err(|_| {
+        Error::new(
+            ErrorCode::CBKP001_SYNTAX,
+            format!("Invalid {value_kind} value '{s}' in {context}"),
+        )
+    })
+}
 
 /// Safely convert a string to `usize`, returning an error on failure.
 ///
@@ -18,12 +32,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[inline]
 #[must_use = "Handle the Result or propagate the error"]
 pub fn parse_usize(s: &str, context: &str) -> Result<usize> {
-    s.parse().map_err(|_| {
-        Error::new(
-            ErrorCode::CBKP001_SYNTAX,
-            format!("Invalid numeric value '{s}' in {context}"),
-        )
-    })
+    parse_numeric(s, context, "numeric")
 }
 
 /// Safely convert a string to `isize`, returning an error on failure.
@@ -34,12 +43,7 @@ pub fn parse_usize(s: &str, context: &str) -> Result<usize> {
 #[inline]
 #[must_use = "Handle the Result or propagate the error"]
 pub fn parse_isize(s: &str, context: &str) -> Result<isize> {
-    s.parse().map_err(|_| {
-        Error::new(
-            ErrorCode::CBKP001_SYNTAX,
-            format!("Invalid signed numeric value '{s}' in {context}"),
-        )
-    })
+    parse_numeric(s, context, "signed numeric")
 }
 
 /// Safely convert `u16` with parse error handling.
@@ -50,15 +54,14 @@ pub fn parse_isize(s: &str, context: &str) -> Result<isize> {
 #[inline]
 #[must_use = "Handle the Result or propagate the error"]
 pub fn safe_parse_u16(s: &str, context: &str) -> Result<u16> {
-    s.parse().map_err(|_| {
-        Error::new(
-            ErrorCode::CBKP001_SYNTAX,
-            format!("Invalid u16 value '{s}' in {context}"),
-        )
-    })
+    parse_numeric(s, context, "u16")
 }
 
 /// Safely access a string character with bounds checking.
+///
+/// The `index` is a Unicode scalar value (Rust `char`) position, not a UTF-8
+/// byte offset. Error messages report the same character length so diagnostics
+/// stay consistent for multibyte text.
 ///
 /// # Errors
 ///
@@ -67,11 +70,11 @@ pub fn safe_parse_u16(s: &str, context: &str) -> Result<u16> {
 #[must_use = "Handle the Result or propagate the error"]
 pub fn safe_string_char_at(s: &str, index: usize, context: &str) -> Result<char> {
     s.chars().nth(index).ok_or_else(|| {
+        let char_len = s.chars().count();
         Error::new(
             ErrorCode::CBKP001_SYNTAX,
             format!(
-                "String character access out of bounds in {context}: index {index} >= length {}",
-                s.len()
+                "String character access out of bounds in {context}: index {index} >= length {char_len}"
             ),
         )
     })

--- a/crates/copybook-safe-text/tests/comprehensive.rs
+++ b/crates/copybook-safe-text/tests/comprehensive.rs
@@ -114,6 +114,34 @@ fn char_at_emoji() {
     assert!(safe_string_char_at(s, 2, "ctx").is_err());
 }
 
+#[test]
+fn char_at_out_of_bounds_reports_character_length_for_multibyte_text() {
+    let err = safe_string_char_at("🦀🐍", 2, "emoji-ctx").unwrap_err();
+
+    assert_eq!(err.code, ErrorCode::CBKP001_SYNTAX);
+    assert!(
+        err.message.contains("emoji-ctx"),
+        "message should include context: {}",
+        err.message
+    );
+    assert!(
+        err.message.contains("index 2 >= length 2"),
+        "message should report character length, not UTF-8 byte length: {}",
+        err.message
+    );
+}
+
+#[test]
+fn char_at_out_of_bounds_reports_character_length_for_mixed_width_text() {
+    let err = safe_string_char_at("Aé日", 3, "mixed-width").unwrap_err();
+
+    assert!(
+        err.message.contains("index 3 >= length 3"),
+        "message should report logical character count: {}",
+        err.message
+    );
+}
+
 // ── safe_write ──────────────────────────────────────────────────────
 
 #[test]

--- a/crates/copybook-support-matrix/src/lib.rs
+++ b/crates/copybook-support-matrix/src/lib.rs
@@ -167,9 +167,9 @@ pub fn find_feature_by_id(id: FeatureId) -> Option<&'static FeatureSupport> {
 #[inline]
 #[must_use]
 pub fn find_feature(id: &str) -> Option<&'static FeatureSupport> {
-    all_features()
-        .iter()
-        .find(|f| serde_plain::to_string(&f.id).ok().as_deref() == Some(id))
+    serde_plain::from_str::<FeatureId>(id)
+        .ok()
+        .and_then(find_feature_by_id)
 }
 
 #[cfg(test)]
@@ -195,6 +195,12 @@ mod tests {
     #[test]
     fn test_find_feature_unknown() {
         let feature = find_feature("no-such-feature");
+        assert!(feature.is_none());
+    }
+
+    #[test]
+    fn test_find_feature_rejects_non_kebab_variant_name() {
+        let feature = find_feature("Level88Conditions");
         assert!(feature.is_none());
     }
 

--- a/crates/copybook/Cargo.toml
+++ b/crates/copybook/Cargo.toml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+[package]
+name = "copybook"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Root facade for the copybook-rs COBOL copybook and mainframe data crate family."
+documentation = "https://docs.rs/copybook"
+readme = "README.md"
+keywords = ["copybook", "cobol", "mainframe", "ebcdic", "fixed-width"]
+categories = ["parsing", "encoding", "data-structures"]
+
+# Keep the root facade tarball focused on the public crate surface.
+include = ["src/**", "Cargo.toml", "README.md"]
+
+[package.metadata.docs.rs]
+all-features = false
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+copybook-charset.workspace = true
+copybook-codec.workspace = true
+copybook-codepage.workspace = true
+copybook-contracts.workspace = true
+copybook-core.workspace = true
+copybook-determinism.workspace = true
+copybook-error.workspace = true
+copybook-error-reporter.workspace = true
+copybook-fixed.workspace = true
+copybook-governance-contracts.workspace = true
+copybook-options.workspace = true
+copybook-overflow.workspace = true
+copybook-overpunch.workspace = true
+copybook-rdw.workspace = true
+copybook-record-io.workspace = true
+copybook-support-matrix.workspace = true
+copybook-utils.workspace = true
+
+[lints]
+workspace = true

--- a/crates/copybook/README.md
+++ b/crates/copybook/README.md
@@ -1,0 +1,46 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# copybook
+
+`copybook` is the canonical crates.io entrypoint for the
+[`copybook-rs`](https://github.com/EffortlessMetrics/copybook-rs) project.
+
+`copybook-rs` is an existing Rust crate family for COBOL copybook and mainframe
+data tooling. The component crates remain available for users who want narrow
+dependencies. This root crate provides a convenient facade over the public
+component crates.
+
+## Facade Modules
+
+The facade keeps the public surface module-shaped and explicit:
+
+```rust
+use copybook::codec;
+use copybook::core;
+use copybook::error;
+```
+
+Each module re-exports the corresponding published component crate:
+
+| Module | Component crate |
+| --- | --- |
+| `charset` | `copybook-charset` |
+| `codec` | `copybook-codec` |
+| `codepage` | `copybook-codepage` |
+| `contracts` | `copybook-contracts` |
+| `core` | `copybook-core` |
+| `determinism` | `copybook-determinism` |
+| `error` | `copybook-error` |
+| `error_reporter` | `copybook-error-reporter` |
+| `fixed` | `copybook-fixed` |
+| `governance_contracts` | `copybook-governance-contracts` |
+| `options` | `copybook-options` |
+| `overflow` | `copybook-overflow` |
+| `overpunch` | `copybook-overpunch` |
+| `rdw` | `copybook-rdw` |
+| `record_io` | `copybook-record-io` |
+| `support_matrix` | `copybook-support-matrix` |
+| `utils` | `copybook-utils` |
+
+Use the component crates directly when you need the smallest possible dependency
+surface. Use `copybook` when you want the canonical project entrypoint and a
+single dependency over the public crate family.

--- a/crates/copybook/src/lib.rs
+++ b/crates/copybook/src/lib.rs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#![doc = include_str!("../README.md")]
+#![forbid(unsafe_code)]
+
+/// Character set conversion utilities for EBCDIC and ASCII data.
+pub mod charset {
+    pub use copybook_charset::*;
+}
+
+/// High-level record encode/decode workflows.
+pub mod codec {
+    pub use copybook_codec::*;
+}
+
+/// Codepage and unmappable-character policy types.
+pub mod codepage {
+    pub use copybook_codepage::*;
+}
+
+/// Shared feature-flag governance contracts.
+pub mod contracts {
+    pub use copybook_contracts::*;
+}
+
+/// COBOL copybook parsing, schema, and validation primitives.
+pub mod core {
+    pub use copybook_core::*;
+}
+
+/// Determinism primitives for stable hash and diff comparison.
+pub mod determinism {
+    pub use copybook_determinism::*;
+}
+
+/// Error types and taxonomy.
+pub mod error {
+    pub use copybook_error::*;
+}
+
+/// Structured error reporting policies and summaries.
+pub mod error_reporter {
+    pub use copybook_error_reporter::*;
+}
+
+/// Fixed-length record framing primitives.
+pub mod fixed {
+    pub use copybook_fixed::*;
+}
+
+/// Governance interoperability contracts.
+pub mod governance_contracts {
+    pub use copybook_governance_contracts::*;
+}
+
+/// Configuration option contracts shared across codec workflows.
+pub mod options {
+    pub use copybook_options::*;
+}
+
+/// Overflow-safe integer narrowing and bounds arithmetic.
+pub mod overflow {
+    pub use copybook_overflow::*;
+}
+
+/// Zoned decimal overpunch encode/decode primitives.
+pub mod overpunch {
+    pub use copybook_overpunch::*;
+}
+
+/// RDW framing primitives.
+pub mod rdw {
+    pub use copybook_rdw::*;
+}
+
+/// Record-format dispatch across fixed and RDW framing.
+pub mod record_io {
+    pub use copybook_record_io::*;
+}
+
+/// COBOL feature support matrix contracts.
+pub mod support_matrix {
+    pub use copybook_support_matrix::*;
+}
+
+/// Panic-safe utility functions and extension traits.
+pub mod utils {
+    pub use copybook_utils::*;
+}

--- a/tools/copybook-bench/src/regression.rs
+++ b/tools/copybook-bench/src/regression.rs
@@ -1364,8 +1364,7 @@ impl CiIntegrator {
                     .throughput_changes
                     .iter()
                     .find(|c| c.metric_name.contains("display"))
-                    .map(|c| c.change_percent)
-                    .unwrap_or(0.0);
+                    .map_or(0.0, |c| c.change_percent);
                 (change, gate.threshold.max_regression_percent)
             }
             GateMetricType::Comp3Throughput => {
@@ -1374,8 +1373,7 @@ impl CiIntegrator {
                     .throughput_changes
                     .iter()
                     .find(|c| c.metric_name.contains("comp3"))
-                    .map(|c| c.change_percent)
-                    .unwrap_or(0.0);
+                    .map_or(0.0, |c| c.change_percent);
                 (change, gate.threshold.max_regression_percent)
             }
             _ => (0.0, gate.threshold.max_regression_percent), // Simplified
@@ -1582,9 +1580,7 @@ mod num_cpus {
 #[cfg(not(test))]
 mod num_cpus {
     pub fn get() -> usize {
-        std::thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(4)
+        std::thread::available_parallelism().map_or(4, |n| n.get())
     }
 }
 

--- a/tools/copybook-bench/src/regression.rs
+++ b/tools/copybook-bench/src/regression.rs
@@ -795,10 +795,24 @@ impl PerformanceRegressionDetector {
             .filter(|change| matches!(change.change_direction, ChangeDirection::Degradation))
             .map(|change| change.change_percent)
             .fold(0.0f64, f64::max);
+        let max_improvement = comparison
+            .throughput_changes
+            .iter()
+            .chain(comparison.memory_changes.iter())
+            .chain(comparison.latency_changes.iter())
+            .filter(|change| matches!(change.change_direction, ChangeDirection::Improvement))
+            .map(|change| change.change_percent)
+            .fold(0.0f64, f64::max);
 
         let is_significant = tests.t_test_result.significant;
 
-        if max_degradation < 2.0 || !is_significant {
+        if !is_significant {
+            Ok(RegressionStatus::NoRegression)
+        } else if max_improvement >= 2.0 && max_degradation < 2.0 {
+            Ok(RegressionStatus::Improvement {
+                magnitude: max_improvement,
+            })
+        } else if max_degradation < 2.0 {
             Ok(RegressionStatus::NoRegression)
         } else if max_degradation < 5.0 {
             Ok(RegressionStatus::MinorRegression {
@@ -1760,6 +1774,136 @@ mod tests {
             .run_statistical_tests(&baseline_metrics, &current_metrics)
             .unwrap();
         assert!(statistical_tests.t_test_result.degrees_of_freedom > 0);
+    }
+
+    fn statistical_test_results(significant: bool) -> StatisticalTestResults {
+        StatisticalTestResults {
+            t_test_result: TTestResult {
+                statistic: if significant { 4.0 } else { 0.5 },
+                p_value: if significant { 0.01 } else { 0.50 },
+                degrees_of_freedom: 98,
+                significant,
+            },
+            mann_whitney_u_result: MannWhitneyResult {
+                u_statistic: 1200.0,
+                p_value: if significant { 0.03 } else { 0.50 },
+                significant,
+            },
+            effect_size: EffectSize {
+                cohens_d: if significant { 0.8 } else { 0.1 },
+                glass_delta: if significant { 0.8 } else { 0.1 },
+                hedges_g: if significant { 0.79 } else { 0.1 },
+                interpretation: if significant {
+                    EffectSizeInterpretation::Large
+                } else {
+                    EffectSizeInterpretation::Negligible
+                },
+            },
+            power_analysis: PowerAnalysisResult {
+                power: 0.9,
+                required_sample_size: 64,
+                adequate_power: true,
+            },
+        }
+    }
+
+    #[test]
+    fn test_determine_regression_status_detects_improvement() {
+        let detector = PerformanceRegressionDetector::new();
+        let comparison = MetricsComparison {
+            throughput_changes: vec![MetricChange {
+                metric_name: "display_throughput_mean".to_string(),
+                baseline_value: 100.0,
+                current_value: 110.0,
+                change_percent: 10.0,
+                change_direction: ChangeDirection::Improvement,
+                statistical_significance: true,
+            }],
+            memory_changes: vec![MetricChange {
+                metric_name: "peak_memory_mb".to_string(),
+                baseline_value: 100.0,
+                current_value: 98.5,
+                change_percent: 1.5,
+                change_direction: ChangeDirection::Neutral,
+                statistical_significance: false,
+            }],
+            latency_changes: vec![MetricChange {
+                metric_name: "p95_latency_ms".to_string(),
+                baseline_value: 10.0,
+                current_value: 9.8,
+                change_percent: 2.0,
+                change_direction: ChangeDirection::Neutral,
+                statistical_significance: false,
+            }],
+            overall_change_percent: 4.5,
+        };
+        let tests = statistical_test_results(true);
+
+        let status = detector
+            .determine_regression_status(&comparison, &tests)
+            .unwrap();
+        match status {
+            RegressionStatus::Improvement { magnitude } => {
+                assert_eq!(magnitude, 10.0);
+            }
+            _ => panic!("Expected improvement status"),
+        }
+    }
+
+    #[test]
+    fn test_determine_regression_status_ignores_non_significant_improvement() {
+        let detector = PerformanceRegressionDetector::new();
+        let comparison = MetricsComparison {
+            throughput_changes: vec![MetricChange {
+                metric_name: "display_throughput_mean".to_string(),
+                baseline_value: 100.0,
+                current_value: 110.0,
+                change_percent: 10.0,
+                change_direction: ChangeDirection::Improvement,
+                statistical_significance: false,
+            }],
+            memory_changes: vec![],
+            latency_changes: vec![],
+            overall_change_percent: 10.0,
+        };
+        let tests = statistical_test_results(false);
+
+        let status = detector
+            .determine_regression_status(&comparison, &tests)
+            .unwrap();
+
+        assert!(matches!(status, RegressionStatus::NoRegression));
+    }
+
+    #[test]
+    fn test_determine_regression_status_prefers_regression_when_present() {
+        let detector = PerformanceRegressionDetector::new();
+        let comparison = MetricsComparison {
+            throughput_changes: vec![MetricChange {
+                metric_name: "display_throughput_mean".to_string(),
+                baseline_value: 100.0,
+                current_value: 95.0,
+                change_percent: 5.0,
+                change_direction: ChangeDirection::Degradation,
+                statistical_significance: true,
+            }],
+            memory_changes: vec![MetricChange {
+                metric_name: "peak_memory_mb".to_string(),
+                baseline_value: 100.0,
+                current_value: 90.0,
+                change_percent: 10.0,
+                change_direction: ChangeDirection::Improvement,
+                statistical_significance: true,
+            }],
+            latency_changes: vec![],
+            overall_change_percent: 7.5,
+        };
+        let tests = statistical_test_results(true);
+
+        let status = detector
+            .determine_regression_status(&comparison, &tests)
+            .unwrap();
+        assert!(matches!(status, RegressionStatus::MajorRegression { .. }));
     }
 
     #[test]

--- a/tools/copybook-bench/src/reporting.rs
+++ b/tools/copybook-bench/src/reporting.rs
@@ -51,6 +51,11 @@ impl PerformanceReport {
 
     /// Validate against SLO thresholds
     pub fn validate_slos(&mut self, display_slo: f64, comp3_slo: f64) {
+        // Recompute validation from current metrics each time to keep behavior idempotent.
+        self.status = default_status();
+        self.warnings.clear();
+        self.errors.clear();
+
         if let Some(display) = self.display_gibs {
             if display < display_slo {
                 self.status = "failure".to_string();
@@ -144,6 +149,25 @@ mod tests {
         report.validate_slos(4.1, 560.0);
         assert_eq!(report.status, "failure");
         assert!(!report.errors.is_empty());
+    }
+
+    #[test]
+    fn test_slo_validation_recomputes_without_stale_messages() {
+        let mut report = PerformanceReport::new();
+        report.display_gibs = Some(3.0);
+        report.comp3_mibs = Some(500.0);
+
+        report.validate_slos(4.1, 560.0);
+        assert_eq!(report.status, "failure");
+        assert!(!report.errors.is_empty());
+
+        report.display_gibs = Some(5.0);
+        report.comp3_mibs = Some(700.0);
+        report.validate_slos(4.1, 560.0);
+
+        assert_eq!(report.status, "success");
+        assert!(report.errors.is_empty());
+        assert!(report.warnings.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Governance summary coverage should count unique support features that are actually present in the support matrix.
- Duplicate bindings and stale binding IDs should not inflate `mapped_support_features` or make `all_features_known()` look complete.

### Description
- Summarize governance coverage from support ID and binding sets.
- Count mapped support features as the intersection of known support IDs and bound support IDs.
- Preserve `total_linked_feature_flags` as the explicit feature-flag binding count.
- Add unit coverage for duplicate binding IDs and stale/unknown binding IDs.

### Testing
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 test -p copybook-governance-grid`
- `cargo +1.95.0 clippy -p copybook-governance-grid --all-targets -- -D warnings`