### PR TITLE
refactor(codec): decompose edited numeric encoding

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -14,6 +14,7 @@ on:
       - 'tests/**'
       - 'Cargo.*'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches: [ main, develop ]
     paths:
       - 'crates/**'
@@ -30,9 +31,13 @@ env:
 
 jobs:
   coverage:
-    name: Code Coverage
+    name: Tarpaulin Coverage
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'coverage') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     steps:
     - name: Checkout code

--- a/.github/workflows/leak-detection.yml
+++ b/.github/workflows/leak-detection.yml
@@ -6,6 +6,7 @@ on:
   schedule:
     - cron: "0 4 * * 0"  # Weekly on Sunday at 04:00 UTC
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - "crates/copybook-codec/**"
       - "crates/copybook-core/**"
@@ -24,6 +25,10 @@ jobs:
     name: Memory Leak Detection (LSAN)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'leak-check') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     steps:
       - uses: actions/checkout@v6
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
  "hex",
  "logos",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "serde_plain",
@@ -1049,7 +1049,7 @@ dependencies = [
  "copybook-codec",
  "copybook-core",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "sha2",
@@ -1156,7 +1156,7 @@ dependencies = [
  "copybook-support-matrix",
  "crossbeam-channel",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
 ]
@@ -3069,9 +3069,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -3364,9 +3364,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3780,7 +3780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/crates/copybook-cli/src/commands/audit.rs
+++ b/crates/copybook-cli/src/commands/audit.rs
@@ -2701,12 +2701,11 @@ fn run_audit_health_check_impl(
         );
     }
 
-    let overall_health_score = if checks_executed == 0 {
-        0
-    } else {
-        let failed_penalty = (checks_failed * 100) / checks_executed;
-        (100u32.saturating_sub(failed_penalty)).min(100)
-    };
+    let overall_health_score = (checks_failed * 100)
+        .checked_div(checks_executed)
+        .map_or(0, |failed_penalty| {
+            (100u32.saturating_sub(failed_penalty)).min(100)
+        });
 
     let status_code = if checks_failed > 0 || !parse_issues.is_empty() {
         ExitCode::Data

--- a/crates/copybook-cli/src/main.rs
+++ b/crates/copybook-cli/src/main.rs
@@ -554,11 +554,8 @@ fn main() -> ProcessExitCode {
 
 #[allow(clippy::too_many_lines)]
 fn run() -> anyhow::Result<ExitCode> {
-    #[allow(clippy::panic)]
-    if std::env::var("COPYBOOK_TEST_PANIC")
-        .map(|v| v == "1")
-        .unwrap_or(false)
-    {
+    #[allow(clippy::panic, clippy::manual_assert)]
+    if std::env::var("COPYBOOK_TEST_PANIC").is_ok_and(|v| v == "1") {
         panic!("COPYBOOK_TEST_PANIC triggered");
     }
 

--- a/crates/copybook-codec/src/edited_pic.rs
+++ b/crates/copybook-codec/src/edited_pic.rs
@@ -9,9 +9,9 @@
 //! and validating formatting symbols. The encode algorithm formats numeric values according to the pattern.
 //!
 //! Encoding is decomposed into three single-responsibility submodules:
-//! - [`encode_pattern`]: structural analysis of the PIC token pattern
-//! - [`encode_scale`]: input parsing and scale adjustment of the digit vector
-//! - [`encode_render`]: token-driven rendering into the output buffer
+//! - `encode_pattern`: structural analysis of the PIC token pattern
+//! - `encode_scale`: input parsing and scale adjustment of the digit vector
+//! - `encode_render`: token-driven rendering into the output buffer
 
 mod encode_pattern;
 mod encode_render;

--- a/crates/copybook-codec/src/edited_pic.rs
+++ b/crates/copybook-codec/src/edited_pic.rs
@@ -7,6 +7,15 @@
 //!
 //! The decode algorithm walks the input string and PIC pattern in lockstep, extracting numeric digits
 //! and validating formatting symbols. The encode algorithm formats numeric values according to the pattern.
+//!
+//! Encoding is decomposed into three single-responsibility submodules:
+//! - [`encode_pattern`]: structural analysis of the PIC token pattern
+//! - [`encode_scale`]: input parsing and scale adjustment of the digit vector
+//! - [`encode_render`]: token-driven rendering into the output buffer
+
+mod encode_pattern;
+mod encode_render;
+mod encode_scale;
 
 use copybook_core::{Error, ErrorCode, Result};
 use tracing::warn;
@@ -559,346 +568,53 @@ pub fn decode_edited_numeric(
     })
 }
 
-/// Parsed numeric value for encoding
-#[derive(Debug, Clone)]
-struct ParsedNumeric {
-    /// Sign of the number
-    sign: Sign,
-    /// All digits without decimal point (e.g., "12345" for 123.45)
-    digits: Vec<u8>,
-    /// Position of decimal point from right (0 for integers, 2 for 2 decimal places)
-    decimal_places: usize,
-}
-
-/// Parse a numeric string into its components for encoding
-fn parse_numeric_value(value: &str) -> Result<ParsedNumeric> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return Err(Error::new(
-            ErrorCode::CBKD421_EDITED_PIC_INVALID_FORMAT,
-            "Empty numeric value",
-        ));
-    }
-
-    let mut chars = trimmed.chars().peekable();
-    let sign = if chars.peek() == Some(&'-') {
-        chars.next();
-        Sign::Negative
-    } else if chars.peek() == Some(&'+') {
-        chars.next();
-        Sign::Positive
-    } else {
-        Sign::Positive
-    };
-
-    let mut digits = Vec::new();
-    let mut found_decimal = false;
-    let mut decimal_places = 0;
-    let mut found_digit = false;
-
-    for ch in chars {
-        if ch.is_ascii_digit() {
-            digits.push(ch as u8 - b'0');
-            if found_decimal {
-                decimal_places += 1;
-            }
-            found_digit = true;
-        } else if ch == '.' {
-            if found_decimal {
-                return Err(Error::new(
-                    ErrorCode::CBKD421_EDITED_PIC_INVALID_FORMAT,
-                    format!("Multiple decimal points in value: {value}"),
-                ));
-            }
-            found_decimal = true;
-        } else {
-            return Err(Error::new(
-                ErrorCode::CBKD421_EDITED_PIC_INVALID_FORMAT,
-                format!("Invalid character '{ch}' in numeric value: {value}"),
-            ));
-        }
-    }
-
-    if !found_digit {
-        return Err(Error::new(
-            ErrorCode::CBKD421_EDITED_PIC_INVALID_FORMAT,
-            format!("No digits found in value: {value}"),
-        ));
-    }
-
-    Ok(ParsedNumeric {
-        sign,
-        digits,
-        decimal_places,
-    })
-}
-
-/// Encode a numeric value to an edited PIC string
+/// Encode a numeric value to an edited PIC string.
+///
+/// Orchestrates four single-responsibility phases:
+/// 1. Parse the input string into a signed digit vector.
+/// 2. Adjust those digits to the pattern's target scale.
+/// 3. Analyze the pattern's structural metrics and validate the value fits.
+/// 4. Render the output buffer token by token.
 ///
 /// # Errors
-/// Returns error if the value cannot be encoded to the pattern
+/// Returns an error if the input value is malformed or does not fit the pattern.
 #[inline]
-#[allow(clippy::too_many_lines)]
 pub fn encode_edited_numeric(
     value: &str,
     pattern: &[PicToken],
     scale: u16,
     _blank_when_zero: bool,
 ) -> Result<String> {
-    // Parse the input value
-    let parsed = parse_numeric_value(value)?;
+    let parsed = encode_scale::parse(value)?;
+    let is_zero = encode_scale::is_all_zero(&parsed.digits);
+    let effective_sign = encode_scale::effective_sign(is_zero, parsed.sign);
 
-    // All tokens are now supported in E3.7 (including Space)
-    // No unsupported token check needed
+    let target_scale = scale as usize;
+    let adjusted_digits =
+        encode_scale::adjust_to_scale(parsed.digits, parsed.decimal_places, target_scale);
+    let int_digits = adjusted_digits.len().saturating_sub(target_scale);
 
-    // Check if value is all zeros (force positive sign)
-    let is_zero = parsed.digits.iter().all(|&d| d == 0);
-    let effective_sign = if is_zero { Sign::Positive } else { parsed.sign };
-
-    // Count numeric positions and decimal point in pattern
-    let mut has_decimal = false;
-    for token in pattern {
-        if *token == PicToken::DecimalPoint {
-            has_decimal = true;
-        }
-    }
-
-    // Calculate expected decimal places from pattern
-    let _pattern_decimal_places = if has_decimal {
-        // Count numeric positions after decimal point
-        let mut after_decimal = 0;
-        let mut found = false;
-        for token in pattern {
-            if *token == PicToken::DecimalPoint {
-                found = true;
-            } else if found
-                && matches!(
-                    token,
-                    PicToken::Digit | PicToken::ZeroSuppress | PicToken::ZeroInsert
-                )
-            {
-                after_decimal += 1;
-            }
-        }
-        after_decimal
-    } else {
-        0
-    };
-
-    // Adjust digits to match pattern scale
-    let scale = scale as usize;
-    let mut adjusted_digits = parsed.digits.clone();
-
-    // Pad or truncate to match scale
-    if scale > parsed.decimal_places {
-        // Need to add trailing zeros
-        let to_add = scale - parsed.decimal_places;
-        adjusted_digits.extend(std::iter::repeat_n(0, to_add));
-    } else if scale < parsed.decimal_places {
-        // Need to truncate (round down for now)
-        let to_remove = parsed.decimal_places - scale;
-        for _ in 0..to_remove {
-            adjusted_digits.pop();
-        }
-    }
-
-    // Calculate integer and fractional parts
-    let decimal_places = scale;
-    let total_digits = adjusted_digits.len();
-    let int_digits = total_digits.saturating_sub(decimal_places);
-
-    // Count integer and fractional positions in pattern
-    let mut int_positions = 0;
-    let mut frac_positions = 0;
-    let mut after_decimal = false;
-    for token in pattern {
-        match token {
-            PicToken::Digit
-            | PicToken::ZeroSuppress
-            | PicToken::ZeroInsert
-            | PicToken::AsteriskFill => {
-                if after_decimal {
-                    frac_positions += 1;
-                } else {
-                    int_positions += 1;
-                }
-            }
-            PicToken::DecimalPoint => {
-                after_decimal = true;
-            }
-            _ => {}
-        }
-    }
-
-    // Check if value fits in pattern
-    if int_digits > int_positions || decimal_places > frac_positions {
+    let metrics = encode_pattern::analyze(pattern);
+    if int_digits > metrics.int_positions || target_scale > metrics.frac_positions {
         return Err(Error::new(
             ErrorCode::CBKD421_EDITED_PIC_INVALID_FORMAT,
             format!(
-                "Value too long for pattern (pattern has {int_positions} integer positions, value has {int_digits} digits)"
+                "Value too long for pattern (pattern has {ip} integer positions, value has {id} digits)",
+                ip = metrics.int_positions,
+                id = int_digits,
             ),
         ));
     }
 
-    // Calculate output length (CR and DB are 2 characters each, others are 1)
-    let output_len: usize = pattern
-        .iter()
-        .map(|token| match token {
-            PicToken::Credit | PicToken::Debit => 2,
-            _ => 1,
-        })
-        .sum();
-
-    // Build output string by filling from right to left
-    let mut result: Vec<char> = vec![' '; output_len];
-    let mut int_digit_idx = int_digits; // Start from the end
-    let mut frac_digit_idx = decimal_places; // Start from the end
-
-    // Fill from right to left
-    // We need to track character position separately from token index
-    let mut char_pos = output_len;
-    for (token_idx, token) in pattern.iter().enumerate().rev() {
-        // Determine how many characters this token occupies
-        let token_width = match token {
-            PicToken::Credit | PicToken::Debit => 2,
-            _ => 1,
-        };
-        char_pos -= token_width;
-
-        match token {
-            PicToken::Digit => {
-                let digit = {
-                    // Check if this position is before or after decimal
-                    let is_after_decimal = pattern[..token_idx].contains(&PicToken::DecimalPoint);
-                    if is_after_decimal && frac_digit_idx > 0 {
-                        frac_digit_idx -= 1;
-                        char::from_digit(
-                            u32::from(adjusted_digits[int_digits + frac_digit_idx]),
-                            10,
-                        )
-                        .unwrap_or('0')
-                    } else if !is_after_decimal && int_digit_idx > 0 {
-                        int_digit_idx -= 1;
-                        char::from_digit(u32::from(adjusted_digits[int_digit_idx]), 10)
-                            .unwrap_or('0')
-                    } else {
-                        '0'
-                    }
-                };
-                result[char_pos] = digit;
-            }
-            PicToken::ZeroSuppress => {
-                let is_after_decimal = pattern[..token_idx].contains(&PicToken::DecimalPoint);
-                if is_after_decimal && frac_digit_idx > 0 {
-                    frac_digit_idx -= 1;
-                    let d = adjusted_digits[int_digits + frac_digit_idx];
-                    result[char_pos] = char::from_digit(u32::from(d), 10).unwrap_or('0');
-                } else if !is_after_decimal && int_digit_idx > 0 {
-                    int_digit_idx -= 1;
-                    let d = adjusted_digits[int_digit_idx];
-                    result[char_pos] = char::from_digit(u32::from(d), 10).unwrap_or('0');
-                } else {
-                    result[char_pos] = ' ';
-                }
-            }
-            PicToken::ZeroInsert => {
-                let is_after_decimal = pattern[..token_idx].contains(&PicToken::DecimalPoint);
-                if is_after_decimal && frac_digit_idx > 0 {
-                    frac_digit_idx -= 1;
-                    let d = adjusted_digits[int_digits + frac_digit_idx];
-                    result[char_pos] = char::from_digit(u32::from(d), 10).unwrap_or('0');
-                } else if !is_after_decimal && int_digit_idx > 0 {
-                    int_digit_idx -= 1;
-                    let d = adjusted_digits[int_digit_idx];
-                    result[char_pos] = char::from_digit(u32::from(d), 10).unwrap_or('0');
-                } else {
-                    result[char_pos] = '0';
-                }
-            }
-            PicToken::AsteriskFill => {
-                let is_after_decimal = pattern[..token_idx].contains(&PicToken::DecimalPoint);
-                if is_after_decimal && frac_digit_idx > 0 {
-                    frac_digit_idx -= 1;
-                    let d = adjusted_digits[int_digits + frac_digit_idx];
-                    result[char_pos] = char::from_digit(u32::from(d), 10).unwrap_or('0');
-                } else if !is_after_decimal && int_digit_idx > 0 {
-                    int_digit_idx -= 1;
-                    let d = adjusted_digits[int_digit_idx];
-                    result[char_pos] = char::from_digit(u32::from(d), 10).unwrap_or('0');
-                } else {
-                    result[char_pos] = '*';
-                }
-            }
-            PicToken::DecimalPoint => {
-                result[char_pos] = '.';
-            }
-            PicToken::Comma => {
-                // Commas are always displayed, but become spaces during zero suppression
-                // Check if there are any significant digits to the right (already filled)
-                // or if the value is not zero
-                let has_significant_right = result[char_pos + 1..]
-                    .iter()
-                    .any(|&ch| ch != ' ' && ch != '0' && ch != ',' && ch != '.');
-                result[char_pos] = if !is_zero || has_significant_right {
-                    ','
-                } else {
-                    ' '
-                };
-            }
-            PicToken::Slash => {
-                // Slashes are always displayed (date format use case)
-                result[char_pos] = '/';
-            }
-            PicToken::Currency => {
-                // Currency symbol ($) is always displayed at its pattern position
-                result[char_pos] = '$';
-            }
-            PicToken::LeadingPlus | PicToken::TrailingPlus => {
-                result[char_pos] = match effective_sign {
-                    Sign::Positive => '+',
-                    Sign::Negative => '-',
-                };
-            }
-            PicToken::LeadingMinus | PicToken::TrailingMinus => {
-                result[char_pos] = match effective_sign {
-                    Sign::Positive => ' ',
-                    Sign::Negative => '-',
-                };
-            }
-            PicToken::Credit => {
-                // CR occupies 2 characters: "CR" for negative, "  " for positive
-                match effective_sign {
-                    Sign::Positive => {
-                        result[char_pos] = ' ';
-                        result[char_pos + 1] = ' ';
-                    }
-                    Sign::Negative => {
-                        result[char_pos] = 'C';
-                        result[char_pos + 1] = 'R';
-                    }
-                }
-            }
-            PicToken::Debit => {
-                // DB occupies 2 characters: "DB" for negative, "  " for positive
-                match effective_sign {
-                    Sign::Positive => {
-                        result[char_pos] = ' ';
-                        result[char_pos + 1] = ' ';
-                    }
-                    Sign::Negative => {
-                        result[char_pos] = 'D';
-                        result[char_pos + 1] = 'B';
-                    }
-                }
-            }
-            PicToken::Space => {
-                // B token always inserts a literal space character
-                result[char_pos] = ' ';
-            }
-        }
-    }
-
-    Ok(result.into_iter().collect())
+    Ok(encode_render::render(
+        pattern,
+        &adjusted_digits,
+        int_digits,
+        target_scale,
+        effective_sign,
+        is_zero,
+        metrics.output_len,
+    ))
 }
 
 #[cfg(test)]

--- a/crates/copybook-codec/src/edited_pic/encode_pattern.rs
+++ b/crates/copybook-codec/src/edited_pic/encode_pattern.rs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Pattern analysis for edited PIC encoding.
+//!
+//! Computes structural facts about a `&[PicToken]` pattern that are independent
+//! of any specific input value: how many integer and fractional digit positions
+//! exist, and the total character width of the rendered output.
+
+use super::PicToken;
+
+/// Structural metrics extracted from an edited PIC pattern.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct PatternMetrics {
+    /// Count of digit-bearing positions before the decimal point.
+    pub int_positions: usize,
+    /// Count of digit-bearing positions after the decimal point.
+    pub frac_positions: usize,
+    /// Total character width of the rendered output (CR/DB count as 2).
+    pub output_len: usize,
+}
+
+/// Analyze a pattern to extract structural metrics needed for encoding.
+pub(super) fn analyze(pattern: &[PicToken]) -> PatternMetrics {
+    let mut int_positions = 0;
+    let mut frac_positions = 0;
+    let mut output_len = 0;
+    let mut after_decimal = false;
+
+    for token in pattern {
+        output_len += token_width(token);
+        match token {
+            PicToken::Digit
+            | PicToken::ZeroSuppress
+            | PicToken::ZeroInsert
+            | PicToken::AsteriskFill => {
+                if after_decimal {
+                    frac_positions += 1;
+                } else {
+                    int_positions += 1;
+                }
+            }
+            PicToken::DecimalPoint => after_decimal = true,
+            _ => {}
+        }
+    }
+
+    PatternMetrics {
+        int_positions,
+        frac_positions,
+        output_len,
+    }
+}
+
+/// Number of characters a single token contributes to rendered output.
+pub(super) fn token_width(token: &PicToken) -> usize {
+    match token {
+        PicToken::Credit | PicToken::Debit => 2,
+        _ => 1,
+    }
+}
+
+/// True if the token at `idx` sits after the (first) decimal point in `pattern`.
+pub(super) fn is_after_decimal_at(pattern: &[PicToken], idx: usize) -> bool {
+    pattern[..idx].contains(&PicToken::DecimalPoint)
+}

--- a/crates/copybook-codec/src/edited_pic/encode_render.rs
+++ b/crates/copybook-codec/src/edited_pic/encode_render.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Output rendering for edited PIC encoding.
+//!
+//! Walks the pattern from right to left, dispatching each token to the
+//! appropriate character(s) in the output buffer. Digits are consumed from
+//! the scaled digit vector; sign editing tokens consult the effective sign;
+//! fill characters (commas, zero suppression) are applied based on whether
+//! significant digits have already been emitted to the right.
+
+use super::encode_pattern::{is_after_decimal_at, token_width};
+use super::{PicToken, Sign};
+
+/// Render the final output string for `encode_edited_numeric`.
+///
+/// `digits` is the scale-adjusted digit vector. `int_digits` is the number of
+/// digits in `digits` that fall before the decimal point. `decimal_places` is
+/// the target scale (digits after the decimal point). `output_len` is the
+/// pre-computed character width of the result. `is_zero` reflects whether the
+/// *original parsed* value is all zeros — comma suppression and sign editing
+/// both depend on this, and scale adjustment can flip the answer.
+pub(super) fn render(
+    pattern: &[PicToken],
+    digits: &[u8],
+    int_digits: usize,
+    decimal_places: usize,
+    effective_sign: Sign,
+    is_zero: bool,
+    output_len: usize,
+) -> String {
+    let mut buf: Vec<char> = vec![' '; output_len];
+    let mut int_cursor = int_digits;
+    let mut frac_cursor = decimal_places;
+    let mut char_pos = output_len;
+
+    for (token_idx, token) in pattern.iter().enumerate().rev() {
+        char_pos -= token_width(token);
+        let after_dec = is_after_decimal_at(pattern, token_idx);
+
+        match token {
+            PicToken::Digit | PicToken::ZeroInsert => {
+                buf[char_pos] = next_digit_char(
+                    digits,
+                    int_digits,
+                    &mut int_cursor,
+                    &mut frac_cursor,
+                    after_dec,
+                )
+                .unwrap_or('0');
+            }
+            PicToken::ZeroSuppress => {
+                buf[char_pos] = next_digit_char(
+                    digits,
+                    int_digits,
+                    &mut int_cursor,
+                    &mut frac_cursor,
+                    after_dec,
+                )
+                .unwrap_or(' ');
+            }
+            PicToken::AsteriskFill => {
+                buf[char_pos] = next_digit_char(
+                    digits,
+                    int_digits,
+                    &mut int_cursor,
+                    &mut frac_cursor,
+                    after_dec,
+                )
+                .unwrap_or('*');
+            }
+            PicToken::DecimalPoint => buf[char_pos] = '.',
+            PicToken::Comma => {
+                buf[char_pos] = comma_or_space(&buf, char_pos, is_zero);
+            }
+            PicToken::Slash => buf[char_pos] = '/',
+            PicToken::Currency => buf[char_pos] = '$',
+            PicToken::LeadingPlus | PicToken::TrailingPlus => {
+                buf[char_pos] = match effective_sign {
+                    Sign::Positive => '+',
+                    Sign::Negative => '-',
+                };
+            }
+            PicToken::LeadingMinus | PicToken::TrailingMinus => {
+                buf[char_pos] = match effective_sign {
+                    Sign::Positive => ' ',
+                    Sign::Negative => '-',
+                };
+            }
+            PicToken::Credit => write_pair(&mut buf, char_pos, effective_sign, ('C', 'R')),
+            PicToken::Debit => write_pair(&mut buf, char_pos, effective_sign, ('D', 'B')),
+            PicToken::Space => buf[char_pos] = ' ',
+        }
+    }
+
+    buf.into_iter().collect()
+}
+
+/// Consume the next digit from the appropriate cursor (integer or fractional)
+/// and return it as a `char`. Returns `None` once that cursor is exhausted.
+fn next_digit_char(
+    digits: &[u8],
+    int_digits: usize,
+    int_cursor: &mut usize,
+    frac_cursor: &mut usize,
+    after_decimal: bool,
+) -> Option<char> {
+    if after_decimal {
+        if *frac_cursor == 0 {
+            return None;
+        }
+        *frac_cursor -= 1;
+        char::from_digit(u32::from(digits[int_digits + *frac_cursor]), 10)
+    } else {
+        if *int_cursor == 0 {
+            return None;
+        }
+        *int_cursor -= 1;
+        char::from_digit(u32::from(digits[*int_cursor]), 10)
+    }
+}
+
+/// Decide whether a comma position should render as `,` or be suppressed to ` `.
+/// Commas are suppressed when the value is zero and no significant digit has
+/// already been emitted to the right of this position.
+fn comma_or_space(buf: &[char], pos: usize, is_zero: bool) -> char {
+    let has_significant_right = buf[pos + 1..]
+        .iter()
+        .any(|&ch| ch != ' ' && ch != '0' && ch != ',' && ch != '.');
+    if !is_zero || has_significant_right {
+        ','
+    } else {
+        ' '
+    }
+}
+
+/// Write a two-character credit/debit marker (`CR` or `DB`) for negatives,
+/// or spaces for positives.
+fn write_pair(buf: &mut [char], pos: usize, sign: Sign, marker: (char, char)) {
+    match sign {
+        Sign::Positive => {
+            buf[pos] = ' ';
+            buf[pos + 1] = ' ';
+        }
+        Sign::Negative => {
+            buf[pos] = marker.0;
+            buf[pos + 1] = marker.1;
+        }
+    }
+}

--- a/crates/copybook-codec/src/edited_pic/encode_scale.rs
+++ b/crates/copybook-codec/src/edited_pic/encode_scale.rs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Input parsing and digit scaling for edited PIC encoding.
+//!
+//! Parses a decimal numeric string into a `ParsedNumeric`, then adjusts its
+//! digit vector to match the target scale (the number of fractional digits
+//! required by the pattern).
+
+use copybook_core::{Error, ErrorCode, Result};
+
+use super::Sign;
+
+/// Parsed numeric value extracted from the input string.
+#[derive(Debug, Clone)]
+pub(super) struct ParsedNumeric {
+    /// Sign of the number.
+    pub sign: Sign,
+    /// All digits without decimal point (e.g. `[1,2,3,4,5]` for `123.45`).
+    pub digits: Vec<u8>,
+    /// Position of decimal point counted from the right.
+    pub decimal_places: usize,
+}
+
+/// Parse a numeric string into its components for encoding.
+pub(super) fn parse(value: &str) -> Result<ParsedNumeric> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(Error::new(
+            ErrorCode::CBKD421_EDITED_PIC_INVALID_FORMAT,
+            "Empty numeric value",
+        ));
+    }
+
+    let mut chars = trimmed.chars().peekable();
+    let sign = if chars.peek() == Some(&'-') {
+        chars.next();
+        Sign::Negative
+    } else if chars.peek() == Some(&'+') {
+        chars.next();
+        Sign::Positive
+    } else {
+        Sign::Positive
+    };
+
+    let mut digits = Vec::new();
+    let mut found_decimal = false;
+    let mut decimal_places = 0;
+    let mut found_digit = false;
+
+    for ch in chars {
+        if ch.is_ascii_digit() {
+            digits.push(ch as u8 - b'0');
+            if found_decimal {
+                decimal_places += 1;
+            }
+            found_digit = true;
+        } else if ch == '.' {
+            if found_decimal {
+                return Err(Error::new(
+                    ErrorCode::CBKD421_EDITED_PIC_INVALID_FORMAT,
+                    format!("Multiple decimal points in value: {value}"),
+                ));
+            }
+            found_decimal = true;
+        } else {
+            return Err(Error::new(
+                ErrorCode::CBKD421_EDITED_PIC_INVALID_FORMAT,
+                format!("Invalid character '{ch}' in numeric value: {value}"),
+            ));
+        }
+    }
+
+    if !found_digit {
+        return Err(Error::new(
+            ErrorCode::CBKD421_EDITED_PIC_INVALID_FORMAT,
+            format!("No digits found in value: {value}"),
+        ));
+    }
+
+    Ok(ParsedNumeric {
+        sign,
+        digits,
+        decimal_places,
+    })
+}
+
+/// Pad with trailing zeros or truncate so the digit vector has exactly
+/// `target_scale` fractional digits.
+pub(super) fn adjust_to_scale(
+    mut digits: Vec<u8>,
+    source_scale: usize,
+    target_scale: usize,
+) -> Vec<u8> {
+    if target_scale > source_scale {
+        digits.extend(std::iter::repeat_n(0, target_scale - source_scale));
+    } else if target_scale < source_scale {
+        let to_remove = source_scale - target_scale;
+        digits.truncate(digits.len().saturating_sub(to_remove));
+    }
+    digits
+}
+
+/// True if every digit in the slice is zero.
+pub(super) fn is_all_zero(digits: &[u8]) -> bool {
+    digits.iter().all(|&d| d == 0)
+}
+
+/// Determine the effective sign: an all-zero magnitude is always positive.
+pub(super) fn effective_sign(is_zero: bool, parsed_sign: Sign) -> Sign {
+    if is_zero { Sign::Positive } else { parsed_sign }
+}

--- a/crates/copybook-codec/src/fidelity.rs
+++ b/crates/copybook-codec/src/fidelity.rs
@@ -948,11 +948,9 @@ pub mod utils {
             .map(|p| p.validation_time_ms)
             .sum();
         let total_records_u64 = u64::try_from(total_records).unwrap_or(u64::MAX);
-        let average_validation_time = if total_records_u64 == 0 {
-            0
-        } else {
-            total_validation_time / total_records_u64
-        };
+        let average_validation_time = total_validation_time
+            .checked_div(total_records_u64)
+            .unwrap_or(0);
 
         BatchFidelityMetrics {
             total_records,

--- a/crates/copybook-contracts/src/feature_flags.rs
+++ b/crates/copybook-contracts/src/feature_flags.rs
@@ -530,8 +530,7 @@ impl FeatureFlagsHandle {
     pub fn is_enabled(&self, feature: Feature) -> bool {
         self.flags
             .read()
-            .map(|flags| flags.is_enabled(feature))
-            .unwrap_or(false)
+            .is_ok_and(|flags| flags.is_enabled(feature))
     }
 
     /// Enable a feature flag through the handle.

--- a/crates/copybook-core/src/audit/security.rs
+++ b/crates/copybook-core/src/audit/security.rs
@@ -421,8 +421,7 @@ impl SecurityMonitor {
         let priority = 16 * 8 + 4; // 132
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_secs());
         format!(
             "<{}>1 {} copybook-rs SecurityMonitor - {} - {}",
             priority, timestamp, violation.violation_id, violation.description


### PR DESCRIPTION
## Summary
- split `encode_edited_numeric` into focused `edited_pic` helper modules for scale parsing, pattern analysis, and rendering
- keep the public edited-PIC codec behavior intact while making the top-level encoder an orchestrator
- retain the existing dependency/clippy cleanup already present on the branch and add the shared heavyweight workflow label gate

## Validation
- `cargo +1.95.0 fmt --all --check`
- `cargo +1.95.0 check -p copybook-codec --all-features`
- `cargo +1.95.0 test -p copybook-codec edited_pic --lib`
- `cargo +1.95.0 test -p copybook-codec --test edited_pic_comprehensive`
- `cargo +1.95.0 test -p copybook-codec`
- `cargo +1.95.0 clippy --workspace --lib --bins --examples --all-features -- -D warnings -W clippy::pedantic`
- `cargo +1.95.0 clippy --workspace --tests --all-features -- -D warnings -A clippy::unwrap_used -A clippy::expect_used -A clippy::panic -A clippy::dbg_macro -A clippy::print_stdout -A clippy::print_stderr -A clippy::missing_inline_in_public_items -A clippy::duplicated_attributes -A deprecated`
- `cargo deny --workspace --all-features check` (passes with existing duplicate-crate warnings and the known unmatched `aws-lc-sys` license exception warning)
- `RUSTDOCFLAGS='-D warnings' cargo +1.95.0 doc --all-features --workspace --no-deps`
- `git diff --check origin/main...HEAD`
- `git diff --check`