### PR TITLE
chore(governance): register coverage lane in policy

### DIFF
--- a/policy/ci-lanes.toml
+++ b/policy/ci-lanes.toml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+[lane.coverage]
+description = "Codecov/cargo-llvm-cov execution-surface reporting for copybook-rs Rust parser and fixed-record conversion crates."
+intent = "execution_surface"
+failure_mode = "Parser/data-conversion tests stop executing meaningful Rust surfaces without visibility."
+proof_obligation = "Generate coverage.json, coverage.txt, lcov.info, upload GitHub artifact, and upload LCOV to Codecov when CODECOV_TOKEN is present."
+owner = "release/ci"
+runner = "ubuntu_latest"
+base_lem = 45
+default_pr = false
+blocking = false
+workflow = ".github/workflows/coverage.yml"
+labels = ["coverage", "full-ci"]
+outputs = ["coverage.json", "coverage.txt", "lcov.info", "coverage-report", "coverage-receipt.json"]
+not_responsible_for = [
+  "COBOL feature completeness",
+  "parser correctness",
+  "EBCDIC conversion correctness",
+  "COMP-3 correctness",
+  "RDW correctness",
+  "mutation adequacy",
+  "fuzz robustness",
+  "release readiness"
+]

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+[[allow]]
+path = "codecov.yml"
+kind = "ci_coverage_policy"
+owner = "release/ci"
+surface = "ci"
+classification = "config"
+reason = "Codecov status and reporting configuration for cargo-llvm-cov coverage uploads."
+covered_by = ["cargo xtask check-file-policy"]
+
+[[allow]]
+path = ".github/workflows/coverage.yml"
+kind = "ci_declarative"
+owner = "release/ci"
+surface = "ci"
+classification = "config"
+reason = "GitHub Actions coverage workflow for cargo-llvm-cov and Codecov uploads."
+covered_by = ["cargo xtask check-file-policy"]


### PR DESCRIPTION
## Summary

Adds step 6 of the copybook-rs Codecov rollout: policy registration documenting the coverage lane in the governance ledger.

This PR registers the Coverage infrastructure in the policy system with explicit metadata about scope, ownership, and claim boundaries.

## CI economics

- **Default PR LEM impact**: none; policy documentation only
- **Files touched**: new `policy/non-rust-allowlist.toml`, `policy/ci-lanes.toml`
- **Branch protection impact**: none
- **Failure mode caught**: coverage lane not tracked in governance ledger
- **Cheaper signal considered**: none; policy ledger is foundational
- **Rollback path**: delete policy files, revert commit

## Policy registration

**File allowlist** (`policy/non-rust-allowlist.toml`):
- `codecov.yml` - CI coverage config (covered by xtask check-file-policy)
- `.github/workflows/coverage.yml` - Coverage workflow (covered by xtask check-file-policy)

**Lane definition** (`policy/ci-lanes.toml`):

```toml
[lane.coverage]
description = "Codecov/cargo-llvm-cov execution-surface reporting"
intent = "execution_surface"
owner = "release/ci"
workflow = ".github/workflows/coverage.yml"
labels = ["coverage", "full-ci"]
outputs = ["coverage.json", "coverage.txt", "lcov.info", "coverage-report", "coverage-receipt.json"]

not_responsible_for = [
  "COBOL feature completeness",
  "parser correctness",
  "EBCDIC conversion correctness",
  "COMP-3 correctness",
  "RDW correctness",
  "mutation adequacy",
  "fuzz robustness",
  "release readiness"
]
```

## Validation

- [x] TOML files parse correctly

## Merge rule

Merge after the coverage workflow (PR #452) is merged and running on main. This establishes the policy layer for the coverage infrastructure.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SpsNicDVRsuPNuS8SbWmx1)_