### PR TITLE
refactor(cli): split runtime into SRP modules

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -14,6 +14,7 @@ on:
       - 'tests/**'
       - 'Cargo.*'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches: [ main, develop ]
     paths:
       - 'crates/**'
@@ -30,9 +31,13 @@ env:
 
 jobs:
   coverage:
-    name: Code Coverage
+    name: Tarpaulin Coverage
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'coverage') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     steps:
     - name: Checkout code

--- a/.github/workflows/leak-detection.yml
+++ b/.github/workflows/leak-detection.yml
@@ -6,6 +6,7 @@ on:
   schedule:
     - cron: "0 4 * * 0"  # Weekly on Sunday at 04:00 UTC
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - "crates/copybook-codec/**"
       - "crates/copybook-core/**"
@@ -24,6 +25,10 @@ jobs:
     name: Memory Leak Detection (LSAN)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'leak-check') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     steps:
       - uses: actions/checkout@v6
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
  "hex",
  "logos",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "serde_plain",
@@ -1049,7 +1049,7 @@ dependencies = [
  "copybook-codec",
  "copybook-core",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "sha2",
@@ -1156,7 +1156,7 @@ dependencies = [
  "copybook-support-matrix",
  "crossbeam-channel",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
 ]
@@ -3069,9 +3069,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -3364,9 +3364,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3780,7 +3780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/crates/copybook-cli/src/commands/audit.rs
+++ b/crates/copybook-cli/src/commands/audit.rs
@@ -2701,12 +2701,11 @@ fn run_audit_health_check_impl(
         );
     }
 
-    let overall_health_score = if checks_executed == 0 {
-        0
-    } else {
-        let failed_penalty = (checks_failed * 100) / checks_executed;
-        (100u32.saturating_sub(failed_penalty)).min(100)
-    };
+    let overall_health_score = (checks_failed * 100)
+        .checked_div(checks_executed)
+        .map_or(0, |failed_penalty| {
+            (100u32.saturating_sub(failed_penalty)).min(100)
+        });
 
     let status_code = if checks_failed > 0 || !parse_issues.is_empty() {
         ExitCode::Data

--- a/crates/copybook-cli/src/main.rs
+++ b/crates/copybook-cli/src/main.rs
@@ -7,14 +7,12 @@
 
 use crate::exit_codes::ExitCode;
 use anyhow::{Error as AnyhowError, anyhow};
-use clap::error::ErrorKind as ClapErrorKind;
 use clap::{Args, ColorChoice, Parser, Subcommand, ValueEnum};
 use copybook_codec::{
     Codepage, FloatFormat, JsonNumberMode, RawMode, RecordFormat, UnmappablePolicy,
 };
 use copybook_core::{Error as CoreError, Feature, FeatureCategory, FeatureFlags};
 use std::borrow::Cow;
-use std::convert::TryFrom;
 use std::error::Error as StdError;
 use std::io::{self, ErrorKind, Write};
 use std::panic::AssertUnwindSafe;
@@ -24,7 +22,6 @@ use std::str::FromStr;
 use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::Level;
-use tracing_subscriber::EnvFilter;
 
 #[cfg(feature = "metrics")]
 use std::net::SocketAddr;
@@ -552,335 +549,8 @@ fn main() -> ProcessExitCode {
     }
 }
 
-#[allow(clippy::too_many_lines)]
 fn run() -> anyhow::Result<ExitCode> {
-    #[allow(clippy::panic)]
-    if std::env::var("COPYBOOK_TEST_PANIC")
-        .map(|v| v == "1")
-        .unwrap_or(false)
-    {
-        panic!("COPYBOOK_TEST_PANIC triggered");
-    }
-
-    let cli = match Cli::try_parse() {
-        Ok(cli) => cli,
-        Err(err) => {
-            let kind = err.kind();
-            let _ = err.print();
-            if matches!(
-                kind,
-                ClapErrorKind::DisplayHelp | ClapErrorKind::DisplayVersion
-            ) {
-                let op = if matches!(kind, ClapErrorKind::DisplayVersion) {
-                    "version"
-                } else {
-                    "help"
-                };
-                let diagnostics = ExitDiagnostics::new(
-                    ExitCode::Ok,
-                    "completed",
-                    op,
-                    "", // op_stage will be overridden by emit_exit_diagnostics_stage
-                    Level::INFO,
-                    0,
-                );
-                emit_exit_diagnostics_stage(&diagnostics, Stage::Finalize);
-                return Ok(ExitCode::Ok);
-            }
-            let exit_code = ExitCode::Encode;
-            let message = err.to_string();
-            let diagnostics = ExitDiagnostics::new(
-                exit_code,
-                &message,
-                "cli_parse",
-                "", // op_stage will be overridden by emit_exit_diagnostics_stage
-                Level::ERROR,
-                exit_code.as_i32(),
-            )
-            .with_error(Some(&err));
-            emit_exit_diagnostics_stage(&diagnostics, Stage::Parse);
-            return Ok(exit_code);
-        }
-    };
-
-    #[cfg(feature = "metrics")]
-    let metrics_opts = cli.metrics.clone();
-
-    #[cfg(feature = "metrics")]
-    let metrics_server = metrics_start_if_requested(&metrics_opts)?;
-
-    #[cfg(feature = "metrics")]
-    if metrics_server.is_some() {
-        describe_metrics_once();
-    }
-
-    #[cfg(feature = "metrics")]
-    let _metrics_guard = metrics_grace_guard(&metrics_opts);
-
-    // Handle feature flags
-    let feature_flags = initialize_feature_flags(&cli.feature_flags)?;
-
-    // Set global feature flags for use by parser
-    copybook_core::feature_flags::FeatureFlags::set_global(feature_flags.clone());
-
-    if cli.feature_flags.list_features {
-        list_all_features(&feature_flags);
-        return Ok(ExitCode::Ok);
-    }
-
-    let strict_policy = effective_strict_policy(&cli);
-    let verbose = cli.verbose || feature_flags.is_enabled(Feature::VerboseLogging);
-    let command = cli.command;
-
-    // Initialize tracing
-    let default_directive = if verbose { "debug" } else { "warn" };
-    let env_filter =
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_directive));
-    tracing_subscriber::fmt()
-        .with_env_filter(env_filter)
-        .with_ansi(false)
-        .with_writer(|| BrokenPipeSafeStderr(std::io::stderr()))
-        .init();
-
-    let help_requested =
-        std::env::args_os().any(|arg| arg == "--help" || arg == "-h" || arg == "-?" || arg == "/?");
-    let version_requested = std::env::args_os().any(|arg| arg == "--version" || arg == "-V");
-    if !(help_requested || version_requested) {
-        tracing::info!(
-            invocation_id = %invocation_id(),
-            version = env!("CARGO_PKG_VERSION"),
-            commit = option_env!("GIT_SHA").unwrap_or("unknown"),
-            os = std::env::consts::OS,
-            arch = std::env::consts::ARCH,
-            strict_policy,
-            "copybook-cli start"
-        );
-    }
-
-    let (exit_status, exit_op): (anyhow::Result<ExitCode>, &'static str) = match command {
-        Commands::Parse {
-            copybook,
-            output,
-            strict,
-            strict_comments,
-            dialect,
-        } => {
-            let effective_dialect = effective_dialect(dialect);
-            (
-                crate::commands::parse::run(
-                    &copybook,
-                    output,
-                    strict,
-                    strict_comments,
-                    effective_dialect,
-                ),
-                "parse",
-            )
-        }
-        Commands::Inspect {
-            copybook,
-            codepage,
-            strict,
-            strict_comments,
-            dialect,
-        } => {
-            let effective_dialect = effective_dialect(dialect);
-            (
-                crate::commands::inspect::run(
-                    &copybook,
-                    codepage,
-                    strict,
-                    strict_comments,
-                    effective_dialect,
-                ),
-                "inspect",
-            )
-        }
-        Commands::Decode {
-            copybook,
-            input,
-            output,
-            format,
-            codepage,
-            json_number,
-            strict,
-            max_errors,
-            fail_fast,
-            emit_filler,
-            emit_meta,
-            emit_raw,
-            on_decode_unmappable,
-            threads,
-            strict_comments,
-            preserve_zoned_encoding,
-            preferred_zoned_encoding: preferred_zoned_encoding_cli,
-            float_format,
-            dialect,
-            select,
-        } => {
-            let effective_dialect = effective_dialect(dialect);
-            (
-                crate::commands::decode::run(&crate::commands::decode::DecodeArgs {
-                    copybook: &copybook,
-                    input: &input,
-                    output: &output,
-                    format,
-                    codepage,
-                    json_number,
-                    strict,
-                    max_errors,
-                    fail_fast,
-                    emit_filler,
-                    emit_meta,
-                    emit_raw,
-                    on_decode_unmappable,
-                    threads,
-                    strict_comments,
-                    preserve_zoned_encoding,
-                    preferred_zoned_encoding: preferred_zoned_encoding_cli.into(),
-                    float_format,
-                    strict_policy,
-                    dialect: effective_dialect.into(),
-                    select: &select,
-                }),
-                "decode",
-            )
-        }
-        Commands::Encode {
-            copybook,
-            input,
-            output,
-            format,
-            codepage,
-            use_raw,
-            bwz_encode,
-            strict,
-            max_errors,
-            fail_fast,
-            threads,
-            coerce_numbers,
-            strict_comments,
-            zoned_encoding_override,
-            float_format,
-            dialect,
-            select,
-        } => {
-            let effective_dialect = effective_dialect(dialect);
-            (
-                crate::commands::encode::run(
-                    &copybook,
-                    &input,
-                    &output,
-                    &crate::commands::encode::EncodeCliOptions {
-                        format,
-                        codepage,
-                        use_raw,
-                        bwz_encode,
-                        strict,
-                        max_errors,
-                        fail_fast,
-                        threads,
-                        coerce_numbers,
-                        strict_comments,
-                        zoned_encoding_override,
-                        float_format,
-                        dialect: effective_dialect.into(),
-                        select: &select,
-                    },
-                ),
-                "encode",
-            )
-        }
-        #[cfg(feature = "audit")]
-        Commands::Audit { audit_command } => {
-            // Run audit command asynchronously
-            let runtime = tokio::runtime::Runtime::new()?;
-            (
-                runtime
-                    .block_on(crate::commands::audit::run(audit_command))
-                    .map_err(|err| anyhow!(err)),
-                "audit",
-            )
-        }
-        Commands::Verify {
-            copybook,
-            input,
-            report,
-            format,
-            codepage,
-            strict,
-            max_errors,
-            sample,
-            strict_comments,
-            dialect,
-            select,
-        } => {
-            let effective_dialect = effective_dialect(dialect);
-            let value = max_errors.unwrap_or(10);
-            let normalized_max_errors = u32::try_from(value).map_err(|_| {
-                anyhow!(
-                    "--max-errors must be between 0 and {} (received {value})",
-                    u32::MAX
-                )
-            })?;
-
-            let opts = crate::commands::verify::VerifyOptions {
-                format,
-                codepage,
-                strict,
-                max_errors: normalized_max_errors,
-                sample: sample.unwrap_or(5),
-                strict_comments,
-                dialect: effective_dialect.into(),
-                select: &select,
-            };
-            (
-                crate::commands::verify::run(&copybook, &input, report, &opts),
-                "verify",
-            )
-        }
-        Commands::Support { args } => (crate::commands::support::run(&args), "support"),
-        Commands::Determinism { command } => {
-            (crate::commands::determinism::run(&command), "determinism")
-        }
-    };
-
-    #[cfg(feature = "metrics")]
-    if let (Err(err), Some((handle, _))) = (&exit_status, &metrics_server) {
-        let records_processed = metrics_records_total(handle);
-        bump_error_if_pre_run(err, records_processed);
-    }
-
-    let status = exit_status?;
-
-    let diagnostics = if status == ExitCode::Ok {
-        ExitDiagnostics::new(
-            ExitCode::Ok,
-            "completed",
-            exit_op,
-            "", // op_stage will be overridden by emit_exit_diagnostics_stage
-            Level::INFO,
-            0,
-        )
-    } else {
-        ExitDiagnostics::new(
-            status,
-            "command completed with non-zero exit code",
-            exit_op,
-            "", // op_stage will be overridden by emit_exit_diagnostics_stage
-            Level::ERROR,
-            status.as_i32(),
-        )
-    };
-
-    let stage = if status == ExitCode::Ok {
-        Stage::Finalize
-    } else {
-        Stage::Execute
-    };
-    emit_exit_diagnostics_stage(&diagnostics, stage);
-
-    Ok(status)
+    runtime::run()
 }
 
 #[cfg(feature = "metrics")]
@@ -1565,6 +1235,7 @@ mod commands {
 }
 
 mod exit_codes;
+mod runtime;
 mod utils;
 
 #[cfg(test)]

--- a/crates/copybook-cli/src/runtime/dispatch.rs
+++ b/crates/copybook-cli/src/runtime/dispatch.rs
@@ -12,7 +12,21 @@ pub(crate) struct CommandExecution {
 }
 
 pub(crate) fn execute_command(command: Commands, strict_policy: bool) -> CommandExecution {
-    let (status, operation) = match command {
+    match command {
+        Commands::Parse { .. } | Commands::Inspect { .. } => execute_schema_command(command),
+        Commands::Decode { .. } | Commands::Encode { .. } => {
+            execute_codec_command(command, strict_policy)
+        }
+        #[cfg(feature = "audit")]
+        Commands::Audit { .. } => execute_support_command(command),
+        Commands::Verify { .. } | Commands::Support { .. } | Commands::Determinism { .. } => {
+            execute_support_command(command)
+        }
+    }
+}
+
+fn execute_schema_command(command: Commands) -> CommandExecution {
+    match command {
         Commands::Parse {
             copybook,
             output,
@@ -21,7 +35,7 @@ pub(crate) fn execute_command(command: Commands, strict_policy: bool) -> Command
             dialect,
         } => {
             let effective_dialect = effective_dialect(dialect);
-            (
+            command_execution(
                 crate::commands::parse::run(
                     &copybook,
                     output,
@@ -40,7 +54,7 @@ pub(crate) fn execute_command(command: Commands, strict_policy: bool) -> Command
             dialect,
         } => {
             let effective_dialect = effective_dialect(dialect);
-            (
+            command_execution(
                 crate::commands::inspect::run(
                     &copybook,
                     codepage,
@@ -51,6 +65,12 @@ pub(crate) fn execute_command(command: Commands, strict_policy: bool) -> Command
                 "inspect",
             )
         }
+        _ => command_routing_error("schema"),
+    }
+}
+
+fn execute_codec_command(command: Commands, strict_policy: bool) -> CommandExecution {
+    match command {
         Commands::Decode {
             copybook,
             input,
@@ -74,7 +94,7 @@ pub(crate) fn execute_command(command: Commands, strict_policy: bool) -> Command
             select,
         } => {
             let effective_dialect = effective_dialect(dialect);
-            (
+            command_execution(
                 crate::commands::decode::run(&crate::commands::decode::DecodeArgs {
                     copybook: &copybook,
                     input: &input,
@@ -121,7 +141,7 @@ pub(crate) fn execute_command(command: Commands, strict_policy: bool) -> Command
             select,
         } => {
             let effective_dialect = effective_dialect(dialect);
-            (
+            command_execution(
                 crate::commands::encode::run(
                     &copybook,
                     &input,
@@ -146,6 +166,12 @@ pub(crate) fn execute_command(command: Commands, strict_policy: bool) -> Command
                 "encode",
             )
         }
+        _ => command_routing_error("codec"),
+    }
+}
+
+fn execute_support_command(command: Commands) -> CommandExecution {
+    match command {
         #[cfg(feature = "audit")]
         Commands::Audit { audit_command } => {
             let status = match tokio::runtime::Runtime::new() {
@@ -154,7 +180,7 @@ pub(crate) fn execute_command(command: Commands, strict_policy: bool) -> Command
                     .map_err(|err| anyhow!(err)),
                 Err(err) => Err(anyhow!(err)),
             };
-            (status, "audit")
+            command_execution(status, "audit")
         }
         Commands::Verify {
             copybook,
@@ -183,15 +209,30 @@ pub(crate) fn execute_command(command: Commands, strict_policy: bool) -> Command
                 };
                 crate::commands::verify::run(&copybook, &input, report, &opts)
             });
-            (status, "verify")
+            command_execution(status, "verify")
         }
-        Commands::Support { args } => (crate::commands::support::run(&args), "support"),
+        Commands::Support { args } => {
+            command_execution(crate::commands::support::run(&args), "support")
+        }
         Commands::Determinism { command } => {
-            (crate::commands::determinism::run(&command), "determinism")
+            command_execution(crate::commands::determinism::run(&command), "determinism")
         }
-    };
+        _ => command_routing_error("support"),
+    }
+}
 
+fn command_execution(
+    status: anyhow::Result<ExitCode>,
+    operation: &'static str,
+) -> CommandExecution {
     CommandExecution { status, operation }
+}
+
+fn command_routing_error(route: &'static str) -> CommandExecution {
+    command_execution(
+        Err(anyhow!("command routed to {route} dispatcher unexpectedly")),
+        "dispatch",
+    )
 }
 
 fn normalize_max_errors(max_errors: Option<u64>) -> anyhow::Result<u32> {

--- a/crates/copybook-cli/src/runtime/dispatch.rs
+++ b/crates/copybook-cli/src/runtime/dispatch.rs
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Command dispatch: translate parsed CLI variants into command module calls.
+
+use crate::exit_codes::ExitCode;
+use crate::{Commands, effective_dialect};
+use anyhow::anyhow;
+use std::convert::TryFrom;
+
+pub(crate) struct CommandExecution {
+    pub(crate) status: anyhow::Result<ExitCode>,
+    pub(crate) operation: &'static str,
+}
+
+pub(crate) fn execute_command(command: Commands, strict_policy: bool) -> CommandExecution {
+    let (status, operation) = match command {
+        Commands::Parse {
+            copybook,
+            output,
+            strict,
+            strict_comments,
+            dialect,
+        } => {
+            let effective_dialect = effective_dialect(dialect);
+            (
+                crate::commands::parse::run(
+                    &copybook,
+                    output,
+                    strict,
+                    strict_comments,
+                    effective_dialect,
+                ),
+                "parse",
+            )
+        }
+        Commands::Inspect {
+            copybook,
+            codepage,
+            strict,
+            strict_comments,
+            dialect,
+        } => {
+            let effective_dialect = effective_dialect(dialect);
+            (
+                crate::commands::inspect::run(
+                    &copybook,
+                    codepage,
+                    strict,
+                    strict_comments,
+                    effective_dialect,
+                ),
+                "inspect",
+            )
+        }
+        Commands::Decode {
+            copybook,
+            input,
+            output,
+            format,
+            codepage,
+            json_number,
+            strict,
+            max_errors,
+            fail_fast,
+            emit_filler,
+            emit_meta,
+            emit_raw,
+            on_decode_unmappable,
+            threads,
+            strict_comments,
+            preserve_zoned_encoding,
+            preferred_zoned_encoding: preferred_zoned_encoding_cli,
+            float_format,
+            dialect,
+            select,
+        } => {
+            let effective_dialect = effective_dialect(dialect);
+            (
+                crate::commands::decode::run(&crate::commands::decode::DecodeArgs {
+                    copybook: &copybook,
+                    input: &input,
+                    output: &output,
+                    format,
+                    codepage,
+                    json_number,
+                    strict,
+                    max_errors,
+                    fail_fast,
+                    emit_filler,
+                    emit_meta,
+                    emit_raw,
+                    on_decode_unmappable,
+                    threads,
+                    strict_comments,
+                    preserve_zoned_encoding,
+                    preferred_zoned_encoding: preferred_zoned_encoding_cli.into(),
+                    float_format,
+                    strict_policy,
+                    dialect: effective_dialect.into(),
+                    select: &select,
+                }),
+                "decode",
+            )
+        }
+        Commands::Encode {
+            copybook,
+            input,
+            output,
+            format,
+            codepage,
+            use_raw,
+            bwz_encode,
+            strict,
+            max_errors,
+            fail_fast,
+            threads,
+            coerce_numbers,
+            strict_comments,
+            zoned_encoding_override,
+            float_format,
+            dialect,
+            select,
+        } => {
+            let effective_dialect = effective_dialect(dialect);
+            (
+                crate::commands::encode::run(
+                    &copybook,
+                    &input,
+                    &output,
+                    &crate::commands::encode::EncodeCliOptions {
+                        format,
+                        codepage,
+                        use_raw,
+                        bwz_encode,
+                        strict,
+                        max_errors,
+                        fail_fast,
+                        threads,
+                        coerce_numbers,
+                        strict_comments,
+                        zoned_encoding_override,
+                        float_format,
+                        dialect: effective_dialect.into(),
+                        select: &select,
+                    },
+                ),
+                "encode",
+            )
+        }
+        #[cfg(feature = "audit")]
+        Commands::Audit { audit_command } => {
+            let status = match tokio::runtime::Runtime::new() {
+                Ok(runtime) => runtime
+                    .block_on(crate::commands::audit::run(audit_command))
+                    .map_err(|err| anyhow!(err)),
+                Err(err) => Err(anyhow!(err)),
+            };
+            (status, "audit")
+        }
+        Commands::Verify {
+            copybook,
+            input,
+            report,
+            format,
+            codepage,
+            strict,
+            max_errors,
+            sample,
+            strict_comments,
+            dialect,
+            select,
+        } => {
+            let effective_dialect = effective_dialect(dialect);
+            let status = normalize_max_errors(max_errors).and_then(|normalized_max_errors| {
+                let opts = crate::commands::verify::VerifyOptions {
+                    format,
+                    codepage,
+                    strict,
+                    max_errors: normalized_max_errors,
+                    sample: sample.unwrap_or(5),
+                    strict_comments,
+                    dialect: effective_dialect.into(),
+                    select: &select,
+                };
+                crate::commands::verify::run(&copybook, &input, report, &opts)
+            });
+            (status, "verify")
+        }
+        Commands::Support { args } => (crate::commands::support::run(&args), "support"),
+        Commands::Determinism { command } => {
+            (crate::commands::determinism::run(&command), "determinism")
+        }
+    };
+
+    CommandExecution { status, operation }
+}
+
+fn normalize_max_errors(max_errors: Option<u64>) -> anyhow::Result<u32> {
+    let value = max_errors.unwrap_or(10);
+    u32::try_from(value).map_err(|_| {
+        anyhow!(
+            "--max-errors must be between 0 and {} (received {value})",
+            u32::MAX
+        )
+    })
+}

--- a/crates/copybook-cli/src/runtime/finalize.rs
+++ b/crates/copybook-cli/src/runtime/finalize.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Exit diagnostics and status finalization.
+
+use super::dispatch::CommandExecution;
+use crate::exit_codes::ExitCode;
+use crate::{ExitDiagnostics, Stage, emit_exit_diagnostics_stage};
+use tracing::Level;
+
+pub(crate) fn finalize_execution(execution: CommandExecution) -> anyhow::Result<ExitCode> {
+    let status = execution.status?;
+    emit_command_diagnostics(status, execution.operation);
+    Ok(status)
+}
+
+fn emit_command_diagnostics(status: ExitCode, operation: &'static str) {
+    let diagnostics = if status == ExitCode::Ok {
+        ExitDiagnostics::new(
+            ExitCode::Ok,
+            "completed",
+            operation,
+            "", // op_stage will be overridden by emit_exit_diagnostics_stage
+            Level::INFO,
+            0,
+        )
+    } else {
+        ExitDiagnostics::new(
+            status,
+            "command completed with non-zero exit code",
+            operation,
+            "", // op_stage will be overridden by emit_exit_diagnostics_stage
+            Level::ERROR,
+            status.as_i32(),
+        )
+    };
+
+    let stage = if status == ExitCode::Ok {
+        Stage::Finalize
+    } else {
+        Stage::Execute
+    };
+    emit_exit_diagnostics_stage(&diagnostics, stage);
+}

--- a/crates/copybook-cli/src/runtime/mod.rs
+++ b/crates/copybook-cli/src/runtime/mod.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Single-responsibility runtime orchestration for the CLI entrypoint.
+
+mod dispatch;
+mod finalize;
+mod parse;
+mod telemetry;
+
+use crate::exit_codes::ExitCode;
+
+pub(crate) fn run() -> anyhow::Result<ExitCode> {
+    trigger_test_panic_if_requested();
+
+    let cli = match parse::parse_cli()? {
+        parse::ParseOutcome::Run(cli) => *cli,
+        parse::ParseOutcome::Exit(exit_code) => return Ok(exit_code),
+    };
+
+    #[cfg(feature = "metrics")]
+    let metrics_opts = cli.metrics.clone();
+
+    #[cfg(feature = "metrics")]
+    let metrics_server = crate::metrics_start_if_requested(&metrics_opts)?;
+
+    #[cfg(feature = "metrics")]
+    if metrics_server.is_some() {
+        crate::describe_metrics_once();
+    }
+
+    #[cfg(feature = "metrics")]
+    let _metrics_guard = crate::metrics_grace_guard(&metrics_opts);
+
+    let startup = telemetry::configure_runtime(cli)?;
+    let (command, strict_policy) = match startup {
+        telemetry::RuntimeStartup::Execute {
+            command,
+            strict_policy,
+        } => (command, strict_policy),
+        telemetry::RuntimeStartup::Exit(exit_code) => return Ok(exit_code),
+    };
+    let execution = dispatch::execute_command(command, strict_policy);
+
+    #[cfg(feature = "metrics")]
+    if let (Err(err), Some((handle, _))) = (&execution.status, &metrics_server) {
+        let records_processed = crate::metrics_records_total(handle);
+        crate::bump_error_if_pre_run(err, records_processed);
+    }
+
+    finalize::finalize_execution(execution)
+}
+
+fn trigger_test_panic_if_requested() {
+    #[allow(clippy::panic)]
+    if std::env::var("COPYBOOK_TEST_PANIC")
+        .map(|v| v == "1")
+        .unwrap_or(false)
+    {
+        panic!("COPYBOOK_TEST_PANIC triggered");
+    }
+}

--- a/crates/copybook-cli/src/runtime/mod.rs
+++ b/crates/copybook-cli/src/runtime/mod.rs
@@ -11,7 +11,7 @@ use crate::exit_codes::ExitCode;
 pub(crate) fn run() -> anyhow::Result<ExitCode> {
     trigger_test_panic_if_requested();
 
-    let cli = match parse::parse_cli()? {
+    let cli = match parse::parse_cli() {
         parse::ParseOutcome::Run(cli) => *cli,
         parse::ParseOutcome::Exit(exit_code) => return Ok(exit_code),
     };

--- a/crates/copybook-cli/src/runtime/mod.rs
+++ b/crates/copybook-cli/src/runtime/mod.rs
@@ -50,11 +50,8 @@ pub(crate) fn run() -> anyhow::Result<ExitCode> {
 }
 
 fn trigger_test_panic_if_requested() {
-    #[allow(clippy::panic)]
-    if std::env::var("COPYBOOK_TEST_PANIC")
-        .map(|v| v == "1")
-        .unwrap_or(false)
-    {
-        panic!("COPYBOOK_TEST_PANIC triggered");
-    }
+    assert!(
+        !std::env::var("COPYBOOK_TEST_PANIC").is_ok_and(|v| v == "1"),
+        "COPYBOOK_TEST_PANIC triggered"
+    );
 }

--- a/crates/copybook-cli/src/runtime/parse.rs
+++ b/crates/copybook-cli/src/runtime/parse.rs
@@ -12,9 +12,9 @@ pub(crate) enum ParseOutcome {
     Exit(ExitCode),
 }
 
-pub(crate) fn parse_cli() -> anyhow::Result<ParseOutcome> {
+pub(crate) fn parse_cli() -> ParseOutcome {
     match Cli::try_parse() {
-        Ok(cli) => Ok(ParseOutcome::Run(Box::new(cli))),
+        Ok(cli) => ParseOutcome::Run(Box::new(cli)),
         Err(err) => {
             let kind = err.kind();
             let _ = err.print();
@@ -36,7 +36,7 @@ pub(crate) fn parse_cli() -> anyhow::Result<ParseOutcome> {
                     0,
                 );
                 emit_exit_diagnostics_stage(&diagnostics, Stage::Finalize);
-                return Ok(ParseOutcome::Exit(ExitCode::Ok));
+                return ParseOutcome::Exit(ExitCode::Ok);
             }
             let exit_code = ExitCode::Encode;
             let message = err.to_string();
@@ -50,7 +50,7 @@ pub(crate) fn parse_cli() -> anyhow::Result<ParseOutcome> {
             )
             .with_error(Some(&err));
             emit_exit_diagnostics_stage(&diagnostics, Stage::Parse);
-            Ok(ParseOutcome::Exit(exit_code))
+            ParseOutcome::Exit(exit_code)
         }
     }
 }

--- a/crates/copybook-cli/src/runtime/parse.rs
+++ b/crates/copybook-cli/src/runtime/parse.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! CLI parsing and parse-error diagnostics.
+
+use crate::exit_codes::ExitCode;
+use crate::{Cli, ExitDiagnostics, Stage, emit_exit_diagnostics_stage};
+use clap::Parser;
+use clap::error::ErrorKind as ClapErrorKind;
+use tracing::Level;
+
+pub(crate) enum ParseOutcome {
+    Run(Box<Cli>),
+    Exit(ExitCode),
+}
+
+pub(crate) fn parse_cli() -> anyhow::Result<ParseOutcome> {
+    match Cli::try_parse() {
+        Ok(cli) => Ok(ParseOutcome::Run(Box::new(cli))),
+        Err(err) => {
+            let kind = err.kind();
+            let _ = err.print();
+            if matches!(
+                kind,
+                ClapErrorKind::DisplayHelp | ClapErrorKind::DisplayVersion
+            ) {
+                let op = if matches!(kind, ClapErrorKind::DisplayVersion) {
+                    "version"
+                } else {
+                    "help"
+                };
+                let diagnostics = ExitDiagnostics::new(
+                    ExitCode::Ok,
+                    "completed",
+                    op,
+                    "", // op_stage will be overridden by emit_exit_diagnostics_stage
+                    Level::INFO,
+                    0,
+                );
+                emit_exit_diagnostics_stage(&diagnostics, Stage::Finalize);
+                return Ok(ParseOutcome::Exit(ExitCode::Ok));
+            }
+            let exit_code = ExitCode::Encode;
+            let message = err.to_string();
+            let diagnostics = ExitDiagnostics::new(
+                exit_code,
+                &message,
+                "cli_parse",
+                "", // op_stage will be overridden by emit_exit_diagnostics_stage
+                Level::ERROR,
+                exit_code.as_i32(),
+            )
+            .with_error(Some(&err));
+            emit_exit_diagnostics_stage(&diagnostics, Stage::Parse);
+            Ok(ParseOutcome::Exit(exit_code))
+        }
+    }
+}

--- a/crates/copybook-cli/src/runtime/telemetry.rs
+++ b/crates/copybook-cli/src/runtime/telemetry.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Feature-flag, strict-policy, and tracing startup concerns.
+
+use crate::{BrokenPipeSafeStderr, Cli, Commands, effective_strict_policy, invocation_id};
+use copybook_core::Feature;
+use tracing_subscriber::EnvFilter;
+
+pub(crate) enum RuntimeStartup {
+    Execute {
+        command: Commands,
+        strict_policy: bool,
+    },
+    Exit(crate::exit_codes::ExitCode),
+}
+
+pub(crate) fn configure_runtime(cli: Cli) -> anyhow::Result<RuntimeStartup> {
+    let feature_flags = crate::initialize_feature_flags(&cli.feature_flags)?;
+
+    copybook_core::feature_flags::FeatureFlags::set_global(feature_flags.clone());
+
+    if cli.feature_flags.list_features {
+        crate::list_all_features(&feature_flags);
+        return Ok(RuntimeStartup::Exit(crate::exit_codes::ExitCode::Ok));
+    }
+
+    let strict_policy = effective_strict_policy(&cli);
+    let verbose = cli.verbose || feature_flags.is_enabled(Feature::VerboseLogging);
+    initialize_tracing(verbose);
+    log_startup(strict_policy);
+
+    Ok(RuntimeStartup::Execute {
+        command: cli.command,
+        strict_policy,
+    })
+}
+
+fn initialize_tracing(verbose: bool) {
+    let default_directive = if verbose { "debug" } else { "warn" };
+    let env_filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_directive));
+    tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .with_ansi(false)
+        .with_writer(|| BrokenPipeSafeStderr(std::io::stderr()))
+        .init();
+}
+
+fn log_startup(strict_policy: bool) {
+    let help_requested =
+        std::env::args_os().any(|arg| arg == "--help" || arg == "-h" || arg == "-?" || arg == "/?");
+    let version_requested = std::env::args_os().any(|arg| arg == "--version" || arg == "-V");
+    if !(help_requested || version_requested) {
+        tracing::info!(
+            invocation_id = %invocation_id(),
+            version = env!("CARGO_PKG_VERSION"),
+            commit = option_env!("GIT_SHA").unwrap_or("unknown"),
+            os = std::env::consts::OS,
+            arch = std::env::consts::ARCH,
+            strict_policy,
+            "copybook-cli start"
+        );
+    }
+}

--- a/crates/copybook-codec/src/fidelity.rs
+++ b/crates/copybook-codec/src/fidelity.rs
@@ -948,11 +948,9 @@ pub mod utils {
             .map(|p| p.validation_time_ms)
             .sum();
         let total_records_u64 = u64::try_from(total_records).unwrap_or(u64::MAX);
-        let average_validation_time = if total_records_u64 == 0 {
-            0
-        } else {
-            total_validation_time / total_records_u64
-        };
+        let average_validation_time = total_validation_time
+            .checked_div(total_records_u64)
+            .unwrap_or(0);
 
         BatchFidelityMetrics {
             total_records,

--- a/crates/copybook-contracts/src/feature_flags.rs
+++ b/crates/copybook-contracts/src/feature_flags.rs
@@ -530,8 +530,7 @@ impl FeatureFlagsHandle {
     pub fn is_enabled(&self, feature: Feature) -> bool {
         self.flags
             .read()
-            .map(|flags| flags.is_enabled(feature))
-            .unwrap_or(false)
+            .is_ok_and(|flags| flags.is_enabled(feature))
     }
 
     /// Enable a feature flag through the handle.

--- a/crates/copybook-core/src/audit/security.rs
+++ b/crates/copybook-core/src/audit/security.rs
@@ -421,8 +421,7 @@ impl SecurityMonitor {
         let priority = 16 * 8 + 4; // 132
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_secs());
         format!(
             "<{}>1 {} copybook-rs SecurityMonitor - {} - {}",
             priority, timestamp, violation.violation_id, violation.description


### PR DESCRIPTION
## Summary
- Keep `main.rs` as a thin entrypoint that delegates to `runtime::run`.
- Split CLI runtime responsibilities into parse, telemetry, dispatch, and finalize modules.
- Preserve the `COPYBOOK_TEST_PANIC` test hook in runtime after the baseline conflict resolution.
- Simplify CLI parsing and split command dispatch helpers so the refactor stays clean under Rust 1.95 clippy.
- Apply the shared CI/security baseline updates used across the active cleanup PRs.

## Validation
- `cargo +1.95.0 fmt --all --check`
- `cargo +1.95.0 check -p copybook-cli --all-features`
- `cargo +1.95.0 test -p copybook-cli --all-features`
- `cargo +1.95.0 clippy --workspace --all-features --lib --bins --examples -- -D warnings -W clippy::pedantic`
- `cargo +1.95.0 clippy --workspace --tests --all-features -- -D warnings -A clippy::unwrap_used -A clippy::expect_used -A clippy::panic -A clippy::dbg_macro -A clippy::print_stdout -A clippy::print_stderr -A clippy::duplicated_attributes -A deprecated`
- `cargo deny --workspace --all-features check` (existing duplicate warnings and known unmatched `aws-lc-sys` warning only)
- `RUSTDOCFLAGS='-D warnings' cargo +1.95.0 doc --all-features --workspace --no-deps`
- `git diff --check origin/main...HEAD`
- `git diff --check`