### PR TITLE
ci(codecov): add advisory coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+name: Coverage
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "crates/**"
+      - "copybook-*/**"
+      - "tools/**"
+      - "tests/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain*"
+      - ".github/workflows/coverage.yml"
+      - "codecov.yml"
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches: [main]
+    paths:
+      - "crates/**"
+      - "copybook-*/**"
+      - "tools/**"
+      - "tests/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain*"
+      - ".github/workflows/coverage.yml"
+      - "codecov.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: coverage-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  RUSTFLAGS: "-C debuginfo=0"
+
+jobs:
+  coverage:
+    name: Codecov Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'coverage') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.92"
+          components: llvm-tools-preview
+
+      - name: Use larger target dir
+        run: echo "CARGO_TARGET_DIR=${RUNNER_TEMP}/target" >> "$GITHUB_ENV"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-directories: ${{ runner.temp }}/target
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov,cargo-nextest
+
+      - name: Generate coverage
+        env:
+          CI: true
+        run: |
+          set -euo pipefail
+          cargo llvm-cov clean --workspace
+
+          cargo llvm-cov nextest \
+            --workspace \
+            --locked \
+            --no-report
+
+          cargo llvm-cov report --json --output-path coverage.json
+          cargo llvm-cov report --lcov --output-path lcov.info
+          cargo llvm-cov report --text | tee coverage.txt
+
+      - name: Validate coverage output
+        run: |
+          set -euo pipefail
+          test -s coverage.json
+          test -s coverage.txt
+          test -s lcov.info
+
+      - name: Detect Codecov token
+        id: codecov-token
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          if [ -n "${CODECOV_TOKEN:-}" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload coverage to Codecov (main)
+        if: ${{ always() && github.event_name == 'push' && hashFiles('lcov.info') != '' && steps.codecov-token.outputs.present == 'true' }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust-core
+          name: copybook-rs-rust-core
+          fail_ci_if_error: true
+
+      - name: Upload coverage to Codecov (advisory)
+        if: ${{ always() && github.event_name != 'push' && hashFiles('lcov.info') != '' && steps.codecov-token.outputs.present == 'true' }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust-core
+          name: copybook-rs-rust-core
+          fail_ci_if_error: false
+
+      - name: Upload coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-report
+          path: |
+            coverage.json
+            coverage.txt
+            lcov.info
+          retention-days: 14


### PR DESCRIPTION
## Summary

Adds step 1 of the copybook-rs Codecov rollout: an advisory coverage workflow using `cargo-llvm-cov` and `cargo-nextest` to generate coverage reports and upload them to Codecov.

The README already contains a Codecov badge; this PR backs that badge with the underlying infrastructure.

## CI economics

- **Default PR LEM impact**: advisory only, fails locally but not CI block (fail_ci_if_error: false on PRs)
- **Workflow touched**: new `.github/workflows/coverage.yml`
- **Branch protection impact**: none; coverage is not part of required CI Quick gate
- **Failure mode caught**: missing coverage tooling (llvm-tools-preview not installed, cargo-llvm-cov not present, cargo-nextest not available)
- **Cheaper signal considered**: none; coverage generation is foundational
- **Rollback path**: delete `.github/workflows/coverage.yml`, revert commit

## Workflow shape

Runs on:
- `push` to `main`
- `workflow_dispatch`
- PRs labeled `coverage` or `full-ci`

Steps:
1. Checkout code with shallow fetch
2. Install Rust 1.92 with llvm-tools-preview
3. Use larger target dir for caching
4. Cache build artifacts
5. Install cargo-llvm-cov and cargo-nextest
6. Generate coverage reports (JSON, text, LCOV)
7. Validate coverage output files exist
8. Detect Codecov token presence
9. Upload to Codecov (fail_ci_if_error: true on main, false on PRs)
10. Upload coverage artifacts to GitHub Actions (JSON, text, LCOV) with 14-day retention

## Claim boundary

Coverage is execution-surface evidence only. It does not prove:

- COBOL feature completeness
- parser correctness
- EBCDIC/ASCII conversion correctness
- COMP-3/RDW behavior correctness
- mutation adequacy
- fuzz robustness
- release readiness

## Validation

- [x] `cargo check -p xtask --locked` (passed)
- [x] `git diff --check` (no whitespace issues)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SpsNicDVRsuPNuS8SbWmx1)_