### PR TITLE
docs(readme): verify Codecov badge target

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # copybook-rs
 
 [![CI Quick](https://github.com/EffortlessMetrics/copybook-rs/actions/workflows/ci-quick.yml/badge.svg)](https://github.com/EffortlessMetrics/copybook-rs/actions/workflows/ci-quick.yml)
-[![codecov](https://codecov.io/gh/EffortlessMetrics/copybook-rs/branch/main/graph/badge.svg)](https://codecov.io/gh/EffortlessMetrics/copybook-rs)
+[![Codecov](https://codecov.io/gh/EffortlessMetrics/copybook-rs/branch/main/graph/badge.svg)](https://codecov.io/gh/EffortlessMetrics/copybook-rs)
 [![Security Audit](https://github.com/EffortlessMetrics/copybook-rs/workflows/Weekly%20Security%20Scan/badge.svg)](https://github.com/EffortlessMetrics/copybook-rs/actions/workflows/security-scan.yml)
 [![Dependency Review](https://img.shields.io/badge/dependencies-Dependabot-blue.svg)](https://github.com/EffortlessMetrics/copybook-rs/blob/main/.github/dependabot.yml)
 [![MSRV](https://img.shields.io/badge/MSRV-1.92-blue.svg)](https://www.rust-lang.org)


### PR DESCRIPTION
## Summary

Adds step 3 of the copybook-rs Codecov rollout: verification and normalization of the existing Codecov badge in the README.

The badge was already present but with lowercase `codecov` alt text. This PR normalizes it to uppercase `Codecov` to match:
- Official Codecov branding
- Capitalization style of other badges in the repository

## Changes

**README.md line 5:**
- Before: `[![codecov](...)`
- After: `[![Codecov](...)`

The URL target and badge source are unchanged; this is purely a capitalization normalization.

## CI economics

- **Default PR LEM impact**: none; documentation only
- **Files touched**: README.md (1 line)
- **Branch protection impact**: none
- **Failure mode caught**: n/a; badge formatting is cosmetic
- **Cheaper signal considered**: n/a
- **Rollback path**: revert commit

## Validation

- [x] `git diff --check` (no whitespace issues)

## Merge rule

Merge only if the diff is actually useful. The badge was already present and functional; this change normalizes capitalization to match repository style.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SpsNicDVRsuPNuS8SbWmx1)_