### PR TITLE
Add governed Clippy policy infrastructure (MSRV 1.93, ledgered lints, xtask gate)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+[alias]
+xtask = "run --package xtask --"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -32,7 +32,7 @@ body:
     attributes:
       label: Rust Version
       description: Which version of Rust are you using?
-      placeholder: e.g., 1.92.0
+      placeholder: e.g., 1.93.0
     validations:
       required: true
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -56,7 +56,7 @@
 - [ ] `cargo test --workspace` passes (or `cargo nextest run --workspace`)
 - [ ] `bash scripts/ci/governance-bdd-smoke.sh` passes (if governance or BDD touched)
 - [ ] Follows [conventional commit format](https://www.conventionalcommits.org/) (e.g., `feat(core):`, `fix(codec):`)
-- [ ] MSRV compliance (Rust 1.92+) verified if dependencies changed
+- [ ] MSRV compliance (Rust 1.93+) verified if dependencies changed
 - [ ] Golden fixtures updated if applicable
 
 ## Testing Instructions

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,7 +46,7 @@ Use the structured error taxonomy with stable codes:
 ### Code Style
 - **No Unsafe**: Do not introduce `unsafe` blocks in public APIs.
 - **Clippy Pedantic**: Code must pass `clippy::pedantic`.
-- **MSRV**: Rust 1.92+.
+- **MSRV**: Rust 1.93+.
 
 ### Feature Specifics
 - **Dialects**: Respect `Dialect` enum (Normative, ZeroTolerant, OneTolerant) for ODO `min_count` handling.

--- a/.github/workflows/ci-fuzz.yml
+++ b/.github/workflows/ci-fuzz.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.92.0"
+          toolchain: "1.93.0"
 
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci-mutants.yml
+++ b/.github/workflows/ci-mutants.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.92.0"
+          toolchain: "1.93.0"
 
       - name: Cache cargo artifacts
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,18 @@ jobs:
     - name: Check formatting
       run: cargo fmt --all -- --check
 
+  lint-policy:
+    name: Lint Policy
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: 1.93.0
+    - uses: Swatinem/rust-cache@v2
+    - name: Verify lint policy ledgers
+      run: cargo xtask check-lint-policy
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
@@ -69,7 +81,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         rust:
-          - 1.92.0  # MSRV
+          - 1.93.0  # MSRV
           - stable
           - beta
         features: ["", "comp3_fast", "audit"]
@@ -222,7 +234,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: 1.92.0
+        toolchain: 1.93.0
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/determinism-smoke.yml
+++ b/.github/workflows/determinism-smoke.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.92.0
+          toolchain: 1.93.0
 
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/perf-bench.yml
+++ b/.github/workflows/perf-bench.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.92.0 # MSRV
+          toolchain: 1.93.0 # MSRV
           components: rustfmt, clippy
 
       - name: Cache cargo

--- a/.github/workflows/perf-validation.yml
+++ b/.github/workflows/perf-validation.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.92.0"
+          toolchain: "1.93.0"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pr-bench-comment.yml
+++ b/.github/workflows/pr-bench-comment.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.92.0 # MSRV
+          toolchain: 1.93.0 # MSRV
           components: rustfmt, clippy
 
       - name: Cache cargo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4842,6 +4842,7 @@ dependencies = [
  "serde_json",
  "serde_plain",
  "tempfile",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ resolver = "2"
 [workspace.package]
 version = "0.4.3"
 edition = "2024"
-rust-version = "1.92" # MSRV (validated in .github/workflows/ci.yml)
+rust-version = "1.93" # MSRV (validated in .github/workflows/ci.yml and policy/clippy-lints.toml)
 license = "AGPL-3.0-or-later"
 authors = ["Steven Zimmerman, CPA <git@effortlesssteven.com>"]
 repository = "https://github.com/EffortlessMetrics/copybook-rs"
@@ -169,22 +169,124 @@ panic = "unwind"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"
+unsafe_op_in_unsafe_fn = "deny"
+unused_must_use = "deny"
+unexpected_cfgs = "warn"
+const_item_interior_mutations = "deny"
+function_casts_as_integer = "deny"
 
 [workspace.lints.clippy]
-# Panic prevention lints (warn to allow test code to use unwrap/expect/panic)
-unwrap_used = "warn"
-expect_used = "warn"
-panic = "warn"
-unreachable = "warn"
-todo = "warn"
-unimplemented = "warn"
+# Panic-free production and tests
+dbg_macro = "deny"
+todo = "deny"
+unimplemented = "deny"
+panic = "deny"
+unreachable = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
+get_unwrap = "deny"
+unwrap_in_result = "deny"
+panic_in_result_fn = "deny"
+string_slice = "deny"
+indexing_slicing = "deny"
+out_of_bounds_indexing = "deny"
+unchecked_time_subtraction = "deny"
 
-# Debug cruft prevention (no dbg! in shipped code; tests are allowed via CI)
-dbg_macro = "warn"
+# AST / parser / UTF-8 / slice safety
+char_indices_as_byte_indices = "deny"
+sliced_string_as_bytes = "deny"
+index_refutable_slice = "deny"
 
-# Performance lints
-missing_inline_in_public_items = "warn"
-cast_lossless = "allow"
-cast_possible_truncation = "allow"
-cast_precision_loss = "allow"
-cast_sign_loss = "allow"
+# Silent failure
+let_underscore_future = "deny"
+let_underscore_must_use = "deny"
+let_underscore_lock = "deny"
+unused_result_ok = "deny"
+map_err_ignore = "deny"
+assertions_on_result_states = "deny"
+lines_filter_map_ok = "deny"
+
+# Async / concurrency
+await_holding_lock = "deny"
+await_holding_refcell_ref = "deny"
+await_holding_invalid_type = "deny"
+future_not_send = "warn"
+large_futures = "warn"
+arc_with_non_send_sync = "deny"
+rc_mutex = "deny"
+mut_mutex_lock = "deny"
+readonly_write_lock = "deny"
+
+# Unsafe / memory
+mem_forget = "deny"
+forget_non_drop = "deny"
+drop_non_drop = "deny"
+undocumented_unsafe_blocks = "deny"
+multiple_unsafe_ops_per_block = "deny"
+repr_packed_without_abi = "deny"
+
+# Numeric correctness
+float_cmp = "deny"
+float_cmp_const = "deny"
+float_equality_without_abs = "deny"
+lossy_float_literal = "deny"
+cast_sign_loss = "deny"
+cast_possible_wrap = "warn"
+cast_possible_truncation = "warn"
+cast_precision_loss = "warn"
+invalid_upcast_comparisons = "deny"
+cast_abs_to_unsigned = "deny"
+cast_enum_truncation = "deny"
+cast_nan_to_int = "deny"
+manual_midpoint = "warn"
+manual_is_multiple_of = "warn"
+manual_div_ceil = "warn"
+arithmetic_side_effects = "warn"
+
+# File/process/path footguns
+suspicious_open_options = "deny"
+nonsensical_open_options = "deny"
+ineffective_open_options = "deny"
+path_buf_push_overwrite = "deny"
+join_absolute_paths = "deny"
+read_line_without_trim = "warn"
+exit = "deny"
+
+# API / trait correctness
+iter_not_returning_iterator = "deny"
+expl_impl_clone_on_copy = "deny"
+infallible_try_from = "deny"
+fallible_impl_from = "deny"
+error_impl_error = "deny"
+result_unit_err = "warn"
+result_large_err = "warn"
+
+# Good taste that pays rent
+format_in_format_args = "deny"
+to_string_in_format_args = "deny"
+unused_format_specs = "deny"
+unnecessary_debug_formatting = "warn"
+uninlined_format_args = "warn"
+manual_let_else = "warn"
+manual_ok_or = "warn"
+manual_strip = "warn"
+manual_split_once = "warn"
+manual_is_variant_and = "warn"
+filter_map_next = "warn"
+flat_map_option = "warn"
+match_result_ok = "deny"
+cloned_instead_of_copied = "warn"
+iter_cloned_collect = "warn"
+iter_overeager_cloned = "warn"
+needless_collect = "warn"
+redundant_closure = "warn"
+redundant_closure_for_method_calls = "warn"
+missing_panics_doc = "deny"
+missing_errors_doc = "warn"
+
+# Suppression governance
+allow_attributes = "deny"
+allow_attributes_without_reason = "deny"
+blanket_clippy_restriction_lints = "deny"
+ignore_without_reason = "deny"
+should_panic_without_expect = "deny"

--- a/clippy.toml
+++ b/clippy.toml
@@ -15,13 +15,10 @@ pass-by-value-size-limit = 256
 
 # Safety and correctness
 avoid-breaking-exported-api = true
-allow-expect-in-tests = true
-allow-unwrap-in-tests = true
-allow-panic-in-tests = true
 
 # Code style preferences
 allow-one-hash-in-raw-strings = true
 
 # Enterprise patterns
 max-suggested-slice-pattern-length = 3
-msrv = "1.92"
+msrv = "1.93"

--- a/docs/CI_GATING_POLICY.md
+++ b/docs/CI_GATING_POLICY.md
@@ -38,7 +38,7 @@ The PR lane runs on every pull request to `main` and `develop` branches. All job
 #### `test` Job
 - Runs `cargo nextest run --workspace --exclude copybook-bench --profile ci`
 - Runs on Ubuntu, macOS, and Windows
-- Tests against MSRV (1.92.0), stable, and beta Rust versions
+- Tests against MSRV (1.93.0), stable, and beta Rust versions
 - Tests with various feature combinations
 
 #### `proptest-smoke` Job

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -1,0 +1,98 @@
+# Effortless Metrics Clippy Policy
+
+copybook-rs follows the shared Effortless Metrics Rust lint posture: one
+workspace-level baseline, no test carveouts, and every temporary exception
+represented as policy data instead of hidden configuration drift.
+
+## Goals
+
+- Keep production and test code panic-free by denying `unwrap`, `expect`,
+  `panic!`, `todo!`, `unimplemented!`, `unreachable!`, unchecked indexing, and
+  string slicing at the workspace boundary.
+- Prevent silent failure by denying ignored futures, ignored must-use values,
+  ignored locks, ignored `Result::ok`, ignored `map_err`, and result-state
+  assertions that do not observe the error payload.
+- Make suppression explicit: do not use broad `#[allow]` attributes. Use a
+  narrow `#[expect(..., reason = "...")]` only when a reviewed local exception
+  is better than weakening policy for the whole workspace.
+- Track future Clippy flips for Rust 1.94 and 1.95 before the MSRV bump so the
+  upgrade is a planned ratchet instead of surprise churn.
+
+## Source of truth
+
+The root `Cargo.toml` contains the active compiler and Clippy lint block. The
+machine-readable ledger lives in `policy/clippy-lints.toml` and must match the
+active block exactly for current lints. Planned lints remain in the ledger with
+`status = "planned"` and `activate_when_msrv` until the workspace MSRV reaches
+that release.
+
+Temporary exceptions belong in `policy/clippy-debt.toml`. Debt entries must have
+all of these fields:
+
+- `lint`
+- `path`
+- `owner`
+- `reason`
+- `expires`
+
+Expired debt fails the policy gate.
+
+## No test carveouts
+
+`clippy.toml` must not contain any of Clippy's test carveout settings, including:
+
+- `allow-unwrap-in-tests`
+- `allow-expect-in-tests`
+- `allow-panic-in-tests`
+- `allow-indexing-slicing-in-tests`
+- `allow-dbg-in-tests`
+
+Tests should return `Result` and use explicit assertion helpers instead of
+panic-driven setup.
+
+```rust
+#[test]
+fn parses_fixture() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = std::fs::read_to_string("tests/fixtures/input.cpy")?;
+    let parsed = parse_copybook(&fixture)?;
+
+    assert_eq!(parsed.records().len(), 3, "fixture should expose three records");
+    Ok(())
+}
+```
+
+## Suppression style
+
+Use `#[expect]` instead of `#[allow]` so suppressions are self-expiring when the
+lint no longer triggers. Every expectation must include a reason.
+
+```rust
+#[expect(
+    clippy::indexing_slicing,
+    reason = "Generated parser table access is guarded by table-shape tests."
+)]
+fn generated_table_lookup(table: &[u8], index: usize) -> u8 {
+    table[index]
+}
+```
+
+If the exception is expected to live beyond the local change, add it to
+`policy/clippy-debt.toml` with an owner and expiry.
+
+## Parser/protocol overlay
+
+copybook-rs is a parser/protocol workspace. The shared baseline is intentionally
+strict around UTF-8, string boundaries, indexing, unreachable states, and numeric
+casts. Those lints catch the local bad shapes most likely to become parsing bugs,
+fixture-only assumptions, or mainframe encoding edge cases.
+
+## Policy gate
+
+Run the policy gate with:
+
+```sh
+cargo xtask check-lint-policy
+```
+
+The gate verifies the MSRV ledger, workspace lint inheritance, active/planned
+lint consistency, absence of test carveouts, and debt metadata.

--- a/docs/FUZZING.md
+++ b/docs/FUZZING.md
@@ -101,7 +101,7 @@ Tests the record I/O dispatch microcrate with various inputs including:
 
 ### Prerequisites
 
-1. Install Rust (1.92.0 or later)
+1. Install Rust (1.93.0 or later)
 2. Install cargo-fuzz:
    ```bash
    cargo install cargo-fuzz --version 0.13.4
@@ -358,7 +358,7 @@ Add to this document's "Fuzz Targets" section.
 Ensure you have the correct Rust version and cargo-fuzz installed:
 
 ```bash
-rustc --version  # Should be 1.92.0 or later
+rustc --version  # Should be 1.93.0 or later
 cargo install cargo-fuzz --version 0.13.4
 ```
 

--- a/docs/REPORT.md
+++ b/docs/REPORT.md
@@ -180,7 +180,7 @@ parse, codec, and structural validation. See
 
 ### Code Quality
 
-- Rust Edition 2024 with MSRV 1.92 (aligned with CI test matrix)
+- Rust Edition 2024 with MSRV 1.93 (aligned with CI test matrix)
 - Clippy pedantic compliance enforced (complete compliance achieved)
 - Comprehensive error handling with structured error taxonomy
 - Idiomatic Rust patterns throughout codebase

--- a/docs/VALIDATION_PROTOCOL.md
+++ b/docs/VALIDATION_PROTOCOL.md
@@ -229,7 +229,7 @@ Compare to tool output in summary.
 
 ### Test failures in `xtask`
 - **Check**: Did you run `cargo fmt` first?
-- **Check**: Are you using Rust 1.92+ (MSRV)?
+- **Check**: Are you using Rust 1.93+ (MSRV)?
 - **Debug**: Run individual tests: `cargo test -p xtask perf::tests::test_name -- --nocapture`
 
 ---

--- a/docs/perf/CONTAINER_IMPLEMENTATION.md
+++ b/docs/perf/CONTAINER_IMPLEMENTATION.md
@@ -13,8 +13,8 @@ This document describes the implementation of the copybook-rs benchmark containe
 
 ### 1. Dockerfile (`/Dockerfile`)
 
-**Base Image**: `rust:1.89-bookworm`
-- Matches MSRV (Rust 1.92)
+**Base Image**: `rust:1.93-bookworm`
+- Matches MSRV (Rust 1.93)
 - Debian Bookworm base for compatibility
 - Full Rust toolchain for `cargo bench` execution
 
@@ -60,7 +60,7 @@ This document describes the implementation of the copybook-rs benchmark containe
 ```
 ==> copybook-rs benchmark container
 ==> Commit: abc1234
-==> Rustc: rustc 1.92.0 (...)
+==> Rustc: rustc 1.93.0 (...)
 ==> CPU: AMD Ryzen 9 9950X3D
 ==> Cores: 32
 
@@ -141,7 +141,7 @@ DISPLAY: 205.0 MiB/s (SLO 80 MiB/s, +156.2%) | COMP-3: 58.0 MiB/s (SLO 40 MiB/s,
 
 ### Why MSRV vs Latest?
 
-**Decision**: Use `rust:1.89-bookworm` (matches MSRV)
+**Decision**: Use `rust:1.93-bookworm` (matches MSRV)
 
 **Rationale**:
 - Ensures compatibility with minimum supported version

--- a/docs/perf/OPERATOR_RUNBOOK.md
+++ b/docs/perf/OPERATOR_RUNBOOK.md
@@ -17,7 +17,7 @@ The copybook-rs benchmark container provides a **reproducible, isolated environm
 - Performance validation before production deployment
 
 **Container Contents**:
-- Rust 1.92 toolchain (matches MSRV)
+- Rust 1.93 toolchain (matches MSRV)
 - Pre-built copybook-bench crate with criterion benchmarks
 - Performance measurement scripts (bench.sh, perf-annotate-host.sh)
 - Runtime dependencies (Python 3, jq, git, time)

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -13,7 +13,7 @@ In this tutorial, you'll learn how to:
 
 ## Prerequisites
 
-- Rust 1.92+ installed
+- Rust 1.93+ installed
 - Basic understanding of COBOL data structures
 - Sample COBOL copybook and data files
 

--- a/policy/clippy-debt.toml
+++ b/policy/clippy-debt.toml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+schema = 1
+
+# Temporary lint exceptions belong here instead of weakening Cargo.toml or clippy.toml.
+# Each entry must include lint, path, owner, reason, and expires.

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,0 +1,800 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+schema = 1
+msrv = "1.93"
+
+[policy]
+panic_free_tests = true
+allow_test_carveouts = false
+suppression_style = "expect-with-reason"
+blanket_categories = false
+
+# Active lints must match the root Cargo.toml workspace lint block.
+
+[[lint]]
+name = "unsafe_code"
+level = "forbid"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep unsafe and memory-sensitive behavior explicit and reviewable."
+
+[[lint]]
+name = "unsafe_op_in_unsafe_fn"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep unsafe and memory-sensitive behavior explicit and reviewable."
+
+[[lint]]
+name = "unused_must_use"
+level = "deny"
+status = "active"
+class = "baseline"
+reason = "Shared workspace lint policy baseline."
+
+[[lint]]
+name = "unexpected_cfgs"
+level = "warn"
+status = "active"
+class = "baseline"
+reason = "Shared workspace lint policy baseline."
+
+[[lint]]
+name = "const_item_interior_mutations"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep unsafe and memory-sensitive behavior explicit and reviewable."
+
+[[lint]]
+name = "function_casts_as_integer"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep unsafe and memory-sensitive behavior explicit and reviewable."
+
+[[lint]]
+name = "clippy::dbg_macro"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and tests panic-free; failures should propagate as errors or structured assertions."
+
+[[lint]]
+name = "clippy::todo"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and tests panic-free; failures should propagate as errors or structured assertions."
+
+[[lint]]
+name = "clippy::unimplemented"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and tests panic-free; failures should propagate as errors or structured assertions."
+
+[[lint]]
+name = "clippy::panic"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and tests panic-free; failures should propagate as errors or structured assertions."
+
+[[lint]]
+name = "clippy::unreachable"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and tests panic-free; failures should propagate as errors or structured assertions."
+
+[[lint]]
+name = "clippy::unwrap_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and tests panic-free; failures should propagate as errors or structured assertions."
+
+[[lint]]
+name = "clippy::expect_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and tests panic-free; failures should propagate as errors or structured assertions."
+
+[[lint]]
+name = "clippy::get_unwrap"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and tests panic-free; failures should propagate as errors or structured assertions."
+
+[[lint]]
+name = "clippy::unwrap_in_result"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and tests panic-free; failures should propagate as errors or structured assertions."
+
+[[lint]]
+name = "clippy::panic_in_result_fn"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and tests panic-free; failures should propagate as errors or structured assertions."
+
+[[lint]]
+name = "clippy::string_slice"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and tests panic-free; failures should propagate as errors or structured assertions."
+
+[[lint]]
+name = "clippy::indexing_slicing"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and tests panic-free; failures should propagate as errors or structured assertions."
+
+[[lint]]
+name = "clippy::out_of_bounds_indexing"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and tests panic-free; failures should propagate as errors or structured assertions."
+
+[[lint]]
+name = "clippy::unchecked_time_subtraction"
+level = "deny"
+status = "active"
+class = "parser-ast"
+reason = "Protect parser, UTF-8, string, and slice boundaries."
+
+[[lint]]
+name = "clippy::char_indices_as_byte_indices"
+level = "deny"
+status = "active"
+class = "parser-ast"
+reason = "Protect parser, UTF-8, string, and slice boundaries."
+
+[[lint]]
+name = "clippy::sliced_string_as_bytes"
+level = "deny"
+status = "active"
+class = "parser-ast"
+reason = "Protect parser, UTF-8, string, and slice boundaries."
+
+[[lint]]
+name = "clippy::index_refutable_slice"
+level = "deny"
+status = "active"
+class = "parser-ast"
+reason = "Protect parser, UTF-8, string, and slice boundaries."
+
+[[lint]]
+name = "clippy::let_underscore_future"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Prevent dropped futures, locks, Results, and ignored error paths."
+
+[[lint]]
+name = "clippy::let_underscore_must_use"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Prevent dropped futures, locks, Results, and ignored error paths."
+
+[[lint]]
+name = "clippy::let_underscore_lock"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Prevent dropped futures, locks, Results, and ignored error paths."
+
+[[lint]]
+name = "clippy::unused_result_ok"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Prevent dropped futures, locks, Results, and ignored error paths."
+
+[[lint]]
+name = "clippy::map_err_ignore"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Prevent dropped futures, locks, Results, and ignored error paths."
+
+[[lint]]
+name = "clippy::assertions_on_result_states"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Prevent dropped futures, locks, Results, and ignored error paths."
+
+[[lint]]
+name = "clippy::lines_filter_map_ok"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Prevent dropped futures, locks, Results, and ignored error paths."
+
+[[lint]]
+name = "clippy::await_holding_lock"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Catch async and synchronization footguns before they reach runtime."
+
+[[lint]]
+name = "clippy::await_holding_refcell_ref"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Catch async and synchronization footguns before they reach runtime."
+
+[[lint]]
+name = "clippy::await_holding_invalid_type"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Catch async and synchronization footguns before they reach runtime."
+
+[[lint]]
+name = "clippy::future_not_send"
+level = "warn"
+status = "active"
+class = "async-concurrency"
+reason = "Catch async and synchronization footguns before they reach runtime."
+
+[[lint]]
+name = "clippy::large_futures"
+level = "warn"
+status = "active"
+class = "async-concurrency"
+reason = "Catch async and synchronization footguns before they reach runtime."
+
+[[lint]]
+name = "clippy::arc_with_non_send_sync"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Catch async and synchronization footguns before they reach runtime."
+
+[[lint]]
+name = "clippy::rc_mutex"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Catch async and synchronization footguns before they reach runtime."
+
+[[lint]]
+name = "clippy::mut_mutex_lock"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Catch async and synchronization footguns before they reach runtime."
+
+[[lint]]
+name = "clippy::readonly_write_lock"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Catch async and synchronization footguns before they reach runtime."
+
+[[lint]]
+name = "clippy::mem_forget"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep unsafe and memory-sensitive behavior explicit and reviewable."
+
+[[lint]]
+name = "clippy::forget_non_drop"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep unsafe and memory-sensitive behavior explicit and reviewable."
+
+[[lint]]
+name = "clippy::drop_non_drop"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep unsafe and memory-sensitive behavior explicit and reviewable."
+
+[[lint]]
+name = "clippy::undocumented_unsafe_blocks"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Catch async and synchronization footguns before they reach runtime."
+
+[[lint]]
+name = "clippy::multiple_unsafe_ops_per_block"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Catch async and synchronization footguns before they reach runtime."
+
+[[lint]]
+name = "clippy::repr_packed_without_abi"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep unsafe and memory-sensitive behavior explicit and reviewable."
+
+[[lint]]
+name = "clippy::float_cmp"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Make numeric conversions and arithmetic risks visible in parser/protocol code."
+
+[[lint]]
+name = "clippy::float_cmp_const"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Make numeric conversions and arithmetic risks visible in parser/protocol code."
+
+[[lint]]
+name = "clippy::float_equality_without_abs"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Make numeric conversions and arithmetic risks visible in parser/protocol code."
+
+[[lint]]
+name = "clippy::lossy_float_literal"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Make numeric conversions and arithmetic risks visible in parser/protocol code."
+
+[[lint]]
+name = "clippy::cast_sign_loss"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Make numeric conversions and arithmetic risks visible in parser/protocol code."
+
+[[lint]]
+name = "clippy::cast_possible_wrap"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Make numeric conversions and arithmetic risks visible in parser/protocol code."
+
+[[lint]]
+name = "clippy::cast_possible_truncation"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Make numeric conversions and arithmetic risks visible in parser/protocol code."
+
+[[lint]]
+name = "clippy::cast_precision_loss"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Make numeric conversions and arithmetic risks visible in parser/protocol code."
+
+[[lint]]
+name = "clippy::invalid_upcast_comparisons"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Make numeric conversions and arithmetic risks visible in parser/protocol code."
+
+[[lint]]
+name = "clippy::cast_abs_to_unsigned"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Make numeric conversions and arithmetic risks visible in parser/protocol code."
+
+[[lint]]
+name = "clippy::cast_enum_truncation"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Make numeric conversions and arithmetic risks visible in parser/protocol code."
+
+[[lint]]
+name = "clippy::cast_nan_to_int"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Make numeric conversions and arithmetic risks visible in parser/protocol code."
+
+[[lint]]
+name = "clippy::manual_midpoint"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Make numeric conversions and arithmetic risks visible in parser/protocol code."
+
+[[lint]]
+name = "clippy::manual_is_multiple_of"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Make numeric conversions and arithmetic risks visible in parser/protocol code."
+
+[[lint]]
+name = "clippy::manual_div_ceil"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Make numeric conversions and arithmetic risks visible in parser/protocol code."
+
+[[lint]]
+name = "clippy::arithmetic_side_effects"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Make numeric conversions and arithmetic risks visible in parser/protocol code."
+
+[[lint]]
+name = "clippy::suspicious_open_options"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Avoid CLI, file, path, and process footguns at boundary surfaces."
+
+[[lint]]
+name = "clippy::nonsensical_open_options"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Avoid CLI, file, path, and process footguns at boundary surfaces."
+
+[[lint]]
+name = "clippy::ineffective_open_options"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Avoid CLI, file, path, and process footguns at boundary surfaces."
+
+[[lint]]
+name = "clippy::path_buf_push_overwrite"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Avoid CLI, file, path, and process footguns at boundary surfaces."
+
+[[lint]]
+name = "clippy::join_absolute_paths"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Avoid CLI, file, path, and process footguns at boundary surfaces."
+
+[[lint]]
+name = "clippy::read_line_without_trim"
+level = "warn"
+status = "active"
+class = "filesystem-process"
+reason = "Avoid CLI, file, path, and process footguns at boundary surfaces."
+
+[[lint]]
+name = "clippy::exit"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Avoid CLI, file, path, and process footguns at boundary surfaces."
+
+[[lint]]
+name = "clippy::iter_not_returning_iterator"
+level = "deny"
+status = "active"
+class = "api-trait"
+reason = "Keep public API and trait behavior idiomatic and predictable."
+
+[[lint]]
+name = "clippy::expl_impl_clone_on_copy"
+level = "deny"
+status = "active"
+class = "api-trait"
+reason = "Keep public API and trait behavior idiomatic and predictable."
+
+[[lint]]
+name = "clippy::infallible_try_from"
+level = "deny"
+status = "active"
+class = "api-trait"
+reason = "Keep public API and trait behavior idiomatic and predictable."
+
+[[lint]]
+name = "clippy::fallible_impl_from"
+level = "deny"
+status = "active"
+class = "api-trait"
+reason = "Keep public API and trait behavior idiomatic and predictable."
+
+[[lint]]
+name = "clippy::error_impl_error"
+level = "deny"
+status = "active"
+class = "api-trait"
+reason = "Keep public API and trait behavior idiomatic and predictable."
+
+[[lint]]
+name = "clippy::result_unit_err"
+level = "warn"
+status = "active"
+class = "api-trait"
+reason = "Keep public API and trait behavior idiomatic and predictable."
+
+[[lint]]
+name = "clippy::result_large_err"
+level = "warn"
+status = "active"
+class = "api-trait"
+reason = "Keep public API and trait behavior idiomatic and predictable."
+
+[[lint]]
+name = "clippy::format_in_format_args"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Reduce noisy patterns and make control-flow, allocation, and contracts easier to review."
+
+[[lint]]
+name = "clippy::to_string_in_format_args"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Reduce noisy patterns and make control-flow, allocation, and contracts easier to review."
+
+[[lint]]
+name = "clippy::unused_format_specs"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Reduce noisy patterns and make control-flow, allocation, and contracts easier to review."
+
+[[lint]]
+name = "clippy::unnecessary_debug_formatting"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Reduce noisy patterns and make control-flow, allocation, and contracts easier to review."
+
+[[lint]]
+name = "clippy::uninlined_format_args"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Reduce noisy patterns and make control-flow, allocation, and contracts easier to review."
+
+[[lint]]
+name = "clippy::manual_let_else"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Reduce noisy patterns and make control-flow, allocation, and contracts easier to review."
+
+[[lint]]
+name = "clippy::manual_ok_or"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Reduce noisy patterns and make control-flow, allocation, and contracts easier to review."
+
+[[lint]]
+name = "clippy::manual_strip"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Reduce noisy patterns and make control-flow, allocation, and contracts easier to review."
+
+[[lint]]
+name = "clippy::manual_split_once"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Reduce noisy patterns and make control-flow, allocation, and contracts easier to review."
+
+[[lint]]
+name = "clippy::manual_is_variant_and"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Reduce noisy patterns and make control-flow, allocation, and contracts easier to review."
+
+[[lint]]
+name = "clippy::filter_map_next"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Reduce noisy patterns and make control-flow, allocation, and contracts easier to review."
+
+[[lint]]
+name = "clippy::flat_map_option"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Reduce noisy patterns and make control-flow, allocation, and contracts easier to review."
+
+[[lint]]
+name = "clippy::match_result_ok"
+level = "deny"
+status = "active"
+class = "api-trait"
+reason = "Keep public API and trait behavior idiomatic and predictable."
+
+[[lint]]
+name = "clippy::cloned_instead_of_copied"
+level = "warn"
+status = "active"
+class = "api-trait"
+reason = "Keep public API and trait behavior idiomatic and predictable."
+
+[[lint]]
+name = "clippy::iter_cloned_collect"
+level = "warn"
+status = "active"
+class = "api-trait"
+reason = "Keep public API and trait behavior idiomatic and predictable."
+
+[[lint]]
+name = "clippy::iter_overeager_cloned"
+level = "warn"
+status = "active"
+class = "api-trait"
+reason = "Keep public API and trait behavior idiomatic and predictable."
+
+[[lint]]
+name = "clippy::needless_collect"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Reduce noisy patterns and make control-flow, allocation, and contracts easier to review."
+
+[[lint]]
+name = "clippy::redundant_closure"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Reduce noisy patterns and make control-flow, allocation, and contracts easier to review."
+
+[[lint]]
+name = "clippy::redundant_closure_for_method_calls"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Reduce noisy patterns and make control-flow, allocation, and contracts easier to review."
+
+[[lint]]
+name = "clippy::missing_panics_doc"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and tests panic-free; failures should propagate as errors or structured assertions."
+
+[[lint]]
+name = "clippy::missing_errors_doc"
+level = "warn"
+status = "active"
+class = "api-trait"
+reason = "Keep public API and trait behavior idiomatic and predictable."
+
+[[lint]]
+name = "clippy::allow_attributes"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Require narrow, reviewable suppressions with explicit reasons instead of silent broad allows."
+
+[[lint]]
+name = "clippy::allow_attributes_without_reason"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Require narrow, reviewable suppressions with explicit reasons instead of silent broad allows."
+
+[[lint]]
+name = "clippy::blanket_clippy_restriction_lints"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Require narrow, reviewable suppressions with explicit reasons instead of silent broad allows."
+
+[[lint]]
+name = "clippy::ignore_without_reason"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Require narrow, reviewable suppressions with explicit reasons instead of silent broad allows."
+
+[[lint]]
+name = "clippy::should_panic_without_expect"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Keep production and tests panic-free; failures should propagate as errors or structured assertions."
+
+# Planned lints are tracked before the MSRV bump, but must not be active yet.
+
+[[lint]]
+name = "clippy::same_length_and_capacity"
+level = "deny"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "unsafe-memory"
+reason = "Catch raw-parts reconstruction mistakes."
+
+[[lint]]
+name = "clippy::manual_ilog2"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "numeric"
+reason = "Prefer the standard integer log helper."
+
+[[lint]]
+name = "clippy::decimal_bitwise_operands"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "numeric"
+reason = "Make bit masks visually inspectable."
+
+[[lint]]
+name = "clippy::needless_type_cast"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "numeric"
+reason = "Avoid stale numeric type drift."
+
+[[lint]]
+name = "clippy::disallowed_fields"
+level = "deny"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "architecture"
+reason = "Allow architecture policy to ban direct field access across protected seams."
+
+[[lint]]
+name = "clippy::manual_checked_ops"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "numeric"
+reason = "Prefer checked arithmetic over manual divide-by-zero guards."
+
+[[lint]]
+name = "clippy::manual_take"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "reviewability"
+reason = "Use standard ownership helper instead of local reimplementation."
+
+[[lint]]
+name = "clippy::manual_pop_if"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "reviewability"
+reason = "Use collection APIs that encode predicate-and-pop intent directly."
+
+[[lint]]
+name = "clippy::duration_suboptimal_units"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "reviewability"
+reason = "Make durations legible without mental unit conversion."
+
+[[lint]]
+name = "clippy::unnecessary_trailing_comma"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "reviewability"
+reason = "Keep generated and hand-written format macro calls clean."

--- a/policy/no-panic-allowlist.toml
+++ b/policy/no-panic-allowlist.toml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+schema_version = "0.3"
+
+# No panic-family exceptions are accepted by default. If a temporary exception is
+# needed, add a narrow [[allow]] entry with path + family + selector identity,
+# owner, classification, explanation, optional expires, and advisory last_seen.

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+schema_version = "1.0"
+
+[[allow]]
+glob = ".github/workflows/*.yml"
+kind = "ci_declarative"
+owner = "release/ci"
+reason = "GitHub Actions workflows are platform-required CI configuration."
+surface = "ci"
+classification = "config"
+covered_by = ["cargo xtask check-lint-policy"]
+
+[[allow]]
+glob = "fixtures/**"
+kind = "fixture_input"
+owner = "parser-fixtures"
+reason = "Fixture workspaces intentionally contain analyzed COBOL, JSON, and supporting source files."
+surface = "fixtures"
+classification = "test"
+covered_by = ["cargo test --workspace"]
+
+[[allow]]
+glob = "docs/**"
+kind = "documentation"
+owner = "docs"
+reason = "Documentation and examples are intentionally non-Rust content."
+surface = "docs"
+classification = "documentation"
+covered_by = ["cargo xtask check-lint-policy"]

--- a/tools/xtask/Cargo.toml
+++ b/tools/xtask/Cargo.toml
@@ -27,6 +27,7 @@ regex.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_plain.workspace = true
+toml.workspace = true
 chrono = { workspace = true, features = ["std", "clock"] }
 copybook-core = { workspace = true }
 copybook-bench = { workspace = true }

--- a/tools/xtask/src/lint_policy.rs
+++ b/tools/xtask/src/lint_policy.rs
@@ -1,0 +1,327 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+use anyhow::{Context, Result, bail, ensure};
+use chrono::{Local, NaiveDate};
+use serde::Deserialize;
+use std::{collections::BTreeMap, fs, path::Path};
+use toml::Value;
+
+const ROOT_MANIFEST: &str = "Cargo.toml";
+const LINT_LEDGER: &str = "policy/clippy-lints.toml";
+const DEBT_LEDGER: &str = "policy/clippy-debt.toml";
+const CLIPPY_CONFIG: &str = "clippy.toml";
+const FORBIDDEN_TEST_CARVEOUTS: &[&str] = &[
+    "allow-unwrap-in-tests",
+    "allow-expect-in-tests",
+    "allow-panic-in-tests",
+    "allow-indexing-slicing-in-tests",
+    "allow-dbg-in-tests",
+];
+const PLANNED_MSRVS: &[&str] = &["1.94", "1.95"];
+
+#[derive(Debug, Deserialize)]
+struct LintLedger {
+    schema: u64,
+    msrv: String,
+    policy: Policy,
+    lint: Vec<LintEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Policy {
+    panic_free_tests: bool,
+    allow_test_carveouts: bool,
+    suppression_style: String,
+    blanket_categories: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct LintEntry {
+    name: String,
+    level: String,
+    status: String,
+    activate_when_msrv: Option<String>,
+    class: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DebtLedger {
+    schema: u64,
+    #[serde(default)]
+    debt: Vec<DebtEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DebtEntry {
+    lint: String,
+    path: String,
+    owner: String,
+    reason: String,
+    expires: String,
+}
+
+/// Verify the workspace lint policy ledgers and manifest wiring.
+///
+/// # Errors
+///
+/// Returns an error when Cargo, Clippy, or policy ledgers drift from the shared
+/// Effortless Metrics lint policy model.
+pub fn check() -> Result<()> {
+    let root = read_toml(ROOT_MANIFEST)?;
+    let ledger = read_lint_ledger()?;
+
+    ensure!(ledger.schema == 1, "{LINT_LEDGER}: schema must be 1");
+    ensure!(
+        ledger.policy.panic_free_tests,
+        "{LINT_LEDGER}: panic_free_tests must be true"
+    );
+    ensure!(
+        !ledger.policy.allow_test_carveouts,
+        "{LINT_LEDGER}: allow_test_carveouts must be false"
+    );
+    ensure!(
+        ledger.policy.suppression_style == "expect-with-reason",
+        "{LINT_LEDGER}: suppression_style must be expect-with-reason"
+    );
+    ensure!(
+        !ledger.policy.blanket_categories,
+        "{LINT_LEDGER}: blanket_categories must be false"
+    );
+
+    let workspace_msrv = root
+        .get("workspace")
+        .and_then(|v| v.get("package"))
+        .and_then(|v| v.get("rust-version"))
+        .and_then(Value::as_str)
+        .context("Cargo.toml must set workspace.package.rust-version")?;
+    ensure!(
+        workspace_msrv == ledger.msrv,
+        "workspace.package.rust-version ({workspace_msrv}) must match {LINT_LEDGER} msrv ({})",
+        ledger.msrv
+    );
+
+    check_clippy_config()?;
+    check_active_lints(&root, &ledger)?;
+    check_workspace_members_inherit_lints(&root)?;
+    check_debt_ledger()?;
+
+    println!(
+        "✓ lint policy is coherent: MSRV {workspace_msrv}, active lint ledger, planned flips, clippy.toml, workspace inheritance, and debt metadata verified"
+    );
+    Ok(())
+}
+
+fn read_toml(path: &str) -> Result<Value> {
+    let content = fs::read_to_string(path).with_context(|| format!("read {path}"))?;
+    toml::from_str(&content).with_context(|| format!("parse {path}"))
+}
+
+fn read_lint_ledger() -> Result<LintLedger> {
+    let content = fs::read_to_string(LINT_LEDGER).with_context(|| format!("read {LINT_LEDGER}"))?;
+    toml::from_str(&content).with_context(|| format!("parse {LINT_LEDGER}"))
+}
+
+fn check_clippy_config() -> Result<()> {
+    let content =
+        fs::read_to_string(CLIPPY_CONFIG).with_context(|| format!("read {CLIPPY_CONFIG}"))?;
+    for carveout in FORBIDDEN_TEST_CARVEOUTS {
+        ensure!(
+            !content
+                .lines()
+                .any(|line| line.trim_start().starts_with(carveout)),
+            "{CLIPPY_CONFIG}: forbidden test carveout `{carveout}` is not allowed"
+        );
+    }
+    Ok(())
+}
+
+fn check_active_lints(root: &Value, ledger: &LintLedger) -> Result<()> {
+    let manifest_lints = manifest_lints(root)?;
+    ensure!(
+        !manifest_lints.is_empty(),
+        "Cargo.toml must define workspace lints"
+    );
+
+    let mut active = BTreeMap::new();
+    let mut planned = Vec::new();
+    for lint in &ledger.lint {
+        ensure!(
+            !lint.name.trim().is_empty(),
+            "{LINT_LEDGER}: lint name is required"
+        );
+        ensure!(
+            !lint.level.trim().is_empty(),
+            "{LINT_LEDGER}: lint level is required for {}",
+            lint.name
+        );
+        ensure!(
+            !lint.class.trim().is_empty(),
+            "{LINT_LEDGER}: class is required for {}",
+            lint.name
+        );
+        ensure!(
+            !lint.reason.trim().is_empty(),
+            "{LINT_LEDGER}: reason is required for {}",
+            lint.name
+        );
+        match lint.status.as_str() {
+            "active" => {
+                ensure!(
+                    lint.activate_when_msrv.is_none(),
+                    "{LINT_LEDGER}: active lint {} must not set activate_when_msrv",
+                    lint.name
+                );
+                active.insert(lint.name.clone(), lint.level.clone());
+            }
+            "planned" => {
+                let msrv = lint.activate_when_msrv.as_deref().with_context(|| {
+                    format!(
+                        "{LINT_LEDGER}: planned lint {} must set activate_when_msrv",
+                        lint.name
+                    )
+                })?;
+                ensure!(
+                    PLANNED_MSRVS.contains(&msrv),
+                    "{LINT_LEDGER}: planned lint {} must target Rust 1.94 or 1.95",
+                    lint.name
+                );
+                planned.push(&lint.name);
+            }
+            other => bail!(
+                "{LINT_LEDGER}: lint {} has unsupported status `{other}`",
+                lint.name
+            ),
+        }
+    }
+
+    for (name, level) in &manifest_lints {
+        let Some(active_level) = active.get(name) else {
+            bail!("{LINT_LEDGER}: active lint ledger is missing manifest lint {name}");
+        };
+        ensure!(
+            active_level == level,
+            "{LINT_LEDGER}: lint {name} level {active_level} does not match Cargo.toml level {level}"
+        );
+    }
+    for (name, level) in &active {
+        let Some(manifest_level) = manifest_lints.get(name) else {
+            bail!("Cargo.toml: active ledger lint {name} is missing from workspace lints");
+        };
+        ensure!(
+            manifest_level == level,
+            "Cargo.toml: lint {name} level {manifest_level} does not match ledger level {level}"
+        );
+    }
+    for name in planned {
+        ensure!(
+            !manifest_lints.contains_key(name),
+            "Cargo.toml: planned lint {name} must not be active before its MSRV bump"
+        );
+    }
+    Ok(())
+}
+
+fn manifest_lints(root: &Value) -> Result<BTreeMap<String, String>> {
+    let mut out = BTreeMap::new();
+    let workspace_lints = root
+        .get("workspace")
+        .and_then(|v| v.get("lints"))
+        .context("Cargo.toml must define [workspace.lints]")?;
+    if let Some(rust) = workspace_lints.get("rust").and_then(Value::as_table) {
+        for (name, value) in rust {
+            if let Some(level) = value.as_str() {
+                if level != "allow" {
+                    out.insert(name.clone(), level.to_owned());
+                }
+            }
+        }
+    }
+    if let Some(clippy) = workspace_lints.get("clippy").and_then(Value::as_table) {
+        for (name, value) in clippy {
+            if let Some(level) = value.as_str() {
+                if level != "allow" {
+                    out.insert(format!("clippy::{name}"), level.to_owned());
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn check_workspace_members_inherit_lints(root: &Value) -> Result<()> {
+    let members = root
+        .get("workspace")
+        .and_then(|v| v.get("members"))
+        .and_then(Value::as_array)
+        .context("Cargo.toml must define workspace.members")?;
+
+    for member in members {
+        let Some(member) = member.as_str() else {
+            continue;
+        };
+        if member.contains('*') {
+            continue;
+        }
+        let manifest = Path::new(member).join("Cargo.toml");
+        ensure!(
+            manifest.exists(),
+            "workspace member {} has no Cargo.toml",
+            member
+        );
+        let value = read_toml_path(&manifest)?;
+        let inherits = value
+            .get("lints")
+            .and_then(|v| v.get("workspace"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        ensure!(
+            inherits,
+            "{} must contain [lints]\nworkspace = true",
+            manifest.display()
+        );
+    }
+    Ok(())
+}
+
+fn read_toml_path(path: &Path) -> Result<Value> {
+    let content = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    toml::from_str(&content).with_context(|| format!("parse {}", path.display()))
+}
+
+fn check_debt_ledger() -> Result<()> {
+    let content = fs::read_to_string(DEBT_LEDGER).with_context(|| format!("read {DEBT_LEDGER}"))?;
+    let ledger: DebtLedger =
+        toml::from_str(&content).with_context(|| format!("parse {DEBT_LEDGER}"))?;
+    ensure!(ledger.schema == 1, "{DEBT_LEDGER}: schema must be 1");
+    let today = Local::now().date_naive();
+    for debt in ledger.debt {
+        ensure!(
+            !debt.lint.trim().is_empty(),
+            "{DEBT_LEDGER}: debt lint is required"
+        );
+        ensure!(
+            !debt.path.trim().is_empty(),
+            "{DEBT_LEDGER}: debt path is required for {}",
+            debt.lint
+        );
+        ensure!(
+            !debt.owner.trim().is_empty(),
+            "{DEBT_LEDGER}: debt owner is required for {}",
+            debt.lint
+        );
+        ensure!(
+            !debt.reason.trim().is_empty(),
+            "{DEBT_LEDGER}: debt reason is required for {}",
+            debt.lint
+        );
+        let expires = NaiveDate::parse_from_str(&debt.expires, "%Y-%m-%d")
+            .with_context(|| format!("{DEBT_LEDGER}: invalid expires date for {}", debt.lint))?;
+        ensure!(
+            expires >= today,
+            "{DEBT_LEDGER}: debt for {} at {} expired on {expires}",
+            debt.lint,
+            debt.path
+        );
+    }
+    Ok(())
+}

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -4,6 +4,7 @@ use copybook_core::support_matrix;
 use std::{fs, path::Path};
 use xtask::{Counts, counts, perf};
 
+mod lint_policy;
 mod pr_insights;
 
 fn main() -> Result<()> {
@@ -23,18 +24,22 @@ fn main() -> Result<()> {
         ["perf", "--enforce", "--out-dir", out_dir] => perf::run(true, Some(out_dir)),
         ["perf", "--summarize-last" | "--summarize"] => perf_summarize_last(),
         ["pr-insights"] => pr_insights::generate_summary(),
+        ["check-lint-policy"] => lint_policy::check(),
         _ => {
             eprintln!(
-                "Usage: cargo run -p xtask -- [docs|perf|pr-insights] <subcommand>\n\
-                 \n\
-                 docs sync-tests                 Sync test status from junit.xml\n\
-                 docs verify-tests               Verify test status is in sync\n\
-                 docs verify-support-matrix      Verify support matrix registry ↔ docs\n\
-                 perf                            Run perf benchmark runner\n\
-                 perf --enforce                  Run perf with SLO enforcement\n\
-                 perf --out-dir <path>           Run perf with custom output directory\n\
-                 perf --summarize-last           Summarize latest perf.json with SLO comparison\n\
-                 pr-insights                     Generate PR insights report (nextest + perf)"
+                "{}",
+                concat!(
+                    "Usage: cargo xtask [docs|perf|pr-insights|check-lint-policy] <subcommand>\n\n",
+                    "docs sync-tests                 Sync test status from junit.xml\n",
+                    "docs verify-tests               Verify test status is in sync\n",
+                    "docs verify-support-matrix      Verify support matrix registry ↔ docs\n",
+                    "perf                            Run perf benchmark runner\n",
+                    "perf --enforce                  Run perf with SLO enforcement\n",
+                    "perf --out-dir <path>           Run perf with custom output directory\n",
+                    "perf --summarize-last           Summarize latest perf.json with SLO comparison\n",
+                    "pr-insights                     Generate PR insights report (nextest + perf)\n",
+                    "check-lint-policy               Verify lint policy ledgers and workspace wiring",
+                ),
             );
             Ok(())
         }


### PR DESCRIPTION
### Motivation

- Establish a governed, machine-readable Clippy policy (panic-free + parser-safe baseline) across the workspace rather than ad-hoc per-repo carveouts.
- Track planned Rust 1.94/1.95 flips and make temporary exceptions explicit as expiring debt instead of weakening workspace lints.
- Provide an executable policy gate so CI can verify lint/ledger coherence and deny silent suppressions and test carveouts.

### Description

- Bump workspace MSRV to `1.93` and replace the previous lightweight lint block with a strict workspace lint baseline under `[workspace.lints.rust]` and `[workspace.lints.clippy]` in `Cargo.toml`. 
- Remove Clippy test carveouts from `clippy.toml` and align its `msrv` to `1.93`. 
- Add machine-readable policy ledgers and allowlists under `policy/`: `policy/clippy-lints.toml`, `policy/clippy-debt.toml`, `policy/no-panic-allowlist.toml`, and `policy/non-rust-allowlist.toml`. 
- Add documentation `docs/CLIPPY_POLICY.md` describing the policy, suppression style (`#[expect(..., reason = "...")]`), debt model, and rollout stance. 
- Implement `cargo xtask check-lint-policy` via a new `tools/xtask/src/lint_policy.rs` module and expose it as a cargo alias (`.cargo/config.toml` alias `xtask`) and an xtask subcommand. 
- Wire the policy gate into CI by adding a `lint-policy` job to `.github/workflows/ci.yml` and update CI/workflow/tooling references and docs from `1.92` → `1.93`. 

### Testing

- Ran formatting check with `cargo +1.93.0 fmt --all -- --check` which passed. 
- Ran the new gate with `cargo +1.93.0 xtask check-lint-policy` which passed and verified ledger/manifest consistency and debt schema. 
- Built and tested `xtask` with `cargo +1.93.0 check -p xtask` and `cargo +1.93.0 test -p xtask`, both of which passed. 
- Running `cargo +1.93.0 clippy -p xtask -- -D warnings` surfaced pre-existing suppression debt (e.g., `#[allow(non_camel_case_types)]` in `crates/copybook-error/src/lib.rs`) and so currently fails as expected; follow-up PR(s) will convert broad `#[allow]` sites into narrow `#[expect(..., reason = "...")]` or tracked debt entries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0869cb848333a5463a6618404ecf)