### PR TITLE
refactor(codec): split alphanumeric codec helper

### DIFF
--- a/crates/copybook-codec/src/numeric.rs
+++ b/crates/copybook-codec/src/numeric.rs
@@ -125,11 +125,13 @@ use copybook_core::{Error, ErrorCode, Result, SignPlacement, SignSeparateInfo};
 use std::convert::TryFrom;
 use tracing::warn;
 
+mod alphanumeric;
 mod binary;
 mod branch;
 mod decimal;
 mod float;
 
+pub use alphanumeric::encode_alphanumeric;
 pub use binary::{
     decode_binary_int, decode_binary_int_fast, encode_binary_int, get_binary_width_from_digits,
     validate_explicit_binary_width,
@@ -1935,66 +1937,6 @@ pub fn encode_packed_decimal(
         result.push(byte_val);
     }
 
-    Ok(result)
-}
-
-/// Encode an alphanumeric (PIC X) field with right-padding to the declared length.
-///
-/// Converts the UTF-8 input string to the target codepage encoding and then
-/// right-pads with space characters (ASCII `0x20` or EBCDIC `0x40`) to fill
-/// the declared field length.
-///
-/// # Arguments
-/// * `text` - UTF-8 string value to encode
-/// * `field_len` - Declared byte length of the COBOL field
-/// * `codepage` - Target character encoding (ASCII or EBCDIC variant)
-///
-/// # Returns
-/// A vector of exactly `field_len` bytes containing the encoded and padded text.
-///
-/// # Errors
-/// * `CBKE501_JSON_TYPE_MISMATCH` - if the encoded text exceeds `field_len` bytes
-///
-/// # Examples
-///
-/// ```
-/// use copybook_codec::numeric::encode_alphanumeric;
-/// use copybook_codec::Codepage;
-///
-/// // Encode a 5-character string into a 10-byte ASCII field (right-padded with spaces)
-/// let result = encode_alphanumeric("HELLO", 10, Codepage::ASCII).unwrap();
-/// assert_eq!(result.len(), 10);
-/// assert_eq!(&result[..5], b"HELLO");
-/// assert_eq!(&result[5..], b"     "); // padded with spaces
-/// ```
-///
-/// # See Also
-/// * [`crate::charset::utf8_to_ebcdic`] - Underlying character conversion
-#[inline]
-#[must_use = "Handle the Result or propagate the error"]
-pub fn encode_alphanumeric(text: &str, field_len: usize, codepage: Codepage) -> Result<Vec<u8>> {
-    // Convert UTF-8 to target encoding
-    let encoded_bytes = crate::charset::utf8_to_ebcdic(text, codepage)?;
-
-    if encoded_bytes.len() > field_len {
-        return Err(Error::new(
-            ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
-            format!(
-                "Text length {} exceeds field length {}",
-                encoded_bytes.len(),
-                field_len
-            ),
-        ));
-    }
-
-    // Pad with spaces to field length (NORMATIVE)
-    let mut result = encoded_bytes;
-    let space_byte = match codepage {
-        Codepage::ASCII => b' ',
-        _ => 0x40, // EBCDIC space
-    };
-
-    result.resize(field_len, space_byte);
     Ok(result)
 }
 

--- a/crates/copybook-codec/src/numeric/alphanumeric.rs
+++ b/crates/copybook-codec/src/numeric/alphanumeric.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Alphanumeric field encoding helpers.
+//!
+//! This module owns text-to-codepage conversion and fixed-width padding for
+//! COBOL alphanumeric fields.
+
+use crate::options::Codepage;
+use copybook_core::{Error, ErrorCode, Result};
+
+/// Encode an alphanumeric (PIC X) field with right-padding to the declared length.
+///
+/// Converts the UTF-8 input string to the target codepage encoding and then
+/// right-pads with space characters (ASCII `0x20` or EBCDIC `0x40`) to fill
+/// the declared field length.
+///
+/// # Arguments
+/// * `text` - UTF-8 string value to encode
+/// * `field_len` - Declared byte length of the COBOL field
+/// * `codepage` - Target character encoding (ASCII or EBCDIC variant)
+///
+/// # Returns
+/// A vector of exactly `field_len` bytes containing the encoded and padded text.
+///
+/// # Errors
+/// * `CBKE501_JSON_TYPE_MISMATCH` - if the encoded text exceeds `field_len` bytes
+///
+/// # Examples
+///
+/// ```
+/// use copybook_codec::numeric::encode_alphanumeric;
+/// use copybook_codec::Codepage;
+///
+/// // Encode a 5-character string into a 10-byte ASCII field.
+/// let result = encode_alphanumeric("HELLO", 10, Codepage::ASCII).unwrap();
+/// assert_eq!(result.len(), 10);
+/// assert_eq!(&result[..5], b"HELLO");
+/// assert_eq!(&result[5..], b"     ");
+/// ```
+///
+/// # See Also
+/// * [`crate::charset::utf8_to_ebcdic`] - Underlying character conversion
+#[inline]
+#[must_use = "Handle the Result or propagate the error"]
+pub fn encode_alphanumeric(text: &str, field_len: usize, codepage: Codepage) -> Result<Vec<u8>> {
+    let encoded_bytes = crate::charset::utf8_to_ebcdic(text, codepage)?;
+
+    if encoded_bytes.len() > field_len {
+        return Err(Error::new(
+            ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
+            format!(
+                "Text length {} exceeds field length {}",
+                encoded_bytes.len(),
+                field_len
+            ),
+        ));
+    }
+
+    let mut result = encoded_bytes;
+    let space_byte = match codepage {
+        Codepage::ASCII => b' ',
+        _ => 0x40,
+    };
+
+    result.resize(field_len, space_byte);
+    Ok(result)
+}


### PR DESCRIPTION
## Summary
- Split the PIC X alphanumeric encoding helper into `numeric::alphanumeric`.
- Keep the existing public `copybook_codec::numeric::encode_alphanumeric` re-export unchanged.
- Drop the stale float/workflow/security baseline changes from the older branch; float codecs already landed in #486.

## Validation
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 check -p copybook-codec --all-features`
- `cargo +1.95.0 test -p copybook-codec numeric:: --lib`
- `cargo +1.95.0 test -p copybook-codec --doc`
- `cargo +1.95.0 run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- check-public-result-docs`
- `cargo +1.95.0 clippy -p copybook-codec --lib --bins --examples --all-features -- -D warnings -W clippy::pedantic`
- `git diff --check`