### PR TITLE
fix(codec): honor encode unmappable policy

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -14,6 +14,7 @@ on:
       - 'tests/**'
       - 'Cargo.*'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches: [ main, develop ]
     paths:
       - 'crates/**'
@@ -30,9 +31,13 @@ env:
 
 jobs:
   coverage:
-    name: Code Coverage
+    name: Tarpaulin Coverage
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'coverage') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     steps:
     - name: Checkout code

--- a/.github/workflows/leak-detection.yml
+++ b/.github/workflows/leak-detection.yml
@@ -6,6 +6,7 @@ on:
   schedule:
     - cron: "0 4 * * 0"  # Weekly on Sunday at 04:00 UTC
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - "crates/copybook-codec/**"
       - "crates/copybook-core/**"
@@ -24,6 +25,10 @@ jobs:
     name: Memory Leak Detection (LSAN)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'leak-check') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     steps:
       - uses: actions/checkout@v6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **codec**: Wire `EncodeOptions::on_encode_unmappable` through the `lib_api` encode path. The option was settable and round-tripped through CLI/option tests but had no effect on encoding — `utf8_to_ebcdic` always errored on unmappable characters regardless of policy. Adds `utf8_to_ebcdic_with_policy` to `copybook-charset` and routes `Replace` (substitute codepage space) and `Skip` (drop the character) through `encode_alphanum_field` and the edited-PIC encode path.
 - Release prep: resolve clippy/rustdoc gate failures across core, codec, arrow examples, and test suites
 - Release prep: stabilize enterprise throughput assertions in `enterprise_mainframe_production_scenarios` for CI-consistent performance checks
 - **ci**: Add `workflow_dispatch` trigger to CI Quick and Feature Flags CI workflows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
  "hex",
  "logos",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "serde_plain",
@@ -1049,7 +1049,7 @@ dependencies = [
  "copybook-codec",
  "copybook-core",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "sha2",
@@ -1156,7 +1156,7 @@ dependencies = [
  "copybook-support-matrix",
  "crossbeam-channel",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
 ]
@@ -3069,9 +3069,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -3364,9 +3364,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3780,7 +3780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/crates/copybook-charset/src/lib.rs
+++ b/crates/copybook-charset/src/lib.rs
@@ -413,9 +413,10 @@ pub fn ebcdic_to_utf8(data: &[u8], codepage: Codepage, policy: UnmappablePolicy)
     Ok(result)
 }
 
-/// Convert UTF-8 string to EBCDIC bytes
+/// Convert UTF-8 string to EBCDIC bytes, erroring on unmappable characters.
 ///
-/// Encodes a UTF-8 string into EBCDIC bytes for the specified codepage.
+/// Equivalent to [`utf8_to_ebcdic_with_policy`] called with
+/// [`UnmappablePolicy::Error`].
 ///
 /// # Examples
 ///
@@ -431,6 +432,45 @@ pub fn ebcdic_to_utf8(data: &[u8], codepage: Codepage, policy: UnmappablePolicy)
 #[inline]
 #[must_use = "Handle the Result or propagate the error"]
 pub fn utf8_to_ebcdic(text: &str, codepage: Codepage) -> Result<Vec<u8>> {
+    utf8_to_ebcdic_with_policy(text, codepage, UnmappablePolicy::Error)
+}
+
+/// Convert UTF-8 string to EBCDIC bytes with an explicit unmappable policy.
+///
+/// Encodes `text` into EBCDIC bytes for `codepage`. When a character cannot
+/// be mapped to the target codepage, behaviour is controlled by `policy`:
+///
+/// - [`UnmappablePolicy::Error`]: return an error (matches [`utf8_to_ebcdic`]).
+/// - [`UnmappablePolicy::Replace`]: substitute the codepage's space byte and
+///   log a warning. The output length is preserved.
+/// - [`UnmappablePolicy::Skip`]: drop the character and log a warning. The
+///   output is shorter than the input by one byte per skipped character;
+///   callers that need fixed-width output should pad after encoding.
+///
+/// # Examples
+///
+/// ```
+/// use copybook_charset::{utf8_to_ebcdic_with_policy, Codepage, UnmappablePolicy};
+///
+/// // Replace policy substitutes EBCDIC space (0x40) for unmappable characters.
+/// let ebcdic = utf8_to_ebcdic_with_policy("A日B", Codepage::CP037, UnmappablePolicy::Replace).unwrap();
+/// assert_eq!(ebcdic, vec![0xC1, 0x40, 0xC2]);
+///
+/// // Skip policy drops unmappable characters.
+/// let ebcdic = utf8_to_ebcdic_with_policy("A日B", Codepage::CP037, UnmappablePolicy::Skip).unwrap();
+/// assert_eq!(ebcdic, vec![0xC1, 0xC2]);
+/// ```
+///
+/// # Errors
+/// Returns an error if `codepage` is unsupported, or if `policy` is
+/// [`UnmappablePolicy::Error`] and the text contains an unmappable character.
+#[inline]
+#[must_use = "Handle the Result or propagate the error"]
+pub fn utf8_to_ebcdic_with_policy(
+    text: &str,
+    codepage: Codepage,
+    policy: UnmappablePolicy,
+) -> Result<Vec<u8>> {
     // ASCII pass-through mode (transparent 8-bit, not Windows-1252)
     if codepage == Codepage::ASCII {
         return Ok(text.as_bytes().to_vec());
@@ -462,11 +502,28 @@ pub fn utf8_to_ebcdic(text: &str, codepage: Codepage) -> Result<Vec<u8>> {
     for ch in text.chars() {
         if let Some(&ebcdic_byte) = reverse_table.get(&ch) {
             result.push(ebcdic_byte);
-        } else {
-            return Err(Error::new(
-                ErrorCode::CBKC301_INVALID_EBCDIC_BYTE,
-                format!("Character '{ch}' cannot be mapped to {codepage:?}"),
-            ));
+            continue;
+        }
+        match policy {
+            UnmappablePolicy::Error => {
+                return Err(Error::new(
+                    ErrorCode::CBKC301_INVALID_EBCDIC_BYTE,
+                    format!("Character '{ch}' cannot be mapped to {codepage:?}"),
+                ));
+            }
+            UnmappablePolicy::Replace => {
+                warn!(
+                    "CBKC301_INVALID_EBCDIC_BYTE: Character '{}' cannot be mapped to {:?}, replacing with space",
+                    ch, codepage
+                );
+                result.push(space_byte(codepage));
+            }
+            UnmappablePolicy::Skip => {
+                warn!(
+                    "CBKC301_INVALID_EBCDIC_BYTE: Character '{}' cannot be mapped to {:?}, skipping",
+                    ch, codepage
+                );
+            }
         }
     }
 
@@ -683,6 +740,56 @@ mod tests {
         // Chinese character cannot be mapped to CP037
         let err = utf8_to_ebcdic("日", Codepage::CP037).unwrap_err();
         assert_eq!(err.code, ErrorCode::CBKC301_INVALID_EBCDIC_BYTE);
+    }
+
+    #[test]
+    fn test_utf8_to_ebcdic_policy_error_matches_default() {
+        let default = utf8_to_ebcdic("日", Codepage::CP037).unwrap_err();
+        let explicit =
+            utf8_to_ebcdic_with_policy("日", Codepage::CP037, UnmappablePolicy::Error).unwrap_err();
+        assert_eq!(default.code, explicit.code);
+    }
+
+    #[test]
+    fn test_utf8_to_ebcdic_policy_replace_substitutes_space() {
+        // Unmappable character is replaced with the codepage's space byte
+        // (0x40 for CP037). Length matches the input character count.
+        let result =
+            utf8_to_ebcdic_with_policy("A日B", Codepage::CP037, UnmappablePolicy::Replace).unwrap();
+        assert_eq!(result, vec![0xC1, 0x40, 0xC2]);
+    }
+
+    #[test]
+    fn test_utf8_to_ebcdic_policy_skip_drops_unmappable() {
+        // Unmappable character is dropped; output is shorter than input.
+        let result =
+            utf8_to_ebcdic_with_policy("A日B", Codepage::CP037, UnmappablePolicy::Skip).unwrap();
+        assert_eq!(result, vec![0xC1, 0xC2]);
+    }
+
+    #[test]
+    fn test_utf8_to_ebcdic_policy_replace_all_unmappable() {
+        // Every character unmappable: output is all space bytes.
+        let result =
+            utf8_to_ebcdic_with_policy("日本語", Codepage::CP037, UnmappablePolicy::Replace)
+                .unwrap();
+        assert_eq!(result, vec![0x40, 0x40, 0x40]);
+    }
+
+    #[test]
+    fn test_utf8_to_ebcdic_policy_skip_all_unmappable() {
+        // Every character unmappable: output is empty.
+        let result =
+            utf8_to_ebcdic_with_policy("日本語", Codepage::CP037, UnmappablePolicy::Skip).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_utf8_to_ebcdic_policy_ascii_passthrough_ignores_policy() {
+        // ASCII codepage is a pure pass-through; the policy has no effect.
+        let result =
+            utf8_to_ebcdic_with_policy("Hello", Codepage::ASCII, UnmappablePolicy::Error).unwrap();
+        assert_eq!(result, b"Hello");
     }
 
     #[test]

--- a/crates/copybook-cli/src/commands/audit.rs
+++ b/crates/copybook-cli/src/commands/audit.rs
@@ -2701,12 +2701,11 @@ fn run_audit_health_check_impl(
         );
     }
 
-    let overall_health_score = if checks_executed == 0 {
-        0
-    } else {
-        let failed_penalty = (checks_failed * 100) / checks_executed;
-        (100u32.saturating_sub(failed_penalty)).min(100)
-    };
+    let overall_health_score = (checks_failed * 100)
+        .checked_div(checks_executed)
+        .map_or(0, |failed_penalty| {
+            (100u32.saturating_sub(failed_penalty)).min(100)
+        });
 
     let status_code = if checks_failed > 0 || !parse_issues.is_empty() {
         ExitCode::Data

--- a/crates/copybook-cli/src/main.rs
+++ b/crates/copybook-cli/src/main.rs
@@ -554,13 +554,10 @@ fn main() -> ProcessExitCode {
 
 #[allow(clippy::too_many_lines)]
 fn run() -> anyhow::Result<ExitCode> {
-    #[allow(clippy::panic)]
-    if std::env::var("COPYBOOK_TEST_PANIC")
-        .map(|v| v == "1")
-        .unwrap_or(false)
-    {
-        panic!("COPYBOOK_TEST_PANIC triggered");
-    }
+    assert!(
+        !std::env::var("COPYBOOK_TEST_PANIC").is_ok_and(|v| v == "1"),
+        "COPYBOOK_TEST_PANIC triggered"
+    );
 
     let cli = match Cli::try_parse() {
         Ok(cli) => cli,

--- a/crates/copybook-codec/src/charset.rs
+++ b/crates/copybook-codec/src/charset.rs
@@ -5,4 +5,5 @@
 
 pub use copybook_charset::{
     Codepage, UnmappablePolicy, ebcdic_to_utf8, get_zoned_sign_table, space_byte, utf8_to_ebcdic,
+    utf8_to_ebcdic_with_policy,
 };

--- a/crates/copybook-codec/src/fidelity.rs
+++ b/crates/copybook-codec/src/fidelity.rs
@@ -948,11 +948,9 @@ pub mod utils {
             .map(|p| p.validation_time_ms)
             .sum();
         let total_records_u64 = u64::try_from(total_records).unwrap_or(u64::MAX);
-        let average_validation_time = if total_records_u64 == 0 {
-            0
-        } else {
-            total_validation_time / total_records_u64
-        };
+        let average_validation_time = total_validation_time
+            .checked_div(total_records_u64)
+            .unwrap_or(0);
 
         BatchFidelityMetrics {
             total_records,

--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -2210,7 +2210,11 @@ fn encode_single_field(
                 )?;
 
                 // Convert to EBCDIC and write to buffer
-                let bytes = crate::charset::utf8_to_ebcdic(&encoded, options.codepage)?;
+                let bytes = crate::charset::utf8_to_ebcdic_with_policy(
+                    &encoded,
+                    options.codepage,
+                    options.on_encode_unmappable,
+                )?;
                 let field_len = field.len as usize;
                 let copy_len = bytes.len().min(field_len);
 
@@ -2367,7 +2371,11 @@ fn encode_alphanum_field(
             .with_field(field.path.clone()));
         }
 
-        let bytes = crate::charset::utf8_to_ebcdic(text, options.codepage)?;
+        let bytes = crate::charset::utf8_to_ebcdic_with_policy(
+            text,
+            options.codepage,
+            options.on_encode_unmappable,
+        )?;
         let copy_len = bytes.len().min(field_len);
 
         if current_offset + field_len <= buffer.len() {

--- a/crates/copybook-codec/tests/encode_unmappable_policy.rs
+++ b/crates/copybook-codec/tests/encode_unmappable_policy.rs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Tests that `EncodeOptions::on_encode_unmappable` is wired through the
+//! `lib_api` encode path for alphanumeric (PIC X) fields.
+//!
+//! The Replace and Skip policies are advertised on `EncodeOptions` and round-
+//! tripped through CLI/option tests, but historically they had no effect on
+//! actual encoding — `utf8_to_ebcdic` always errored on unmappable characters.
+//! These tests pin that wiring.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use copybook_codec::{Codepage, EncodeOptions, RecordFormat, UnmappablePolicy, encode_record};
+use copybook_core::parse_copybook;
+use serde_json::json;
+
+fn schema(size: usize) -> copybook_core::Schema {
+    let cpy = format!("       01 REC.\n           05 FLD PIC X({size}).");
+    parse_copybook(&cpy).expect("schema should parse")
+}
+
+fn ebcdic_opts(policy: UnmappablePolicy) -> EncodeOptions {
+    EncodeOptions::new()
+        .with_format(RecordFormat::Fixed)
+        .with_codepage(Codepage::CP037)
+        .with_unmappable_policy(policy)
+}
+
+// PIC X size is set above the UTF-8 byte length of the input so the byte-based
+// length pre-check in encode_alphanum_field is satisfied. Only the codepage
+// mapping should reject (or rewrite) the CJK character.
+const FIELD_SIZE: usize = 7;
+
+#[test]
+fn error_policy_rejects_unmappable() {
+    // CJK character has no CP037 mapping; default Error policy must reject.
+    let s = schema(FIELD_SIZE);
+    let value = json!({ "FLD": "A日B" });
+    let err = encode_record(&s, &value, &ebcdic_opts(UnmappablePolicy::Error)).unwrap_err();
+    assert_eq!(
+        err.code,
+        copybook_core::ErrorCode::CBKC301_INVALID_EBCDIC_BYTE,
+        "expected CBKC301 for unmappable encode, got {err:?}",
+    );
+}
+
+#[test]
+fn replace_policy_substitutes_codepage_space() {
+    // Replace must substitute the codepage's space byte (0x40 for EBCDIC) and
+    // preserve the input-char count; remaining bytes pad to the field width.
+    let s = schema(FIELD_SIZE);
+    let value = json!({ "FLD": "A日B" });
+    let bytes = encode_record(&s, &value, &ebcdic_opts(UnmappablePolicy::Replace)).unwrap();
+    // 'A' -> 0xC1, '日' -> replaced with 0x40, 'B' -> 0xC2, then 4 bytes of pad.
+    assert_eq!(bytes, vec![0xC1, 0x40, 0xC2, 0x40, 0x40, 0x40, 0x40]);
+}
+
+#[test]
+fn skip_policy_drops_unmappable_and_pads() {
+    // Skip must drop the unmappable char; the field then space-pads to width.
+    let s = schema(FIELD_SIZE);
+    let value = json!({ "FLD": "A日B" });
+    let bytes = encode_record(&s, &value, &ebcdic_opts(UnmappablePolicy::Skip)).unwrap();
+    // 'A' -> 0xC1, 日 dropped, 'B' -> 0xC2, then 5 bytes of pad.
+    assert_eq!(bytes, vec![0xC1, 0xC2, 0x40, 0x40, 0x40, 0x40, 0x40]);
+}
+
+#[test]
+fn ascii_codepage_passthrough_ignores_policy() {
+    // ASCII codepage is a transparent pass-through; the policy is irrelevant
+    // because no character is "unmappable" under that mode.
+    let s = schema(5);
+    let value = json!({ "FLD": "HELLO" });
+    let opts = EncodeOptions::new()
+        .with_format(RecordFormat::Fixed)
+        .with_codepage(Codepage::ASCII)
+        .with_unmappable_policy(UnmappablePolicy::Error);
+    let bytes = encode_record(&s, &value, &opts).unwrap();
+    assert_eq!(bytes, b"HELLO");
+}

--- a/crates/copybook-contracts/src/feature_flags.rs
+++ b/crates/copybook-contracts/src/feature_flags.rs
@@ -530,8 +530,7 @@ impl FeatureFlagsHandle {
     pub fn is_enabled(&self, feature: Feature) -> bool {
         self.flags
             .read()
-            .map(|flags| flags.is_enabled(feature))
-            .unwrap_or(false)
+            .is_ok_and(|flags| flags.is_enabled(feature))
     }
 
     /// Enable a feature flag through the handle.

--- a/crates/copybook-core/src/audit/security.rs
+++ b/crates/copybook-core/src/audit/security.rs
@@ -421,8 +421,7 @@ impl SecurityMonitor {
         let priority = 16 * 8 + 4; // 132
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_secs());
         format!(
             "<{}>1 {} copybook-rs SecurityMonitor - {} - {}",
             priority, timestamp, violation.violation_id, violation.description


### PR DESCRIPTION
## Summary
- add `utf8_to_ebcdic_with_policy` so encode-side charset conversion can honor `UnmappablePolicy`
- route `EncodeOptions::on_encode_unmappable` through the lib API alphanumeric and edited-PIC encode paths
- add charset and codec tests for `Error`, `Replace`, and `Skip` behavior while preserving the existing default `Error` API
- apply the shared CI/security baseline and heavyweight workflow label gate

## Validation
- `cargo +1.95.0 fmt --all --check`
- `cargo +1.95.0 check -p copybook-charset -p copybook-codec --all-features`
- `cargo +1.95.0 test -p copybook-charset`
- `cargo +1.95.0 test -p copybook-codec`
- `cargo +1.95.0 clippy --workspace --lib --bins --examples --all-features -- -D warnings -W clippy::pedantic`
- `cargo +1.95.0 clippy --workspace --tests --all-features -- -D warnings -A clippy::unwrap_used -A clippy::expect_used -A clippy::panic -A clippy::dbg_macro -A clippy::print_stdout -A clippy::print_stderr -A clippy::missing_inline_in_public_items -A clippy::duplicated_attributes -A deprecated`
- `cargo deny --workspace --all-features check` (passes with existing duplicate-crate warnings and the known unmatched `aws-lc-sys` license exception warning)
- `RUSTDOCFLAGS='-D warnings' cargo +1.95.0 doc --all-features --workspace --no-deps`
- `git diff --check origin/main...HEAD`
- `git diff --check`