### PR TITLE
refactor(cli): split run lifecycle into SRP modules

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -14,6 +14,7 @@ on:
       - 'tests/**'
       - 'Cargo.*'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches: [ main, develop ]
     paths:
       - 'crates/**'
@@ -30,9 +31,13 @@ env:
 
 jobs:
   coverage:
-    name: Code Coverage
+    name: Tarpaulin Coverage
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'coverage') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     steps:
     - name: Checkout code

--- a/.github/workflows/leak-detection.yml
+++ b/.github/workflows/leak-detection.yml
@@ -6,6 +6,7 @@ on:
   schedule:
     - cron: "0 4 * * 0"  # Weekly on Sunday at 04:00 UTC
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - "crates/copybook-codec/**"
       - "crates/copybook-core/**"
@@ -24,6 +25,10 @@ jobs:
     name: Memory Leak Detection (LSAN)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'leak-check') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     steps:
       - uses: actions/checkout@v6
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
  "hex",
  "logos",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "serde_plain",
@@ -1049,7 +1049,7 @@ dependencies = [
  "copybook-codec",
  "copybook-core",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "sha2",
@@ -1156,7 +1156,7 @@ dependencies = [
  "copybook-support-matrix",
  "crossbeam-channel",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
 ]
@@ -3069,9 +3069,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -3364,9 +3364,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3780,7 +3780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/crates/copybook-cli/src/commands/audit.rs
+++ b/crates/copybook-cli/src/commands/audit.rs
@@ -2701,12 +2701,11 @@ fn run_audit_health_check_impl(
         );
     }
 
-    let overall_health_score = if checks_executed == 0 {
-        0
-    } else {
-        let failed_penalty = (checks_failed * 100) / checks_executed;
-        (100u32.saturating_sub(failed_penalty)).min(100)
-    };
+    let overall_health_score = (checks_failed * 100)
+        .checked_div(checks_executed)
+        .map_or(0, |failed_penalty| {
+            (100u32.saturating_sub(failed_penalty)).min(100)
+        });
 
     let status_code = if checks_failed > 0 || !parse_issues.is_empty() {
         ExitCode::Data

--- a/crates/copybook-cli/src/main.rs
+++ b/crates/copybook-cli/src/main.rs
@@ -602,13 +602,10 @@ mod cli_runtime {
     }
 
     pub(super) fn maybe_trigger_test_panic() {
-        #[allow(clippy::panic)]
-        if std::env::var("COPYBOOK_TEST_PANIC")
-            .map(|v| v == "1")
-            .unwrap_or(false)
-        {
-            panic!("COPYBOOK_TEST_PANIC triggered");
-        }
+        assert!(
+            !std::env::var("COPYBOOK_TEST_PANIC").is_ok_and(|v| v == "1"),
+            "COPYBOOK_TEST_PANIC triggered"
+        );
     }
 
     pub(super) fn parse_cli_or_exit() -> CliParseOutcome {

--- a/crates/copybook-cli/src/main.rs
+++ b/crates/copybook-cli/src/main.rs
@@ -552,335 +552,549 @@ fn main() -> ProcessExitCode {
     }
 }
 
-#[allow(clippy::too_many_lines)]
 fn run() -> anyhow::Result<ExitCode> {
-    #[allow(clippy::panic)]
-    if std::env::var("COPYBOOK_TEST_PANIC")
-        .map(|v| v == "1")
-        .unwrap_or(false)
-    {
-        panic!("COPYBOOK_TEST_PANIC triggered");
-    }
+    cli_runtime::maybe_trigger_test_panic();
 
-    let cli = match Cli::try_parse() {
-        Ok(cli) => cli,
-        Err(err) => {
-            let kind = err.kind();
-            let _ = err.print();
-            if matches!(
-                kind,
-                ClapErrorKind::DisplayHelp | ClapErrorKind::DisplayVersion
-            ) {
-                let op = if matches!(kind, ClapErrorKind::DisplayVersion) {
-                    "version"
-                } else {
-                    "help"
-                };
-                let diagnostics = ExitDiagnostics::new(
-                    ExitCode::Ok,
-                    "completed",
-                    op,
-                    "", // op_stage will be overridden by emit_exit_diagnostics_stage
-                    Level::INFO,
-                    0,
-                );
-                emit_exit_diagnostics_stage(&diagnostics, Stage::Finalize);
-                return Ok(ExitCode::Ok);
-            }
-            let exit_code = ExitCode::Encode;
-            let message = err.to_string();
-            let diagnostics = ExitDiagnostics::new(
-                exit_code,
-                &message,
-                "cli_parse",
-                "", // op_stage will be overridden by emit_exit_diagnostics_stage
-                Level::ERROR,
-                exit_code.as_i32(),
-            )
-            .with_error(Some(&err));
-            emit_exit_diagnostics_stage(&diagnostics, Stage::Parse);
-            return Ok(exit_code);
-        }
+    let cli = match cli_runtime::parse_cli_or_exit() {
+        cli_runtime::CliParseOutcome::Run(cli) => *cli,
+        cli_runtime::CliParseOutcome::Exit(exit_code) => return Ok(exit_code),
     };
 
-    #[cfg(feature = "metrics")]
-    let metrics_opts = cli.metrics.clone();
-
-    #[cfg(feature = "metrics")]
-    let metrics_server = metrics_start_if_requested(&metrics_opts)?;
-
-    #[cfg(feature = "metrics")]
-    if metrics_server.is_some() {
-        describe_metrics_once();
-    }
-
-    #[cfg(feature = "metrics")]
-    let _metrics_guard = metrics_grace_guard(&metrics_opts);
-
-    // Handle feature flags
-    let feature_flags = initialize_feature_flags(&cli.feature_flags)?;
-
-    // Set global feature flags for use by parser
-    copybook_core::feature_flags::FeatureFlags::set_global(feature_flags.clone());
-
-    if cli.feature_flags.list_features {
-        list_all_features(&feature_flags);
-        return Ok(ExitCode::Ok);
-    }
-
-    let strict_policy = effective_strict_policy(&cli);
-    let verbose = cli.verbose || feature_flags.is_enabled(Feature::VerboseLogging);
-    let command = cli.command;
-
-    // Initialize tracing
-    let default_directive = if verbose { "debug" } else { "warn" };
-    let env_filter =
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_directive));
-    tracing_subscriber::fmt()
-        .with_env_filter(env_filter)
-        .with_ansi(false)
-        .with_writer(|| BrokenPipeSafeStderr(std::io::stderr()))
-        .init();
-
-    let help_requested =
-        std::env::args_os().any(|arg| arg == "--help" || arg == "-h" || arg == "-?" || arg == "/?");
-    let version_requested = std::env::args_os().any(|arg| arg == "--version" || arg == "-V");
-    if !(help_requested || version_requested) {
-        tracing::info!(
-            invocation_id = %invocation_id(),
-            version = env!("CARGO_PKG_VERSION"),
-            commit = option_env!("GIT_SHA").unwrap_or("unknown"),
-            os = std::env::consts::OS,
-            arch = std::env::consts::ARCH,
-            strict_policy,
-            "copybook-cli start"
-        );
-    }
-
-    let (exit_status, exit_op): (anyhow::Result<ExitCode>, &'static str) = match command {
-        Commands::Parse {
-            copybook,
-            output,
-            strict,
-            strict_comments,
-            dialect,
-        } => {
-            let effective_dialect = effective_dialect(dialect);
-            (
-                crate::commands::parse::run(
-                    &copybook,
-                    output,
-                    strict,
-                    strict_comments,
-                    effective_dialect,
-                ),
-                "parse",
-            )
-        }
-        Commands::Inspect {
-            copybook,
-            codepage,
-            strict,
-            strict_comments,
-            dialect,
-        } => {
-            let effective_dialect = effective_dialect(dialect);
-            (
-                crate::commands::inspect::run(
-                    &copybook,
-                    codepage,
-                    strict,
-                    strict_comments,
-                    effective_dialect,
-                ),
-                "inspect",
-            )
-        }
-        Commands::Decode {
-            copybook,
-            input,
-            output,
-            format,
-            codepage,
-            json_number,
-            strict,
-            max_errors,
-            fail_fast,
-            emit_filler,
-            emit_meta,
-            emit_raw,
-            on_decode_unmappable,
-            threads,
-            strict_comments,
-            preserve_zoned_encoding,
-            preferred_zoned_encoding: preferred_zoned_encoding_cli,
-            float_format,
-            dialect,
-            select,
-        } => {
-            let effective_dialect = effective_dialect(dialect);
-            (
-                crate::commands::decode::run(&crate::commands::decode::DecodeArgs {
-                    copybook: &copybook,
-                    input: &input,
-                    output: &output,
-                    format,
-                    codepage,
-                    json_number,
-                    strict,
-                    max_errors,
-                    fail_fast,
-                    emit_filler,
-                    emit_meta,
-                    emit_raw,
-                    on_decode_unmappable,
-                    threads,
-                    strict_comments,
-                    preserve_zoned_encoding,
-                    preferred_zoned_encoding: preferred_zoned_encoding_cli.into(),
-                    float_format,
-                    strict_policy,
-                    dialect: effective_dialect.into(),
-                    select: &select,
-                }),
-                "decode",
-            )
-        }
-        Commands::Encode {
-            copybook,
-            input,
-            output,
-            format,
-            codepage,
-            use_raw,
-            bwz_encode,
-            strict,
-            max_errors,
-            fail_fast,
-            threads,
-            coerce_numbers,
-            strict_comments,
-            zoned_encoding_override,
-            float_format,
-            dialect,
-            select,
-        } => {
-            let effective_dialect = effective_dialect(dialect);
-            (
-                crate::commands::encode::run(
-                    &copybook,
-                    &input,
-                    &output,
-                    &crate::commands::encode::EncodeCliOptions {
-                        format,
-                        codepage,
-                        use_raw,
-                        bwz_encode,
-                        strict,
-                        max_errors,
-                        fail_fast,
-                        threads,
-                        coerce_numbers,
-                        strict_comments,
-                        zoned_encoding_override,
-                        float_format,
-                        dialect: effective_dialect.into(),
-                        select: &select,
-                    },
-                ),
-                "encode",
-            )
-        }
-        #[cfg(feature = "audit")]
-        Commands::Audit { audit_command } => {
-            // Run audit command asynchronously
-            let runtime = tokio::runtime::Runtime::new()?;
-            (
-                runtime
-                    .block_on(crate::commands::audit::run(audit_command))
-                    .map_err(|err| anyhow!(err)),
-                "audit",
-            )
-        }
-        Commands::Verify {
-            copybook,
-            input,
-            report,
-            format,
-            codepage,
-            strict,
-            max_errors,
-            sample,
-            strict_comments,
-            dialect,
-            select,
-        } => {
-            let effective_dialect = effective_dialect(dialect);
-            let value = max_errors.unwrap_or(10);
-            let normalized_max_errors = u32::try_from(value).map_err(|_| {
-                anyhow!(
-                    "--max-errors must be between 0 and {} (received {value})",
-                    u32::MAX
-                )
-            })?;
-
-            let opts = crate::commands::verify::VerifyOptions {
-                format,
-                codepage,
-                strict,
-                max_errors: normalized_max_errors,
-                sample: sample.unwrap_or(5),
-                strict_comments,
-                dialect: effective_dialect.into(),
-                select: &select,
-            };
-            (
-                crate::commands::verify::run(&copybook, &input, report, &opts),
-                "verify",
-            )
-        }
-        Commands::Support { args } => (crate::commands::support::run(&args), "support"),
-        Commands::Determinism { command } => {
-            (crate::commands::determinism::run(&command), "determinism")
-        }
+    let runtime = match cli_runtime::initialize(cli)? {
+        cli_runtime::InitOutcome::Run(runtime) => runtime,
+        cli_runtime::InitOutcome::Exit(exit_code) => return Ok(exit_code),
     };
+    let command_dispatch::CommandRun { status, op } =
+        command_dispatch::execute(runtime.command, runtime.strict_policy)?;
 
     #[cfg(feature = "metrics")]
-    if let (Err(err), Some((handle, _))) = (&exit_status, &metrics_server) {
+    if let (Err(err), Some((handle, _))) = (&status, &runtime.metrics_server) {
         let records_processed = metrics_records_total(handle);
         bump_error_if_pre_run(err, records_processed);
     }
 
-    let status = exit_status?;
+    exit_reporting::finish(status?, op)
+}
 
-    let diagnostics = if status == ExitCode::Ok {
-        ExitDiagnostics::new(
-            ExitCode::Ok,
-            "completed",
-            exit_op,
-            "", // op_stage will be overridden by emit_exit_diagnostics_stage
-            Level::INFO,
-            0,
-        )
-    } else {
-        ExitDiagnostics::new(
-            status,
-            "command completed with non-zero exit code",
-            exit_op,
+mod cli_runtime {
+    use super::*;
+
+    pub(super) enum CliParseOutcome {
+        Run(Box<Cli>),
+        Exit(ExitCode),
+    }
+
+    pub(super) enum InitOutcome {
+        Run(RuntimeContext),
+        Exit(ExitCode),
+    }
+
+    pub(super) struct RuntimeContext {
+        pub(super) command: Commands,
+        pub(super) strict_policy: bool,
+        #[cfg(feature = "metrics")]
+        pub(super) metrics_server: Option<(
+            metrics_exporter_prometheus::PrometheusHandle,
+            std::thread::JoinHandle<()>,
+        )>,
+        #[cfg(feature = "metrics")]
+        _metrics_guard: MetricsGraceGuard,
+    }
+
+    pub(super) fn maybe_trigger_test_panic() {
+        #[allow(clippy::panic)]
+        if std::env::var("COPYBOOK_TEST_PANIC")
+            .map(|v| v == "1")
+            .unwrap_or(false)
+        {
+            panic!("COPYBOOK_TEST_PANIC triggered");
+        }
+    }
+
+    pub(super) fn parse_cli_or_exit() -> CliParseOutcome {
+        match Cli::try_parse() {
+            Ok(cli) => CliParseOutcome::Run(Box::new(cli)),
+            Err(err) => handle_parse_error(err),
+        }
+    }
+
+    pub(super) fn initialize(cli: Cli) -> anyhow::Result<InitOutcome> {
+        #[cfg(feature = "metrics")]
+        let metrics_opts = cli.metrics.clone();
+
+        #[cfg(feature = "metrics")]
+        let metrics_server = metrics_start_if_requested(&metrics_opts)?;
+
+        #[cfg(feature = "metrics")]
+        if metrics_server.is_some() {
+            describe_metrics_once();
+        }
+
+        #[cfg(feature = "metrics")]
+        let metrics_guard = metrics_grace_guard(&metrics_opts);
+
+        let feature_flags = initialize_feature_flags(&cli.feature_flags)?;
+        copybook_core::feature_flags::FeatureFlags::set_global(feature_flags.clone());
+
+        if cli.feature_flags.list_features {
+            list_all_features(&feature_flags);
+            return Ok(InitOutcome::Exit(ExitCode::Ok));
+        }
+
+        let strict_policy = effective_strict_policy(&cli);
+        initialize_tracing(cli.verbose || feature_flags.is_enabled(Feature::VerboseLogging));
+        emit_startup_log(strict_policy);
+
+        Ok(InitOutcome::Run(RuntimeContext {
+            command: cli.command,
+            strict_policy,
+            #[cfg(feature = "metrics")]
+            metrics_server,
+            #[cfg(feature = "metrics")]
+            _metrics_guard: metrics_guard,
+        }))
+    }
+
+    fn handle_parse_error(err: clap::Error) -> CliParseOutcome {
+        let kind = err.kind();
+        let _ = err.print();
+        if matches!(
+            kind,
+            ClapErrorKind::DisplayHelp | ClapErrorKind::DisplayVersion
+        ) {
+            let op = if matches!(kind, ClapErrorKind::DisplayVersion) {
+                "version"
+            } else {
+                "help"
+            };
+            let diagnostics = ExitDiagnostics::new(
+                ExitCode::Ok,
+                "completed",
+                op,
+                "", // op_stage will be overridden by emit_exit_diagnostics_stage
+                Level::INFO,
+                0,
+            );
+            emit_exit_diagnostics_stage(&diagnostics, Stage::Finalize);
+            return CliParseOutcome::Exit(ExitCode::Ok);
+        }
+
+        let exit_code = ExitCode::Encode;
+        let message = err.to_string();
+        let diagnostics = ExitDiagnostics::new(
+            exit_code,
+            &message,
+            "cli_parse",
             "", // op_stage will be overridden by emit_exit_diagnostics_stage
             Level::ERROR,
-            status.as_i32(),
+            exit_code.as_i32(),
         )
-    };
+        .with_error(Some(&err));
+        emit_exit_diagnostics_stage(&diagnostics, Stage::Parse);
+        CliParseOutcome::Exit(exit_code)
+    }
 
-    let stage = if status == ExitCode::Ok {
-        Stage::Finalize
-    } else {
-        Stage::Execute
-    };
-    emit_exit_diagnostics_stage(&diagnostics, stage);
+    fn initialize_tracing(verbose: bool) {
+        let default_directive = if verbose { "debug" } else { "warn" };
+        let env_filter =
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_directive));
+        tracing_subscriber::fmt()
+            .with_env_filter(env_filter)
+            .with_ansi(false)
+            .with_writer(|| BrokenPipeSafeStderr(std::io::stderr()))
+            .init();
+    }
 
-    Ok(status)
+    fn emit_startup_log(strict_policy: bool) {
+        let help_requested = std::env::args_os()
+            .any(|arg| arg == "--help" || arg == "-h" || arg == "-?" || arg == "/?");
+        let version_requested = std::env::args_os().any(|arg| arg == "--version" || arg == "-V");
+        if !(help_requested || version_requested) {
+            tracing::info!(
+                invocation_id = %invocation_id(),
+                version = env!("CARGO_PKG_VERSION"),
+                commit = option_env!("GIT_SHA").unwrap_or("unknown"),
+                os = std::env::consts::OS,
+                arch = std::env::consts::ARCH,
+                strict_policy,
+                "copybook-cli start"
+            );
+        }
+    }
+}
+
+mod command_dispatch {
+    use super::*;
+
+    pub(super) struct CommandRun {
+        pub(super) status: anyhow::Result<ExitCode>,
+        pub(super) op: &'static str,
+    }
+
+    pub(super) fn execute(command: Commands, strict_policy: bool) -> anyhow::Result<CommandRun> {
+        let (status, op) = match command {
+            Commands::Parse {
+                copybook,
+                output,
+                strict,
+                strict_comments,
+                dialect,
+            } => run_parse(copybook, output, strict, strict_comments, dialect),
+            Commands::Inspect {
+                copybook,
+                codepage,
+                strict,
+                strict_comments,
+                dialect,
+            } => run_inspect(copybook, codepage, strict, strict_comments, dialect),
+            Commands::Decode {
+                copybook,
+                input,
+                output,
+                format,
+                codepage,
+                json_number,
+                strict,
+                max_errors,
+                fail_fast,
+                emit_filler,
+                emit_meta,
+                emit_raw,
+                on_decode_unmappable,
+                threads,
+                strict_comments,
+                preserve_zoned_encoding,
+                preferred_zoned_encoding: preferred_zoned_encoding_cli,
+                float_format,
+                dialect,
+                select,
+            } => run_decode(DecodeDispatchArgs {
+                copybook,
+                input,
+                output,
+                format,
+                codepage,
+                json_number,
+                strict,
+                max_errors,
+                fail_fast,
+                emit_filler,
+                emit_meta,
+                emit_raw,
+                on_decode_unmappable,
+                threads,
+                strict_comments,
+                preserve_zoned_encoding,
+                preferred_zoned_encoding_cli,
+                float_format,
+                dialect,
+                select,
+                strict_policy,
+            }),
+            Commands::Encode {
+                copybook,
+                input,
+                output,
+                format,
+                codepage,
+                use_raw,
+                bwz_encode,
+                strict,
+                max_errors,
+                fail_fast,
+                threads,
+                coerce_numbers,
+                strict_comments,
+                zoned_encoding_override,
+                float_format,
+                dialect,
+                select,
+            } => run_encode(EncodeDispatchArgs {
+                copybook,
+                input,
+                output,
+                format,
+                codepage,
+                use_raw,
+                bwz_encode,
+                strict,
+                max_errors,
+                fail_fast,
+                threads,
+                coerce_numbers,
+                strict_comments,
+                zoned_encoding_override,
+                float_format,
+                dialect,
+                select,
+            }),
+            #[cfg(feature = "audit")]
+            Commands::Audit { audit_command } => run_audit(audit_command)?,
+            Commands::Verify {
+                copybook,
+                input,
+                report,
+                format,
+                codepage,
+                strict,
+                max_errors,
+                sample,
+                strict_comments,
+                dialect,
+                select,
+            } => run_verify(VerifyDispatchArgs {
+                copybook,
+                input,
+                report,
+                format,
+                codepage,
+                strict,
+                max_errors,
+                sample,
+                strict_comments,
+                dialect,
+                select,
+            })?,
+            Commands::Support { args } => (crate::commands::support::run(&args), "support"),
+            Commands::Determinism { command } => {
+                (crate::commands::determinism::run(&command), "determinism")
+            }
+        };
+
+        Ok(CommandRun { status, op })
+    }
+
+    fn run_parse(
+        copybook: PathBuf,
+        output: Option<PathBuf>,
+        strict: bool,
+        strict_comments: bool,
+        dialect: Option<DialectPreference>,
+    ) -> (anyhow::Result<ExitCode>, &'static str) {
+        let effective_dialect = effective_dialect(dialect);
+        (
+            crate::commands::parse::run(
+                &copybook,
+                output,
+                strict,
+                strict_comments,
+                effective_dialect,
+            ),
+            "parse",
+        )
+    }
+
+    fn run_inspect(
+        copybook: PathBuf,
+        codepage: Codepage,
+        strict: bool,
+        strict_comments: bool,
+        dialect: Option<DialectPreference>,
+    ) -> (anyhow::Result<ExitCode>, &'static str) {
+        let effective_dialect = effective_dialect(dialect);
+        (
+            crate::commands::inspect::run(
+                &copybook,
+                codepage,
+                strict,
+                strict_comments,
+                effective_dialect,
+            ),
+            "inspect",
+        )
+    }
+
+    struct DecodeDispatchArgs {
+        copybook: PathBuf,
+        input: PathBuf,
+        output: PathBuf,
+        format: RecordFormat,
+        codepage: Codepage,
+        json_number: JsonNumberMode,
+        strict: bool,
+        max_errors: Option<u64>,
+        fail_fast: bool,
+        emit_filler: bool,
+        emit_meta: bool,
+        emit_raw: RawMode,
+        on_decode_unmappable: UnmappablePolicy,
+        threads: usize,
+        strict_comments: bool,
+        preserve_zoned_encoding: bool,
+        preferred_zoned_encoding_cli: ZonedEncodingPreference,
+        float_format: FloatFormat,
+        dialect: Option<DialectPreference>,
+        select: Vec<String>,
+        strict_policy: bool,
+    }
+
+    fn run_decode(args: DecodeDispatchArgs) -> (anyhow::Result<ExitCode>, &'static str) {
+        let effective_dialect = effective_dialect(args.dialect);
+        (
+            crate::commands::decode::run(&crate::commands::decode::DecodeArgs {
+                copybook: &args.copybook,
+                input: &args.input,
+                output: &args.output,
+                format: args.format,
+                codepage: args.codepage,
+                json_number: args.json_number,
+                strict: args.strict,
+                max_errors: args.max_errors,
+                fail_fast: args.fail_fast,
+                emit_filler: args.emit_filler,
+                emit_meta: args.emit_meta,
+                emit_raw: args.emit_raw,
+                on_decode_unmappable: args.on_decode_unmappable,
+                threads: args.threads,
+                strict_comments: args.strict_comments,
+                preserve_zoned_encoding: args.preserve_zoned_encoding,
+                preferred_zoned_encoding: args.preferred_zoned_encoding_cli.into(),
+                float_format: args.float_format,
+                strict_policy: args.strict_policy,
+                dialect: effective_dialect.into(),
+                select: &args.select,
+            }),
+            "decode",
+        )
+    }
+
+    struct EncodeDispatchArgs {
+        copybook: PathBuf,
+        input: PathBuf,
+        output: PathBuf,
+        format: RecordFormat,
+        codepage: Codepage,
+        use_raw: bool,
+        bwz_encode: bool,
+        strict: bool,
+        max_errors: Option<u64>,
+        fail_fast: bool,
+        threads: usize,
+        coerce_numbers: bool,
+        strict_comments: bool,
+        zoned_encoding_override: Option<copybook_codec::ZonedEncodingFormat>,
+        float_format: FloatFormat,
+        dialect: Option<DialectPreference>,
+        select: Vec<String>,
+    }
+
+    fn run_encode(args: EncodeDispatchArgs) -> (anyhow::Result<ExitCode>, &'static str) {
+        let effective_dialect = effective_dialect(args.dialect);
+        (
+            crate::commands::encode::run(
+                &args.copybook,
+                &args.input,
+                &args.output,
+                &crate::commands::encode::EncodeCliOptions {
+                    format: args.format,
+                    codepage: args.codepage,
+                    use_raw: args.use_raw,
+                    bwz_encode: args.bwz_encode,
+                    strict: args.strict,
+                    max_errors: args.max_errors,
+                    fail_fast: args.fail_fast,
+                    threads: args.threads,
+                    coerce_numbers: args.coerce_numbers,
+                    strict_comments: args.strict_comments,
+                    zoned_encoding_override: args.zoned_encoding_override,
+                    float_format: args.float_format,
+                    dialect: effective_dialect.into(),
+                    select: &args.select,
+                },
+            ),
+            "encode",
+        )
+    }
+
+    #[cfg(feature = "audit")]
+    fn run_audit(
+        audit_command: crate::commands::audit::AuditCommand,
+    ) -> anyhow::Result<(anyhow::Result<ExitCode>, &'static str)> {
+        let runtime = tokio::runtime::Runtime::new()?;
+        Ok((
+            runtime
+                .block_on(crate::commands::audit::run(audit_command))
+                .map_err(|err| anyhow!(err)),
+            "audit",
+        ))
+    }
+
+    struct VerifyDispatchArgs {
+        copybook: PathBuf,
+        input: PathBuf,
+        report: Option<PathBuf>,
+        format: RecordFormat,
+        codepage: Codepage,
+        strict: bool,
+        max_errors: Option<u64>,
+        sample: Option<u32>,
+        strict_comments: bool,
+        dialect: Option<DialectPreference>,
+        select: Vec<String>,
+    }
+
+    fn run_verify(
+        args: VerifyDispatchArgs,
+    ) -> anyhow::Result<(anyhow::Result<ExitCode>, &'static str)> {
+        let effective_dialect = effective_dialect(args.dialect);
+        let value = args.max_errors.unwrap_or(10);
+        let normalized_max_errors = u32::try_from(value).map_err(|_| {
+            anyhow!(
+                "--max-errors must be between 0 and {} (received {value})",
+                u32::MAX
+            )
+        })?;
+
+        let opts = crate::commands::verify::VerifyOptions {
+            format: args.format,
+            codepage: args.codepage,
+            strict: args.strict,
+            max_errors: normalized_max_errors,
+            sample: args.sample.unwrap_or(5),
+            strict_comments: args.strict_comments,
+            dialect: effective_dialect.into(),
+            select: &args.select,
+        };
+        Ok((
+            crate::commands::verify::run(&args.copybook, &args.input, args.report, &opts),
+            "verify",
+        ))
+    }
+}
+
+mod exit_reporting {
+    use super::*;
+
+    pub(super) fn finish(status: ExitCode, op: &'static str) -> anyhow::Result<ExitCode> {
+        let diagnostics = if status == ExitCode::Ok {
+            ExitDiagnostics::new(
+                ExitCode::Ok,
+                "completed",
+                op,
+                "", // op_stage will be overridden by emit_exit_diagnostics_stage
+                Level::INFO,
+                0,
+            )
+        } else {
+            ExitDiagnostics::new(
+                status,
+                "command completed with non-zero exit code",
+                op,
+                "", // op_stage will be overridden by emit_exit_diagnostics_stage
+                Level::ERROR,
+                status.as_i32(),
+            )
+        };
+
+        let stage = if status == ExitCode::Ok {
+            Stage::Finalize
+        } else {
+            Stage::Execute
+        };
+        emit_exit_diagnostics_stage(&diagnostics, stage);
+
+        Ok(status)
+    }
 }
 
 #[cfg(feature = "metrics")]

--- a/crates/copybook-cli/src/main.rs
+++ b/crates/copybook-cli/src/main.rs
@@ -14,7 +14,6 @@ use copybook_codec::{
 };
 use copybook_core::{Error as CoreError, Feature, FeatureCategory, FeatureFlags};
 use std::borrow::Cow;
-use std::convert::TryFrom;
 use std::error::Error as StdError;
 use std::io::{self, ErrorKind, Write};
 use std::panic::AssertUnwindSafe;
@@ -565,7 +564,7 @@ fn run() -> anyhow::Result<ExitCode> {
         cli_runtime::InitOutcome::Exit(exit_code) => return Ok(exit_code),
     };
     let command_dispatch::CommandRun { status, op } =
-        command_dispatch::execute(runtime.command, runtime.strict_policy)?;
+        command_dispatch::execute(runtime.command, runtime.strict_policy);
 
     #[cfg(feature = "metrics")]
     if let (Err(err), Some((handle, _))) = (&status, &runtime.metrics_server) {
@@ -573,11 +572,20 @@ fn run() -> anyhow::Result<ExitCode> {
         bump_error_if_pre_run(err, records_processed);
     }
 
-    exit_reporting::finish(status?, op)
+    Ok(exit_reporting::finish(status?, op))
 }
 
 mod cli_runtime {
-    use super::*;
+    use super::{
+        BrokenPipeSafeStderr, ClapErrorKind, Cli, Commands, EnvFilter, ExitCode, ExitDiagnostics,
+        Feature, Level, Parser, Stage, effective_strict_policy, emit_exit_diagnostics_stage,
+        initialize_feature_flags, invocation_id, list_all_features,
+    };
+
+    #[cfg(feature = "metrics")]
+    use super::{
+        MetricsGraceGuard, describe_metrics_once, metrics_grace_guard, metrics_start_if_requested,
+    };
 
     pub(super) enum CliParseOutcome {
         Run(Box<Cli>),
@@ -611,7 +619,7 @@ mod cli_runtime {
     pub(super) fn parse_cli_or_exit() -> CliParseOutcome {
         match Cli::try_parse() {
             Ok(cli) => CliParseOutcome::Run(Box::new(cli)),
-            Err(err) => handle_parse_error(err),
+            Err(err) => handle_parse_error(&err),
         }
     }
 
@@ -652,7 +660,7 @@ mod cli_runtime {
         }))
     }
 
-    fn handle_parse_error(err: clap::Error) -> CliParseOutcome {
+    fn handle_parse_error(err: &clap::Error) -> CliParseOutcome {
         let kind = err.kind();
         let _ = err.print();
         if matches!(
@@ -686,7 +694,7 @@ mod cli_runtime {
             Level::ERROR,
             exit_code.as_i32(),
         )
-        .with_error(Some(&err));
+        .with_error(Some(err));
         emit_exit_diagnostics_stage(&diagnostics, Stage::Parse);
         CliParseOutcome::Exit(exit_code)
     }
@@ -721,29 +729,76 @@ mod cli_runtime {
 }
 
 mod command_dispatch {
-    use super::*;
+    use anyhow::anyhow;
+    use std::convert::TryFrom;
+
+    use super::{Commands, ExitCode, effective_dialect};
 
     pub(super) struct CommandRun {
         pub(super) status: anyhow::Result<ExitCode>,
         pub(super) op: &'static str,
     }
 
-    pub(super) fn execute(command: Commands, strict_policy: bool) -> anyhow::Result<CommandRun> {
-        let (status, op) = match command {
+    pub(super) fn execute(command: Commands, strict_policy: bool) -> CommandRun {
+        match command {
+            Commands::Parse { .. } | Commands::Inspect { .. } => execute_schema_command(command),
+            Commands::Decode { .. } | Commands::Encode { .. } => {
+                execute_codec_command(command, strict_policy)
+            }
+            #[cfg(feature = "audit")]
+            Commands::Audit { .. } => execute_support_command(command),
+            Commands::Verify { .. } | Commands::Support { .. } | Commands::Determinism { .. } => {
+                execute_support_command(command)
+            }
+        }
+    }
+
+    fn execute_schema_command(command: Commands) -> CommandRun {
+        match command {
             Commands::Parse {
                 copybook,
                 output,
                 strict,
                 strict_comments,
                 dialect,
-            } => run_parse(copybook, output, strict, strict_comments, dialect),
+            } => {
+                let effective_dialect = effective_dialect(dialect);
+                command_run(
+                    crate::commands::parse::run(
+                        &copybook,
+                        output,
+                        strict,
+                        strict_comments,
+                        effective_dialect,
+                    ),
+                    "parse",
+                )
+            }
             Commands::Inspect {
                 copybook,
                 codepage,
                 strict,
                 strict_comments,
                 dialect,
-            } => run_inspect(copybook, codepage, strict, strict_comments, dialect),
+            } => {
+                let effective_dialect = effective_dialect(dialect);
+                command_run(
+                    crate::commands::inspect::run(
+                        &copybook,
+                        codepage,
+                        strict,
+                        strict_comments,
+                        effective_dialect,
+                    ),
+                    "inspect",
+                )
+            }
+            _ => command_routing_error("schema"),
+        }
+    }
+
+    fn execute_codec_command(command: Commands, strict_policy: bool) -> CommandRun {
+        match command {
             Commands::Decode {
                 copybook,
                 input,
@@ -765,29 +820,35 @@ mod command_dispatch {
                 float_format,
                 dialect,
                 select,
-            } => run_decode(DecodeDispatchArgs {
-                copybook,
-                input,
-                output,
-                format,
-                codepage,
-                json_number,
-                strict,
-                max_errors,
-                fail_fast,
-                emit_filler,
-                emit_meta,
-                emit_raw,
-                on_decode_unmappable,
-                threads,
-                strict_comments,
-                preserve_zoned_encoding,
-                preferred_zoned_encoding_cli,
-                float_format,
-                dialect,
-                select,
-                strict_policy,
-            }),
+            } => {
+                let effective_dialect = effective_dialect(dialect);
+                command_run(
+                    crate::commands::decode::run(&crate::commands::decode::DecodeArgs {
+                        copybook: &copybook,
+                        input: &input,
+                        output: &output,
+                        format,
+                        codepage,
+                        json_number,
+                        strict,
+                        max_errors,
+                        fail_fast,
+                        emit_filler,
+                        emit_meta,
+                        emit_raw,
+                        on_decode_unmappable,
+                        threads,
+                        strict_comments,
+                        preserve_zoned_encoding,
+                        preferred_zoned_encoding: preferred_zoned_encoding_cli.into(),
+                        float_format,
+                        strict_policy,
+                        dialect: effective_dialect.into(),
+                        select: &select,
+                    }),
+                    "decode",
+                )
+            }
             Commands::Encode {
                 copybook,
                 input,
@@ -806,27 +867,49 @@ mod command_dispatch {
                 float_format,
                 dialect,
                 select,
-            } => run_encode(EncodeDispatchArgs {
-                copybook,
-                input,
-                output,
-                format,
-                codepage,
-                use_raw,
-                bwz_encode,
-                strict,
-                max_errors,
-                fail_fast,
-                threads,
-                coerce_numbers,
-                strict_comments,
-                zoned_encoding_override,
-                float_format,
-                dialect,
-                select,
-            }),
+            } => {
+                let effective_dialect = effective_dialect(dialect);
+                command_run(
+                    crate::commands::encode::run(
+                        &copybook,
+                        &input,
+                        &output,
+                        &crate::commands::encode::EncodeCliOptions {
+                            format,
+                            codepage,
+                            use_raw,
+                            bwz_encode,
+                            strict,
+                            max_errors,
+                            fail_fast,
+                            threads,
+                            coerce_numbers,
+                            strict_comments,
+                            zoned_encoding_override,
+                            float_format,
+                            dialect: effective_dialect.into(),
+                            select: &select,
+                        },
+                    ),
+                    "encode",
+                )
+            }
+            _ => command_routing_error("codec"),
+        }
+    }
+
+    fn execute_support_command(command: Commands) -> CommandRun {
+        match command {
             #[cfg(feature = "audit")]
-            Commands::Audit { audit_command } => run_audit(audit_command)?,
+            Commands::Audit { audit_command } => {
+                let status = match tokio::runtime::Runtime::new() {
+                    Ok(runtime) => runtime
+                        .block_on(crate::commands::audit::run(audit_command))
+                        .map_err(|err| anyhow!(err)),
+                    Err(err) => Err(anyhow!(err)),
+                };
+                command_run(status, "audit")
+            }
             Commands::Verify {
                 copybook,
                 input,
@@ -839,230 +922,60 @@ mod command_dispatch {
                 strict_comments,
                 dialect,
                 select,
-            } => run_verify(VerifyDispatchArgs {
-                copybook,
-                input,
-                report,
-                format,
-                codepage,
-                strict,
-                max_errors,
-                sample,
-                strict_comments,
-                dialect,
-                select,
-            })?,
-            Commands::Support { args } => (crate::commands::support::run(&args), "support"),
-            Commands::Determinism { command } => {
-                (crate::commands::determinism::run(&command), "determinism")
+            } => {
+                let effective_dialect = effective_dialect(dialect);
+                let status = (|| {
+                    let normalized_max_errors = normalize_max_errors(max_errors)?;
+                    let opts = crate::commands::verify::VerifyOptions {
+                        format,
+                        codepage,
+                        strict,
+                        max_errors: normalized_max_errors,
+                        sample: sample.unwrap_or(5),
+                        strict_comments,
+                        dialect: effective_dialect.into(),
+                        select: &select,
+                    };
+                    crate::commands::verify::run(&copybook, &input, report, &opts)
+                })();
+                command_run(status, "verify")
             }
-        };
-
-        Ok(CommandRun { status, op })
+            Commands::Support { args } => {
+                command_run(crate::commands::support::run(&args), "support")
+            }
+            Commands::Determinism { command } => {
+                command_run(crate::commands::determinism::run(&command), "determinism")
+            }
+            _ => command_routing_error("support"),
+        }
     }
 
-    fn run_parse(
-        copybook: PathBuf,
-        output: Option<PathBuf>,
-        strict: bool,
-        strict_comments: bool,
-        dialect: Option<DialectPreference>,
-    ) -> (anyhow::Result<ExitCode>, &'static str) {
-        let effective_dialect = effective_dialect(dialect);
-        (
-            crate::commands::parse::run(
-                &copybook,
-                output,
-                strict,
-                strict_comments,
-                effective_dialect,
-            ),
-            "parse",
+    fn command_run(status: anyhow::Result<ExitCode>, op: &'static str) -> CommandRun {
+        CommandRun { status, op }
+    }
+
+    fn command_routing_error(route: &'static str) -> CommandRun {
+        command_run(
+            Err(anyhow!("command routed to {route} dispatcher unexpectedly")),
+            "dispatch",
         )
     }
 
-    fn run_inspect(
-        copybook: PathBuf,
-        codepage: Codepage,
-        strict: bool,
-        strict_comments: bool,
-        dialect: Option<DialectPreference>,
-    ) -> (anyhow::Result<ExitCode>, &'static str) {
-        let effective_dialect = effective_dialect(dialect);
-        (
-            crate::commands::inspect::run(
-                &copybook,
-                codepage,
-                strict,
-                strict_comments,
-                effective_dialect,
-            ),
-            "inspect",
-        )
-    }
-
-    struct DecodeDispatchArgs {
-        copybook: PathBuf,
-        input: PathBuf,
-        output: PathBuf,
-        format: RecordFormat,
-        codepage: Codepage,
-        json_number: JsonNumberMode,
-        strict: bool,
-        max_errors: Option<u64>,
-        fail_fast: bool,
-        emit_filler: bool,
-        emit_meta: bool,
-        emit_raw: RawMode,
-        on_decode_unmappable: UnmappablePolicy,
-        threads: usize,
-        strict_comments: bool,
-        preserve_zoned_encoding: bool,
-        preferred_zoned_encoding_cli: ZonedEncodingPreference,
-        float_format: FloatFormat,
-        dialect: Option<DialectPreference>,
-        select: Vec<String>,
-        strict_policy: bool,
-    }
-
-    fn run_decode(args: DecodeDispatchArgs) -> (anyhow::Result<ExitCode>, &'static str) {
-        let effective_dialect = effective_dialect(args.dialect);
-        (
-            crate::commands::decode::run(&crate::commands::decode::DecodeArgs {
-                copybook: &args.copybook,
-                input: &args.input,
-                output: &args.output,
-                format: args.format,
-                codepage: args.codepage,
-                json_number: args.json_number,
-                strict: args.strict,
-                max_errors: args.max_errors,
-                fail_fast: args.fail_fast,
-                emit_filler: args.emit_filler,
-                emit_meta: args.emit_meta,
-                emit_raw: args.emit_raw,
-                on_decode_unmappable: args.on_decode_unmappable,
-                threads: args.threads,
-                strict_comments: args.strict_comments,
-                preserve_zoned_encoding: args.preserve_zoned_encoding,
-                preferred_zoned_encoding: args.preferred_zoned_encoding_cli.into(),
-                float_format: args.float_format,
-                strict_policy: args.strict_policy,
-                dialect: effective_dialect.into(),
-                select: &args.select,
-            }),
-            "decode",
-        )
-    }
-
-    struct EncodeDispatchArgs {
-        copybook: PathBuf,
-        input: PathBuf,
-        output: PathBuf,
-        format: RecordFormat,
-        codepage: Codepage,
-        use_raw: bool,
-        bwz_encode: bool,
-        strict: bool,
-        max_errors: Option<u64>,
-        fail_fast: bool,
-        threads: usize,
-        coerce_numbers: bool,
-        strict_comments: bool,
-        zoned_encoding_override: Option<copybook_codec::ZonedEncodingFormat>,
-        float_format: FloatFormat,
-        dialect: Option<DialectPreference>,
-        select: Vec<String>,
-    }
-
-    fn run_encode(args: EncodeDispatchArgs) -> (anyhow::Result<ExitCode>, &'static str) {
-        let effective_dialect = effective_dialect(args.dialect);
-        (
-            crate::commands::encode::run(
-                &args.copybook,
-                &args.input,
-                &args.output,
-                &crate::commands::encode::EncodeCliOptions {
-                    format: args.format,
-                    codepage: args.codepage,
-                    use_raw: args.use_raw,
-                    bwz_encode: args.bwz_encode,
-                    strict: args.strict,
-                    max_errors: args.max_errors,
-                    fail_fast: args.fail_fast,
-                    threads: args.threads,
-                    coerce_numbers: args.coerce_numbers,
-                    strict_comments: args.strict_comments,
-                    zoned_encoding_override: args.zoned_encoding_override,
-                    float_format: args.float_format,
-                    dialect: effective_dialect.into(),
-                    select: &args.select,
-                },
-            ),
-            "encode",
-        )
-    }
-
-    #[cfg(feature = "audit")]
-    fn run_audit(
-        audit_command: crate::commands::audit::AuditCommand,
-    ) -> anyhow::Result<(anyhow::Result<ExitCode>, &'static str)> {
-        let runtime = tokio::runtime::Runtime::new()?;
-        Ok((
-            runtime
-                .block_on(crate::commands::audit::run(audit_command))
-                .map_err(|err| anyhow!(err)),
-            "audit",
-        ))
-    }
-
-    struct VerifyDispatchArgs {
-        copybook: PathBuf,
-        input: PathBuf,
-        report: Option<PathBuf>,
-        format: RecordFormat,
-        codepage: Codepage,
-        strict: bool,
-        max_errors: Option<u64>,
-        sample: Option<u32>,
-        strict_comments: bool,
-        dialect: Option<DialectPreference>,
-        select: Vec<String>,
-    }
-
-    fn run_verify(
-        args: VerifyDispatchArgs,
-    ) -> anyhow::Result<(anyhow::Result<ExitCode>, &'static str)> {
-        let effective_dialect = effective_dialect(args.dialect);
-        let value = args.max_errors.unwrap_or(10);
-        let normalized_max_errors = u32::try_from(value).map_err(|_| {
+    fn normalize_max_errors(max_errors: Option<u64>) -> anyhow::Result<u32> {
+        let value = max_errors.unwrap_or(10);
+        u32::try_from(value).map_err(|_| {
             anyhow!(
                 "--max-errors must be between 0 and {} (received {value})",
                 u32::MAX
             )
-        })?;
-
-        let opts = crate::commands::verify::VerifyOptions {
-            format: args.format,
-            codepage: args.codepage,
-            strict: args.strict,
-            max_errors: normalized_max_errors,
-            sample: args.sample.unwrap_or(5),
-            strict_comments: args.strict_comments,
-            dialect: effective_dialect.into(),
-            select: &args.select,
-        };
-        Ok((
-            crate::commands::verify::run(&args.copybook, &args.input, args.report, &opts),
-            "verify",
-        ))
+        })
     }
 }
 
 mod exit_reporting {
-    use super::*;
+    use super::{ExitCode, ExitDiagnostics, Level, Stage, emit_exit_diagnostics_stage};
 
-    pub(super) fn finish(status: ExitCode, op: &'static str) -> anyhow::Result<ExitCode> {
+    pub(super) fn finish(status: ExitCode, op: &'static str) -> ExitCode {
         let diagnostics = if status == ExitCode::Ok {
             ExitDiagnostics::new(
                 ExitCode::Ok,
@@ -1090,7 +1003,7 @@ mod exit_reporting {
         };
         emit_exit_diagnostics_stage(&diagnostics, stage);
 
-        Ok(status)
+        status
     }
 }
 

--- a/crates/copybook-codec/src/fidelity.rs
+++ b/crates/copybook-codec/src/fidelity.rs
@@ -948,11 +948,9 @@ pub mod utils {
             .map(|p| p.validation_time_ms)
             .sum();
         let total_records_u64 = u64::try_from(total_records).unwrap_or(u64::MAX);
-        let average_validation_time = if total_records_u64 == 0 {
-            0
-        } else {
-            total_validation_time / total_records_u64
-        };
+        let average_validation_time = total_validation_time
+            .checked_div(total_records_u64)
+            .unwrap_or(0);
 
         BatchFidelityMetrics {
             total_records,

--- a/crates/copybook-contracts/src/feature_flags.rs
+++ b/crates/copybook-contracts/src/feature_flags.rs
@@ -530,8 +530,7 @@ impl FeatureFlagsHandle {
     pub fn is_enabled(&self, feature: Feature) -> bool {
         self.flags
             .read()
-            .map(|flags| flags.is_enabled(feature))
-            .unwrap_or(false)
+            .is_ok_and(|flags| flags.is_enabled(feature))
     }
 
     /// Enable a feature flag through the handle.

--- a/crates/copybook-core/src/audit/security.rs
+++ b/crates/copybook-core/src/audit/security.rs
@@ -421,8 +421,7 @@ impl SecurityMonitor {
         let priority = 16 * 8 + 4; // 132
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_secs());
         format!(
             "<{}>1 {} copybook-rs SecurityMonitor - {} - {}",
             priority, timestamp, violation.violation_id, violation.description


### PR DESCRIPTION
## Summary
- Split the CLI `run` lifecycle into focused in-file modules for parsing/initialization, command dispatch, and exit reporting.
- Preserved existing CLI behavior while keeping `main.rs` as a small orchestrator over the runtime stages.
- Resolved the shared baseline conflict by moving the `COPYBOOK_TEST_PANIC` hook into the runtime helper with the Rust 1.95 clippy-friendly assertion form.
- Reworked the dispatcher helpers to avoid wildcard imports, oversized dispatch functions, needless by-value arguments, and unnecessary `Result` wrapping under the current pedantic clippy gate.
- Applied the shared CI/security baseline updates used across the active cleanup PRs.

## Validation
- `cargo +1.95.0 fmt --all --check`
- `cargo +1.95.0 check -p copybook-cli --all-features`
- `cargo +1.95.0 test -p copybook-cli --all-features`
- `cargo +1.95.0 clippy --workspace --all-features --lib --bins --examples -- -D warnings -W clippy::pedantic`
- `cargo +1.95.0 clippy --workspace --tests --all-features -- -D warnings -A clippy::unwrap_used -A clippy::expect_used -A clippy::panic -A clippy::dbg_macro -A clippy::print_stdout -A clippy::print_stderr -A clippy::duplicated_attributes -A deprecated`
- `cargo deny --workspace --all-features check` (existing duplicate warnings and known unmatched `aws-lc-sys` warning only)
- `RUSTDOCFLAGS='-D warnings' cargo +1.95.0 doc --all-features --workspace --no-deps`
- `git diff --check origin/main...HEAD`
- `git diff --check`