### PR TITLE
docs(ci): document coverage lane

### DIFF
--- a/docs/ci/coverage.md
+++ b/docs/ci/coverage.md
@@ -1,0 +1,34 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# Coverage
+
+Coverage is execution-surface evidence.
+
+It answers:
+
+> Did tests execute this Rust parser/data-conversion surface?
+
+It does not answer:
+
+- whether COBOL feature support is complete,
+- whether parser behavior is correct,
+- whether EBCDIC/ASCII conversion is correct,
+- whether COMP-3, packed decimal, RDW, ODO, or REDEFINES behavior is correct,
+- whether mutation adequacy is strong,
+- whether fuzzing is sufficient,
+- whether release packaging is valid.
+
+Those are separate proof lanes.
+
+The Coverage workflow runs on:
+
+- push to `main`,
+- `workflow_dispatch`,
+- PRs labeled `coverage` or `full-ci`.
+
+Codecov comments are disabled. Durable receipts are:
+
+- `coverage.json`,
+- `coverage.txt`,
+- `lcov.info`,
+- the GitHub Actions coverage artifact,
+- the Codecov dashboard.


### PR DESCRIPTION
## Summary

Adds step 4 of the copybook-rs Codecov rollout: documentation explaining what coverage evidence does and does not provide.

This PR adds `docs/ci/coverage.md` clarifying the scope and limitations of code coverage as an execution-surface metric.

## CI economics

- **Default PR LEM impact**: none; documentation only
- **Files touched**: new `docs/ci/coverage.md`
- **Branch protection impact**: none
- **Failure mode caught**: n/a; documentation is informational
- **Cheaper signal considered**: n/a
- **Rollback path**: delete `docs/ci/coverage.md`, revert commit

## Documentation content

Explains:
- **What coverage answers**: Did tests execute this Rust parser/data-conversion surface?
- **What coverage does NOT answer**: 8 separate proof lanes (COBOL feature completeness, parser correctness, EBCDIC conversion, COMP-3/RDW behavior, mutation adequacy, fuzzing adequacy, release packaging)
- **When Coverage runs**: main, workflow_dispatch, PR labels `coverage` or `full-ci`
- **Durable receipts**: JSON report, text report, LCOV file, GitHub artifact, Codecov dashboard

## Validation

- [x] `git diff --check` (no whitespace issues)

## Merge rule

Merge after the Coverage workflow (PR #452) demonstrates working coverage collection and reporting.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SpsNicDVRsuPNuS8SbWmx1)_