### PR TITLE
fix(codec): resolve and encode tail ODO arrays

### DIFF
--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -1947,31 +1947,37 @@ fn validate_lib_api_odo_encoding(
     }
 
     if let Some(array) = json_lookup_array(fields_value, &tail_odo.array_path) {
-        let array_field = schema.find_field(&tail_odo.array_path).ok_or_else(|| {
-            Error::new(
-                ErrorCode::CBKS121_COUNTER_NOT_FOUND,
-                format!(
-                    "ODO array field '{}' not found in schema",
-                    tail_odo.array_path
-                ),
-            )
-            .with_context(crate::odo_redefines::create_comprehensive_error_context(
-                0,
-                &tail_odo.array_path,
-                0,
-                None,
-            ))
-        })?;
+        let array_field =
+            crate::odo_redefines::find_field_by_path_or_unique_name(schema, &tail_odo.array_path)
+                .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::CBKS121_COUNTER_NOT_FOUND,
+                    format!(
+                        "ODO array field '{}' not found in schema",
+                        tail_odo.array_path
+                    ),
+                )
+                .with_context(
+                    crate::odo_redefines::create_comprehensive_error_context(
+                        0,
+                        &tail_odo.array_path,
+                        0,
+                        None,
+                    ),
+                )
+            })?;
 
-        let counter_field = schema.find_field(&tail_odo.counter_path).ok_or_else(|| {
-            crate::odo_redefines::handle_missing_counter_field(
-                &tail_odo.counter_path,
-                &tail_odo.array_path,
-                schema,
-                0,
-                0,
-            )
-        })?;
+        let counter_field =
+            crate::odo_redefines::find_field_by_path_or_unique_name(schema, &tail_odo.counter_path)
+                .ok_or_else(|| {
+                    crate::odo_redefines::handle_missing_counter_field(
+                        &tail_odo.counter_path,
+                        &tail_odo.array_path,
+                        schema,
+                        0,
+                        0,
+                    )
+                })?;
 
         if json_lookup_value(fields_value, &tail_odo.counter_path).is_none() {
             return Err(crate::odo_redefines::handle_missing_counter_field(

--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -2359,14 +2359,7 @@ fn encode_occurs_field(
         return Ok(current_offset + allocation_len);
     };
 
-    validate_occurs_array_len(
-        array.len(),
-        occurs,
-        field,
-        field_path,
-        current_offset,
-        options,
-    )?;
+    validate_occurs_array_len(array.len(), occurs, field)?;
 
     for (index, element) in array.iter().enumerate() {
         let element_offset = current_offset + index * element_len;
@@ -2395,9 +2388,6 @@ fn validate_occurs_array_len(
     actual_len: usize,
     occurs: &copybook_core::Occurs,
     field: &copybook_core::Field,
-    field_path: &str,
-    current_offset: usize,
-    options: &EncodeOptions,
 ) -> Result<()> {
     match occurs {
         copybook_core::Occurs::Fixed { count } if actual_len != *count as usize => Err(Error::new(
@@ -2409,20 +2399,15 @@ fn validate_occurs_array_len(
         )
         .with_field(field.path.clone())),
         copybook_core::Occurs::Fixed { .. } => Ok(()),
-        copybook_core::Occurs::ODO {
-            min,
-            max,
-            counter_path,
-        } => {
-            let context = crate::odo_redefines::OdoValidationContext {
-                field_path: field_path.to_string(),
-                counter_path: counter_path.clone(),
-                record_index: 0,
-                byte_offset: current_offset as u64,
-            };
-            crate::odo_redefines::validate_odo_encode(actual_len, *min, *max, &context, options)
-                .map(|_| ())
-        }
+        copybook_core::Occurs::ODO { max, .. } if actual_len > *max as usize => Err(Error::new(
+            ErrorCode::CBKE521_ARRAY_LEN_OOB,
+            format!(
+                "Array length {} exceeds ODO max {} for field '{}'",
+                actual_len, max, field.path
+            ),
+        )
+        .with_field(field.path.clone())),
+        copybook_core::Occurs::ODO { .. } => Ok(()),
     }
 }
 

--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -2398,7 +2398,6 @@ fn validate_occurs_array_len(
             ),
         )
         .with_field(field.path.clone())),
-        copybook_core::Occurs::Fixed { .. } => Ok(()),
         copybook_core::Occurs::ODO { max, .. } if actual_len > *max as usize => Err(Error::new(
             ErrorCode::CBKE521_ARRAY_LEN_OOB,
             format!(
@@ -2407,7 +2406,7 @@ fn validate_occurs_array_len(
             ),
         )
         .with_field(field.path.clone())),
-        copybook_core::Occurs::ODO { .. } => Ok(()),
+        copybook_core::Occurs::Fixed { .. } | copybook_core::Occurs::ODO { .. } => Ok(()),
     }
 }
 

--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -2440,38 +2440,35 @@ fn encode_occurs_element(
     let mut element_field = field.clone();
     element_field.occurs = None;
 
-    match &field.kind {
-        FieldKind::Group => {
-            let element_obj = element.as_object().ok_or_else(|| {
-                Error::new(
-                    ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
-                    format!("Expected object element for OCCURS group '{}'", field.path),
-                )
-                .with_field(field.path.clone())
-            })?;
-            encode_fields_recursive(
-                &element_field.children,
-                element_obj,
-                encoding_metadata,
-                field_path,
-                buffer,
-                element_offset,
-                options,
-            )?;
-        }
-        _ => {
-            let mut element_obj = serde_json::Map::new();
-            element_obj.insert(field.name.clone(), element.clone());
-            encode_single_field(
-                &element_field,
-                field_path,
-                &element_obj,
-                encoding_metadata,
-                buffer,
-                element_offset,
-                options,
-            )?;
-        }
+    if let FieldKind::Group = &field.kind {
+        let element_obj = element.as_object().ok_or_else(|| {
+            Error::new(
+                ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
+                format!("Expected object element for OCCURS group '{}'", field.path),
+            )
+            .with_field(field.path.clone())
+        })?;
+        encode_fields_recursive(
+            &element_field.children,
+            element_obj,
+            encoding_metadata,
+            field_path,
+            buffer,
+            element_offset,
+            options,
+        )?;
+    } else {
+        let mut element_obj = serde_json::Map::new();
+        element_obj.insert(field.name.clone(), element.clone());
+        encode_single_field(
+            &element_field,
+            field_path,
+            &element_obj,
+            encoding_metadata,
+            buffer,
+            element_offset,
+            options,
+        )?;
     }
 
     Ok(())

--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -1946,10 +1946,9 @@ fn validate_lib_api_odo_encoding(
         return Ok(());
     }
 
-    if let Some(array) = json_lookup_array(fields_value, &tail_odo.array_path) {
-        let array_field =
-            crate::odo_redefines::find_field_by_path_or_unique_name(schema, &tail_odo.array_path)
-                .ok_or_else(|| {
+    let array_field =
+        crate::odo_redefines::find_field_by_path_or_unique_name(schema, &tail_odo.array_path)
+            .ok_or_else(|| {
                 Error::new(
                     ErrorCode::CBKS121_COUNTER_NOT_FOUND,
                     format!(
@@ -1967,22 +1966,28 @@ fn validate_lib_api_odo_encoding(
                 )
             })?;
 
-        let counter_field =
-            crate::odo_redefines::find_field_by_path_or_unique_name(schema, &tail_odo.counter_path)
-                .ok_or_else(|| {
-                    crate::odo_redefines::handle_missing_counter_field(
-                        &tail_odo.counter_path,
-                        &tail_odo.array_path,
-                        schema,
-                        0,
-                        0,
-                    )
-                })?;
+    let counter_field =
+        crate::odo_redefines::find_field_by_path_or_unique_name(schema, &tail_odo.counter_path)
+            .ok_or_else(|| {
+                crate::odo_redefines::handle_missing_counter_field(
+                    &tail_odo.counter_path,
+                    &tail_odo.array_path,
+                    schema,
+                    0,
+                    0,
+                )
+            })?;
 
-        if json_lookup_value(fields_value, &tail_odo.counter_path).is_none() {
+    if let Some(array) = json_lookup_array(fields_value, &array_field.path)
+        .or_else(|| json_lookup_array(fields_value, &tail_odo.array_path))
+    {
+        if json_lookup_value(fields_value, &counter_field.path)
+            .or_else(|| json_lookup_value(fields_value, &tail_odo.counter_path))
+            .is_none()
+        {
             return Err(crate::odo_redefines::handle_missing_counter_field(
-                &tail_odo.counter_path,
-                &tail_odo.array_path,
+                &counter_field.path,
+                &array_field.path,
                 schema,
                 0,
                 u64::from(counter_field.offset),
@@ -1990,8 +1995,8 @@ fn validate_lib_api_odo_encoding(
         }
 
         let context = crate::odo_redefines::OdoValidationContext {
-            field_path: tail_odo.array_path.clone(),
-            counter_path: tail_odo.counter_path.clone(),
+            field_path: array_field.path.clone(),
+            counter_path: counter_field.path.clone(),
             record_index: 0,
             byte_offset: u64::from(array_field.offset),
         };
@@ -2009,6 +2014,13 @@ fn validate_lib_api_odo_encoding(
 }
 
 fn json_lookup_value<'a>(value: &'a Value, field_path: &str) -> Option<&'a Value> {
+    json_lookup_exact_value(value, field_path).or_else(|| {
+        let (_, path_without_root) = field_path.split_once('.')?;
+        json_lookup_exact_value(value, path_without_root)
+    })
+}
+
+fn json_lookup_exact_value<'a>(value: &'a Value, field_path: &str) -> Option<&'a Value> {
     let mut current = value;
     for segment in field_path.split('.') {
         current = current.as_object()?.get(segment)?;
@@ -2110,6 +2122,19 @@ fn encode_single_field(
     options: &EncodeOptions,
 ) -> Result<usize> {
     use copybook_core::FieldKind;
+
+    if let Some(occurs) = &field.occurs {
+        return encode_occurs_field(
+            field,
+            occurs,
+            field_path,
+            json_obj,
+            encoding_metadata,
+            buffer,
+            current_offset,
+            options,
+        );
+    }
 
     match &field.kind {
         FieldKind::Group => encode_group_field(
@@ -2311,6 +2336,145 @@ fn encode_single_field(
             Ok(current_offset + field_len)
         }
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn encode_occurs_field(
+    field: &copybook_core::Field,
+    occurs: &copybook_core::Occurs,
+    field_path: &str,
+    json_obj: &serde_json::Map<String, Value>,
+    encoding_metadata: Option<&serde_json::Map<String, Value>>,
+    buffer: &mut [u8],
+    current_offset: usize,
+    options: &EncodeOptions,
+) -> Result<usize> {
+    let max_count = occurs_max_count(occurs);
+    let element_len = field.len as usize;
+    let allocation_len = element_len
+        .checked_mul(max_count as usize)
+        .ok_or_else(|| Error::new(ErrorCode::CBKS141_RECORD_TOO_LARGE, "OCCURS size overflow"))?;
+
+    let Some(array) = json_obj.get(&field.name).and_then(Value::as_array) else {
+        return Ok(current_offset + allocation_len);
+    };
+
+    validate_occurs_array_len(
+        array.len(),
+        occurs,
+        field,
+        field_path,
+        current_offset,
+        options,
+    )?;
+
+    for (index, element) in array.iter().enumerate() {
+        let element_offset = current_offset + index * element_len;
+        encode_occurs_element(
+            field,
+            field_path,
+            element,
+            encoding_metadata,
+            buffer,
+            element_offset,
+            options,
+        )?;
+    }
+
+    Ok(current_offset + allocation_len)
+}
+
+fn occurs_max_count(occurs: &copybook_core::Occurs) -> u32 {
+    match occurs {
+        copybook_core::Occurs::Fixed { count } => *count,
+        copybook_core::Occurs::ODO { max, .. } => *max,
+    }
+}
+
+fn validate_occurs_array_len(
+    actual_len: usize,
+    occurs: &copybook_core::Occurs,
+    field: &copybook_core::Field,
+    field_path: &str,
+    current_offset: usize,
+    options: &EncodeOptions,
+) -> Result<()> {
+    match occurs {
+        copybook_core::Occurs::Fixed { count } if actual_len != *count as usize => Err(Error::new(
+            ErrorCode::CBKE521_ARRAY_LEN_OOB,
+            format!(
+                "Array length {} doesn't match fixed OCCURS count {} for field '{}'",
+                actual_len, count, field.path
+            ),
+        )
+        .with_field(field.path.clone())),
+        copybook_core::Occurs::Fixed { .. } => Ok(()),
+        copybook_core::Occurs::ODO {
+            min,
+            max,
+            counter_path,
+        } => {
+            let context = crate::odo_redefines::OdoValidationContext {
+                field_path: field_path.to_string(),
+                counter_path: counter_path.clone(),
+                record_index: 0,
+                byte_offset: current_offset as u64,
+            };
+            crate::odo_redefines::validate_odo_encode(actual_len, *min, *max, &context, options)
+                .map(|_| ())
+        }
+    }
+}
+
+fn encode_occurs_element(
+    field: &copybook_core::Field,
+    field_path: &str,
+    element: &Value,
+    encoding_metadata: Option<&serde_json::Map<String, Value>>,
+    buffer: &mut [u8],
+    element_offset: usize,
+    options: &EncodeOptions,
+) -> Result<()> {
+    use copybook_core::FieldKind;
+
+    let mut element_field = field.clone();
+    element_field.occurs = None;
+
+    match &field.kind {
+        FieldKind::Group => {
+            let element_obj = element.as_object().ok_or_else(|| {
+                Error::new(
+                    ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
+                    format!("Expected object element for OCCURS group '{}'", field.path),
+                )
+                .with_field(field.path.clone())
+            })?;
+            encode_fields_recursive(
+                &element_field.children,
+                element_obj,
+                encoding_metadata,
+                field_path,
+                buffer,
+                element_offset,
+                options,
+            )?;
+        }
+        _ => {
+            let mut element_obj = serde_json::Map::new();
+            element_obj.insert(field.name.clone(), element.clone());
+            encode_single_field(
+                &element_field,
+                field_path,
+                &element_obj,
+                encoding_metadata,
+                buffer,
+                element_offset,
+                options,
+            )?;
+        }
+    }
+
+    Ok(())
 }
 
 /// Recursively encode a group field and its children.

--- a/crates/copybook-codec/src/odo_redefines.rs
+++ b/crates/copybook-codec/src/odo_redefines.rs
@@ -660,6 +660,59 @@ mod tests {
         schema
     }
 
+    fn alphanum_field(path: &str, name: &str, offset: u32) -> Field {
+        Field {
+            path: path.to_string(),
+            name: name.to_string(),
+            level: 5,
+            kind: FieldKind::Alphanum { len: 1 },
+            offset,
+            len: 1,
+            redefines_of: None,
+            occurs: None,
+            sync_padding: None,
+            synchronized: false,
+            blank_when_zero: false,
+            resolved_renames: None,
+            children: vec![],
+        }
+    }
+
+    #[test]
+    fn test_find_field_by_path_or_unique_name_prefers_exact_path() {
+        let mut schema = Schema::new();
+        schema.fields = vec![
+            alphanum_field("ROOT.LEFT.ITEM", "ITEM", 0),
+            alphanum_field("ROOT.RIGHT.ITEM", "ITEM", 1),
+        ];
+
+        let field = find_field_by_path_or_unique_name(&schema, "ROOT.RIGHT.ITEM")
+            .expect("exact path should resolve even when leaf names are duplicated");
+
+        assert_eq!(field.path, "ROOT.RIGHT.ITEM");
+    }
+
+    #[test]
+    fn test_find_field_by_path_or_unique_name_resolves_unique_leaf() {
+        let schema = create_test_schema_with_odo();
+
+        let field = find_field_by_path_or_unique_name(&schema, "ARRAY")
+            .expect("unique short ODO array name should resolve");
+
+        assert_eq!(field.path, "ROOT.ARRAY");
+    }
+
+    #[test]
+    fn test_find_field_by_path_or_unique_name_rejects_ambiguous_leaf() {
+        let mut schema = Schema::new();
+        schema.fields = vec![
+            alphanum_field("ROOT.LEFT.ITEM", "ITEM", 0),
+            alphanum_field("ROOT.RIGHT.ITEM", "ITEM", 1),
+        ];
+
+        assert!(find_field_by_path_or_unique_name(&schema, "ITEM").is_none());
+    }
+
     #[test]
     fn test_odo_validation_within_bounds() -> TestResult {
         let result = validate_odo_counter(3, 0, 5, "ROOT.ARRAY", "ROOT.COUNTER", 1, 3, false)?;

--- a/crates/copybook-codec/src/odo_redefines.rs
+++ b/crates/copybook-codec/src/odo_redefines.rs
@@ -13,6 +13,35 @@ use serde_json::Value;
 use std::collections::HashMap;
 use tracing::{debug, warn};
 
+/// Resolve a schema field by exact path first, then by unique field name.
+///
+/// Tail-ODO metadata may store short names (for example `ARRAY`) while other
+/// subsystems require canonical schema paths (for example `RECORD.ARRAY`).
+/// This helper keeps lookup strict by allowing the name fallback only when it
+/// resolves to exactly one field in the schema.
+#[must_use]
+pub fn find_field_by_path_or_unique_name<'a>(
+    schema: &'a Schema,
+    path_or_name: &str,
+) -> Option<&'a Field> {
+    if let Some(field) = schema.find_field(path_or_name) {
+        return Some(field);
+    }
+
+    let target_name = path_or_name.rsplit('.').next().unwrap_or(path_or_name);
+    let mut matches = schema
+        .all_fields()
+        .into_iter()
+        .filter(|field| field.name.eq_ignore_ascii_case(target_name));
+
+    let first_match = matches.next()?;
+    if matches.next().is_some() {
+        return None;
+    }
+
+    Some(first_match)
+}
+
 /// ODO validation result
 #[derive(Debug, Clone)]
 pub struct OdoValidationResult {

--- a/crates/copybook-codec/src/processor.rs
+++ b/crates/copybook-codec/src/processor.rs
@@ -1124,12 +1124,11 @@ impl EncodeProcessor {
                 json_value
             };
 
-            if let Some(array) = json_lookup_array(fields_object, &tail_odo.array_path) {
-                let array_field =
-                    crate::odo_redefines::find_field_by_path_or_unique_name(
-                        schema,
-                        &tail_odo.array_path,
-                    )
+            let array_field =
+                crate::odo_redefines::find_field_by_path_or_unique_name(
+                    schema,
+                    &tail_odo.array_path,
+                )
                     .ok_or_else(|| {
                     Error::new(
                         ErrorCode::CBKS121_COUNTER_NOT_FOUND,
@@ -1148,11 +1147,11 @@ impl EncodeProcessor {
                     )
                     })?;
 
-                let counter_field =
-                    crate::odo_redefines::find_field_by_path_or_unique_name(
-                        schema,
-                        &tail_odo.counter_path,
-                    )
+            let counter_field =
+                crate::odo_redefines::find_field_by_path_or_unique_name(
+                    schema,
+                    &tail_odo.counter_path,
+                )
                     .ok_or_else(|| {
                         crate::odo_redefines::handle_missing_counter_field(
                             &tail_odo.counter_path,
@@ -1163,10 +1162,16 @@ impl EncodeProcessor {
                         )
                     })?;
 
-                if json_lookup_value(fields_object, &tail_odo.counter_path).is_none() {
+            if let Some(array) = json_lookup_array(fields_object, &array_field.path)
+                .or_else(|| json_lookup_array(fields_object, &tail_odo.array_path))
+            {
+                if json_lookup_value(fields_object, &counter_field.path)
+                    .or_else(|| json_lookup_value(fields_object, &tail_odo.counter_path))
+                    .is_none()
+                {
                     return Err(crate::odo_redefines::handle_missing_counter_field(
-                        &tail_odo.counter_path,
-                        &tail_odo.array_path,
+                        &counter_field.path,
+                        &array_field.path,
                         schema,
                         record_index,
                         counter_field.offset as u64,
@@ -1174,8 +1179,8 @@ impl EncodeProcessor {
                 }
 
                 let validation_context = crate::odo_redefines::OdoValidationContext {
-                    field_path: tail_odo.array_path.clone(),
-                    counter_path: tail_odo.counter_path.clone(),
+                    field_path: array_field.path.clone(),
+                    counter_path: counter_field.path.clone(),
                     record_index,
                     byte_offset: array_field.offset as u64,
                 };
@@ -1192,9 +1197,19 @@ impl EncodeProcessor {
         }
 
         Ok(())
-    }
+}
 
 fn json_lookup_value(value: &serde_json::Value, field_path: &str) -> Option<&serde_json::Value> {
+    json_lookup_exact_value(value, field_path).or_else(|| {
+        let (_, path_without_root) = field_path.split_once('.')?;
+        json_lookup_exact_value(value, path_without_root)
+    })
+}
+
+fn json_lookup_exact_value(
+    value: &serde_json::Value,
+    field_path: &str,
+) -> Option<&serde_json::Value> {
     let mut current = value;
     for segment in field_path.split('.') {
         current = current.as_object()?.get(segment)?;

--- a/crates/copybook-codec/src/processor.rs
+++ b/crates/copybook-codec/src/processor.rs
@@ -1125,7 +1125,12 @@ impl EncodeProcessor {
             };
 
             if let Some(array) = json_lookup_array(fields_object, &tail_odo.array_path) {
-                let array_field = schema.find_field(&tail_odo.array_path).ok_or_else(|| {
+                let array_field =
+                    crate::odo_redefines::find_field_by_path_or_unique_name(
+                        schema,
+                        &tail_odo.array_path,
+                    )
+                    .ok_or_else(|| {
                     Error::new(
                         ErrorCode::CBKS121_COUNTER_NOT_FOUND,
                         format!(
@@ -1141,17 +1146,22 @@ impl EncodeProcessor {
                             None,
                         ),
                     )
-                })?;
+                    })?;
 
-                let counter_field = schema.find_field(&tail_odo.counter_path).ok_or_else(|| {
-                    crate::odo_redefines::handle_missing_counter_field(
-                        &tail_odo.counter_path,
-                        &tail_odo.array_path,
+                let counter_field =
+                    crate::odo_redefines::find_field_by_path_or_unique_name(
                         schema,
-                        record_index,
-                        0,
+                        &tail_odo.counter_path,
                     )
-                })?;
+                    .ok_or_else(|| {
+                        crate::odo_redefines::handle_missing_counter_field(
+                            &tail_odo.counter_path,
+                            &tail_odo.array_path,
+                            schema,
+                            record_index,
+                            0,
+                        )
+                    })?;
 
                 if json_lookup_value(fields_object, &tail_odo.counter_path).is_none() {
                     return Err(crate::odo_redefines::handle_missing_counter_field(

--- a/crates/copybook-codec/tests/occurs_codec.rs
+++ b/crates/copybook-codec/tests/occurs_codec.rs
@@ -14,9 +14,9 @@
 //! 9. Determinism: same input → same output
 //! 10. Dialect: zero-tolerant ODO behavior
 //!
-//! Note: `lib_api::encode_record` does not dispatch on `field.occurs`, so
-//! OCCURS arrays are silently skipped during encoding. Encode tests here are
-//! limited to ODO validation which fires before field-level encoding.
+//! Direct `lib_api::encode_record` dispatches on `field.occurs`; encode tests
+//! here focus on ODO validation, with byte-level array encode coverage in the
+//! dedicated ODO and property-test suites.
 
 use copybook_codec::{
     Codepage, DecodeOptions, EncodeOptions, JsonNumberMode, RecordFormat, decode_record,

--- a/crates/copybook-codec/tests/odo_comprehensive.rs
+++ b/crates/copybook-codec/tests/odo_comprehensive.rs
@@ -125,6 +125,43 @@ fn test_valid_odo_configuration() {
 }
 
 #[test]
+fn test_nested_tail_odo_encode_uses_schema_path_resolution() {
+    let copybook = r#"
+01 RECORD-LAYOUT.
+   05 HEADER.
+      10 ITEM-COUNT PIC 9(2).
+   05 DETAIL.
+      10 ITEMS OCCURS 1 TO 5 TIMES DEPENDING ON ITEM-COUNT.
+         15 ITEM-CODE PIC X(2).
+"#;
+
+    let schema = parse_copybook(copybook).unwrap();
+    let payload = json!({
+        "HEADER": { "ITEM-COUNT": "02" },
+        "DETAIL": {
+            "ITEMS": [
+                { "ITEM-CODE": "A1" },
+                { "ITEM-CODE": "B2" }
+            ]
+        }
+    });
+
+    let options = EncodeOptions::new()
+        .with_format(RecordFormat::Fixed)
+        .with_codepage(Codepage::ASCII);
+
+    let encoded = copybook_codec::encode_record(&schema, &payload, &options)
+        .expect("nested ODO encode should resolve schema paths from tail metadata");
+
+    assert_eq!(&encoded[..2], b"02");
+    assert_eq!(&encoded[2..6], b"A1B2");
+    assert_eq!(
+        encoded.len(),
+        usize::try_from(schema.lrecl_fixed.unwrap()).unwrap()
+    );
+}
+
+#[test]
 fn test_odo_strict_mode_clamp_fatal() {
     let copybook = r#"
 01 RECORD-LAYOUT.
@@ -191,13 +228,10 @@ fn test_odo_lenient_mode_clamp_with_warning() {
     // Counter value exceeds maximum (005 > 3)
     let test_data = b"005ITEM1     ITEM2     ITEM3     ";
     // Lenient mode should clamp and continue with a warning
-    let result = copybook_codec::decode_record(&schema, test_data, &options);
-    assert!(result.is_ok());
-
-    match result {
-        Err(error) => assert_eq!(error.code, ErrorCode::CBKS301_ODO_CLIPPED),
-        Ok(_) => panic!("expected error"),
-    }
+    let decoded =
+        copybook_codec::decode_record(&schema, test_data, &options).expect("lenient decode ok");
+    let items = decoded["ITEMS"].as_array().expect("ITEMS array");
+    assert_eq!(items.len(), 3);
 }
 
 #[test]
@@ -229,13 +263,10 @@ fn test_odo_lenient_mode_raise_to_minimum() {
     // Counter value below minimum (001 < 2)
     let test_data = b"001ITEM1     ITEM2     ";
     // Lenient mode should clamp and continue with a warning
-    let result = copybook_codec::decode_record(&schema, test_data, &options);
-    assert!(result.is_ok());
-
-    match result {
-        Err(error) => assert_eq!(error.code, ErrorCode::CBKS302_ODO_RAISED),
-        Ok(_) => panic!("expected error"),
-    }
+    let decoded =
+        copybook_codec::decode_record(&schema, test_data, &options).expect("lenient decode ok");
+    let items = decoded["ITEMS"].as_array().expect("ITEMS array");
+    assert_eq!(items.len(), 2);
 }
 
 #[test]

--- a/tests/proptest/arrays.rs
+++ b/tests/proptest/arrays.rs
@@ -464,7 +464,6 @@ proptest! {
 }
 
 /// Property: OCCURS with DEPENDING ON respects the count field
-/// FIXME: tail_odo.array_path stores field name but encode calls find_field() which expects full path
 proptest! {
     #![proptest_config(ProptestConfig {
         cases: QUICK_CASES,
@@ -472,7 +471,6 @@ proptest! {
     })]
 
     #[test]
-    #[ignore = "tail_odo.array_path stores name not full path; encode find_field fails"]
     fn prop_odo_respects_count_field(
         count_value in 1usize..=10,
         max_count in 10usize..=20,


### PR DESCRIPTION
### Motivation
- Tail ODO metadata stores short field names while encode-time validation needs canonical schema paths.
- Nested ODO payloads can omit the top-level record qualifier, so validation needs to resolve schema paths without accepting arbitrary suffix matches.
- The direct `encode_record` path was validating ODO arrays but not writing OCCURS array element bytes.

### Description
- Add a shared tail-ODO schema resolver that matches exact paths first and falls back only to a unique field-name match.
- Use resolved schema paths for lib API and streaming encode validation, with JSON lookup that tolerates an omitted leading record name plus the existing short-name fallback.
- Teach direct `encode_record` to encode scalar and group OCCURS elements across the allocated record area while preserving dialect-adjusted ODO lower bounds.
- Re-enable `prop_odo_respects_count_field`, add a byte-level nested tail ODO encode regression, and correct contradictory lenient-mode ODO assertions.

### Testing
- `cargo +1.95.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.95.0 test -p copybook-codec --test occurs_codec`
- `cargo +1.95.0 test -p copybook-codec --features comprehensive-tests --test odo_comprehensive`
- `cargo +1.95.0 test -p copybook-codec --lib`
- `cargo +1.95.0 test -p copybook-e2e --test e2e_dialect_integration dialect_encode_respects_bounds -- --nocapture`
- `cargo +1.95.0 test -p copybook-proptest arrays::prop_odo_respects_count_field`
- `cargo +1.95.0 clippy -p copybook-codec --features comprehensive-tests --all-targets -- -D warnings`