### PR TITLE
refactor(scripts): validate perf receipts in Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,6 +1258,7 @@ dependencies = [
  "num_cpus",
  "regex",
  "serde_json",
+ "sha2",
 ]
 
 [[package]]

--- a/scripts/bench-enhanced.sh
+++ b/scripts/bench-enhanced.sh
@@ -68,7 +68,6 @@ get_kernel_version() {
 
 python3 <<PY
 import datetime
-import hashlib
 import json
 import pathlib
 import subprocess
@@ -207,18 +206,10 @@ report = {
 output_dir = ROOT / "scripts" / "bench"
 output_dir.mkdir(parents=True, exist_ok=True)
 output_path = output_dir / "perf.json"
-
-canonical = json.dumps(report, sort_keys=True, separators=(",", ":"))
-report["integrity"] = {
-    "sha256": hashlib.sha256(canonical.encode("utf-8")).hexdigest()
-}
-
 output_path.write_text(json.dumps(report, indent=2) + "\n")
-print(
-    f"✅ receipts: {output_path.relative_to(ROOT)} "
-    f"(integrity: {report['integrity']['sha256'][:16]}...)"
-)
 PY
+
+cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- seal-perf-receipt scripts/bench/perf.json
 
 # Receipt is complete and immutable - no post-write modifications
 # Note: Percentile aggregation is now done in the Python block above,

--- a/scripts/bench-enhanced.sh
+++ b/scripts/bench-enhanced.sh
@@ -68,6 +68,7 @@ get_kernel_version() {
 
 python3 <<PY
 import datetime
+import hashlib
 import json
 import pathlib
 import subprocess
@@ -207,20 +208,17 @@ output_dir = ROOT / "scripts" / "bench"
 output_dir.mkdir(parents=True, exist_ok=True)
 output_path = output_dir / "perf.json"
 
-# Write receipt WITHOUT integrity field first
-# We'll compute hash using jq to match the validator exactly
-temp_json = json.dumps(report, indent=2) + "\n"
-output_path.write_text(temp_json)
+canonical = json.dumps(report, sort_keys=True, separators=(",", ":"))
+report["integrity"] = {
+    "sha256": hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+}
+
+output_path.write_text(json.dumps(report, indent=2) + "\n")
+print(
+    f"✅ receipts: {output_path.relative_to(ROOT)} "
+    f"(integrity: {report['integrity']['sha256'][:16]}...)"
+)
 PY
-
-# Compute integrity hash using jq - EXACTLY matches validator logic
-TEMP_HASH=$(jq -cS '.' scripts/bench/perf.json | sha256sum | cut -d' ' -f1)
-
-# Add integrity field using jq and rewrite
-jq --arg hash "$TEMP_HASH" '. + {integrity: {sha256: $hash}}' scripts/bench/perf.json > scripts/bench/perf.json.tmp
-mv scripts/bench/perf.json.tmp scripts/bench/perf.json
-
-echo "✅ receipts: scripts/bench/perf.json (integrity: ${TEMP_HASH:0:16}...)"
 
 # Receipt is complete and immutable - no post-write modifications
 # Note: Percentile aggregation is now done in the Python block above,

--- a/scripts/check_no_unwrap_expect.sh
+++ b/scripts/check_no_unwrap_expect.sh
@@ -14,9 +14,9 @@ bootstrap_rustup() {
 run_cargo() {
   bootstrap_rustup
 
-  if command -v rustup >/dev/null 2>&1; then
+  if command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q '^stable'; then
     rustup run stable cargo "$@"
-  elif command -v rustup.exe >/dev/null 2>&1; then
+  elif command -v rustup.exe >/dev/null 2>&1 && rustup.exe toolchain list | grep -q '^stable'; then
     rustup.exe run stable cargo "$@"
   else
     cargo "$@"

--- a/scripts/check_no_unwrap_expect.sh
+++ b/scripts/check_no_unwrap_expect.sh
@@ -13,11 +13,12 @@ bootstrap_rustup() {
 
 run_cargo() {
   bootstrap_rustup
+  local toolchain="${COPYBOOK_RUST_TOOLCHAIN:-stable}"
 
-  if command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q '^stable'; then
-    rustup run stable cargo "$@"
-  elif command -v rustup.exe >/dev/null 2>&1 && rustup.exe toolchain list | grep -q '^stable'; then
-    rustup.exe run stable cargo "$@"
+  if command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q "^${toolchain}"; then
+    rustup run "$toolchain" cargo "$@"
+  elif command -v rustup.exe >/dev/null 2>&1 && rustup.exe toolchain list | grep -q "^${toolchain}"; then
+    rustup.exe run "$toolchain" cargo "$@"
   else
     cargo "$@"
   fi

--- a/scripts/guard-hotpaths.sh
+++ b/scripts/guard-hotpaths.sh
@@ -14,9 +14,9 @@ bootstrap_rustup() {
 run_cargo() {
   bootstrap_rustup
 
-  if command -v rustup >/dev/null 2>&1; then
+  if command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q '^stable'; then
     rustup run stable cargo "$@"
-  elif command -v rustup.exe >/dev/null 2>&1; then
+  elif command -v rustup.exe >/dev/null 2>&1 && rustup.exe toolchain list | grep -q '^stable'; then
     rustup.exe run stable cargo "$@"
   else
     cargo "$@"

--- a/scripts/guard-hotpaths.sh
+++ b/scripts/guard-hotpaths.sh
@@ -13,11 +13,12 @@ bootstrap_rustup() {
 
 run_cargo() {
   bootstrap_rustup
+  local toolchain="${COPYBOOK_RUST_TOOLCHAIN:-stable}"
 
-  if command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q '^stable'; then
-    rustup run stable cargo "$@"
-  elif command -v rustup.exe >/dev/null 2>&1 && rustup.exe toolchain list | grep -q '^stable'; then
-    rustup.exe run stable cargo "$@"
+  if command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q "^${toolchain}"; then
+    rustup run "$toolchain" cargo "$@"
+  elif command -v rustup.exe >/dev/null 2>&1 && rustup.exe toolchain list | grep -q "^${toolchain}"; then
+    rustup.exe run "$toolchain" cargo "$@"
   else
     cargo "$@"
   fi

--- a/scripts/perf-annotate-host.sh
+++ b/scripts/perf-annotate-host.sh
@@ -14,9 +14,9 @@ bootstrap_rustup() {
 run_cargo() {
   bootstrap_rustup
 
-  if command -v rustup >/dev/null 2>&1; then
+  if command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q '^stable'; then
     rustup run stable cargo "$@"
-  elif command -v rustup.exe >/dev/null 2>&1; then
+  elif command -v rustup.exe >/dev/null 2>&1 && rustup.exe toolchain list | grep -q '^stable'; then
     rustup.exe run stable cargo "$@"
   else
     cargo "$@"

--- a/scripts/perf-annotate-host.sh
+++ b/scripts/perf-annotate-host.sh
@@ -13,11 +13,12 @@ bootstrap_rustup() {
 
 run_cargo() {
   bootstrap_rustup
+  local toolchain="${COPYBOOK_RUST_TOOLCHAIN:-stable}"
 
-  if command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q '^stable'; then
-    rustup run stable cargo "$@"
-  elif command -v rustup.exe >/dev/null 2>&1 && rustup.exe toolchain list | grep -q '^stable'; then
-    rustup.exe run stable cargo "$@"
+  if command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q "^${toolchain}"; then
+    rustup run "$toolchain" cargo "$@"
+  elif command -v rustup.exe >/dev/null 2>&1 && rustup.exe toolchain list | grep -q "^${toolchain}"; then
+    rustup.exe run "$toolchain" cargo "$@"
   else
     cargo "$@"
   fi

--- a/scripts/soak-dispatch.sh
+++ b/scripts/soak-dispatch.sh
@@ -14,9 +14,9 @@ bootstrap_rustup() {
 run_cargo() {
   bootstrap_rustup
 
-  if command -v rustup >/dev/null 2>&1; then
+  if command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q '^stable'; then
     rustup run stable cargo "$@"
-  elif command -v rustup.exe >/dev/null 2>&1; then
+  elif command -v rustup.exe >/dev/null 2>&1 && rustup.exe toolchain list | grep -q '^stable'; then
     rustup.exe run stable cargo "$@"
   else
     cargo "$@"

--- a/scripts/soak-dispatch.sh
+++ b/scripts/soak-dispatch.sh
@@ -13,11 +13,12 @@ bootstrap_rustup() {
 
 run_cargo() {
   bootstrap_rustup
+  local toolchain="${COPYBOOK_RUST_TOOLCHAIN:-stable}"
 
-  if command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q '^stable'; then
-    rustup run stable cargo "$@"
-  elif command -v rustup.exe >/dev/null 2>&1 && rustup.exe toolchain list | grep -q '^stable'; then
-    rustup.exe run stable cargo "$@"
+  if command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q "^${toolchain}"; then
+    rustup run "$toolchain" cargo "$@"
+  elif command -v rustup.exe >/dev/null 2>&1 && rustup.exe toolchain list | grep -q "^${toolchain}"; then
+    rustup.exe run "$toolchain" cargo "$@"
   else
     cargo "$@"
   fi

--- a/scripts/validate-perf-receipt.sh
+++ b/scripts/validate-perf-receipt.sh
@@ -13,11 +13,12 @@ bootstrap_rustup() {
 
 run_cargo() {
   bootstrap_rustup
+  local toolchain="${COPYBOOK_RUST_TOOLCHAIN:-stable}"
 
-  if command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q '^stable'; then
-    rustup run stable cargo "$@"
-  elif command -v rustup.exe >/dev/null 2>&1 && rustup.exe toolchain list | grep -q '^stable'; then
-    rustup.exe run stable cargo "$@"
+  if command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q "^${toolchain}"; then
+    rustup run "$toolchain" cargo "$@"
+  elif command -v rustup.exe >/dev/null 2>&1 && rustup.exe toolchain list | grep -q "^${toolchain}"; then
+    rustup.exe run "$toolchain" cargo "$@"
   else
     cargo "$@"
   fi

--- a/scripts/validate-perf-receipt.sh
+++ b/scripts/validate-perf-receipt.sh
@@ -2,211 +2,25 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 set -euo pipefail
 
-# Performance receipt validation script for copybook-rs
-# Ensures receipts conform to canonical schema and contain required metadata
+ROOT_DIR="$(git rev-parse --show-toplevel)"
 
-RECEIPT_FILE="${1:-scripts/bench/perf.json}"
-# Reserved for future JSON Schema validation (see schemas/perf-receipt-schema.json)
-# shellcheck disable=SC2034
-_SCHEMA_FILE="schemas/perf-receipt-schema.json"
-
-# Function to validate JSON against schema (basic validation)
-validate_receipt_structure() {
-  local receipt_file="$1"
-  
-  if ! command -v jq >/dev/null 2>&1; then
-    echo "❌ jq is required for receipt validation" >&2
-    return 1
+bootstrap_rustup() {
+  if [ -n "${HOME:-}" ] && [ -f "$HOME/.cargo/env" ]; then
+    # Non-login bash shells may not populate Rust's shims on PATH.
+    . "$HOME/.cargo/env"
   fi
-  
-  # Check required top-level fields
-  local required_fields=("format_version" "timestamp" "commit" "build_profile" "target_cpu" "environment" "benchmarks" "summary")
-  for field in "${required_fields[@]}"; do
-    if ! jq -e ".${field}" "$receipt_file" >/dev/null; then
-      echo "❌ Missing required field: ${field}" >&2
-      return 1
-    fi
-  done
-  
-  # Check environment sub-fields
-  # Use has() instead of -e to avoid false-negatives on boolean false values
-  # (jq -e treats both null and false as exit code 1)
-  local env_fields=("os" "kernel" "cpu_model" "cpu_cores" "wsl2_detected")
-  for field in "${env_fields[@]}"; do
-    if ! jq -e ".environment | has(\"${field}\")" "$receipt_file" >/dev/null; then
-      echo "❌ Missing required environment field: ${field}" >&2
-      return 1
-    fi
-  done
-  
-  # Check benchmark fields
-  if ! jq -e '.benchmarks[] | select(has("name") and has("mean_ns") and has("bytes_processed") and has("mean_mibps"))' "$receipt_file" >/dev/null; then
-    echo "❌ Benchmarks missing required fields" >&2
-    return 1
-  fi
-  
-  # Check summary fields
-  local summary_fields=("display_mibps" "comp3_mibps" "max_rss_mib")
-  for field in "${summary_fields[@]}"; do
-    if ! jq -e ".summary.${field}" "$receipt_file" >/dev/null; then
-      echo "❌ Missing required summary field: ${field}" >&2
-      return 1
-    fi
-  done
-  
-  # Check integrity field
-  if ! jq -e '.integrity.sha256' "$receipt_file" >/dev/null; then
-    echo "❌ Missing integrity SHA256 hash" >&2
-    return 1
-  fi
-  
-  echo "✅ Receipt structure validation passed"
-  return 0
 }
 
-# Function to validate receipt integrity
-validate_receipt_integrity() {
-  local receipt_file="$1"
+run_cargo() {
+  bootstrap_rustup
 
-  # Extract stored hash
-  local stored_hash
-  stored_hash=$(jq -r '.integrity.sha256' "$receipt_file")
-
-  # Calculate actual hash using canonical JSON (sorted keys, compact) excluding integrity field
-  # This MUST match the generator: json.dumps(report, sort_keys=True, separators=(',', ':'))
-  local actual_hash
-  actual_hash=$(jq -cS 'del(.integrity)' "$receipt_file" | sha256sum | cut -d' ' -f1)
-
-  if [[ "$stored_hash" == "$actual_hash" ]]; then
-    echo "✅ Receipt integrity validation passed"
-    return 0
+  if command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q '^stable'; then
+    rustup run stable cargo "$@"
+  elif command -v rustup.exe >/dev/null 2>&1 && rustup.exe toolchain list | grep -q '^stable'; then
+    rustup.exe run stable cargo "$@"
   else
-    echo "❌ Receipt integrity validation failed" >&2
-    echo "  Stored hash: ${stored_hash}" >&2
-    echo "  Actual hash: ${actual_hash}" >&2
-    echo "  Hint: Receipt may have been modified after hashing" >&2
-    return 1
+    cargo "$@"
   fi
 }
 
-# Function to validate format version
-validate_format_version() {
-  local receipt_file="$1"
-  local format_version
-  format_version=$(jq -r '.format_version' "$receipt_file")
-  
-  # Simple semantic version validation
-  if [[ "$format_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "✅ Format version validation passed: ${format_version}"
-    return 0
-  else
-    echo "❌ Invalid format version: ${format_version}" >&2
-    return 1
-  fi
-}
-
-# Function to validate timestamp format
-validate_timestamp() {
-  local receipt_file="$1"
-  local timestamp
-  timestamp=$(jq -r '.timestamp' "$receipt_file")
-  
-  # Basic ISO 8601 validation with Z suffix
-  if [[ "$timestamp" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
-    echo "✅ Timestamp format validation passed: ${timestamp}"
-    return 0
-  else
-    echo "❌ Invalid timestamp format: ${timestamp}" >&2
-    return 1
-  fi
-}
-
-# Function to validate commit hash
-validate_commit_hash() {
-  local receipt_file="$1"
-  local commit
-  commit=$(jq -r '.commit' "$receipt_file")
-  
-  # Git commit hash validation (7-40 hex characters)
-  if [[ "$commit" =~ ^[a-f0-9]{7,40}$ ]]; then
-    echo "✅ Commit hash validation passed: ${commit}"
-    return 0
-  else
-    echo "❌ Invalid commit hash format: ${commit}" >&2
-    return 1
-  fi
-}
-
-# Function to validate performance values
-validate_performance_values() {
-  local receipt_file="$1"
-
-  # Check that performance values are reasonable
-  local display_mibps
-  local comp3_mibps
-  display_mibps=$(jq -r '.summary.display_mibps' "$receipt_file")
-  comp3_mibps=$(jq -r '.summary.comp3_mibps' "$receipt_file")
-
-  # Basic sanity checks using awk for numeric comparison (no bc dependency)
-  if awk -v val="$display_mibps" 'BEGIN { exit !(val < 0) }'; then
-    echo "❌ Invalid DISPLAY throughput: ${display_mibps} MiB/s (must be >= 0)" >&2
-    return 1
-  fi
-
-  if awk -v val="$comp3_mibps" 'BEGIN { exit !(val < 0) }'; then
-    echo "❌ Invalid COMP-3 throughput: ${comp3_mibps} MiB/s (must be >= 0)" >&2
-    return 1
-  fi
-
-  # Check for extremely high values that might indicate measurement errors
-  if awk -v val="$display_mibps" 'BEGIN { exit !(val > 100000) }'; then
-    echo "⚠️  DISPLAY throughput seems unusually high: ${display_mibps} MiB/s" >&2
-  fi
-
-  if awk -v val="$comp3_mibps" 'BEGIN { exit !(val > 10000) }'; then
-    echo "⚠️  COMP-3 throughput seems unusually high: ${comp3_mibps} MiB/s" >&2
-  fi
-
-  echo "✅ Performance values validation passed"
-  return 0
-}
-
-# Main validation function
-validate_receipt() {
-  local receipt_file="$1"
-  
-  echo "🔍 Validating performance receipt: ${receipt_file}"
-  
-  if [[ ! -f "$receipt_file" ]]; then
-    echo "❌ Receipt file not found: ${receipt_file}" >&2
-    return 1
-  fi
-  
-  # Check if it's valid JSON
-  if ! jq empty "$receipt_file" >/dev/null 2>&1; then
-    echo "❌ Invalid JSON format" >&2
-    return 1
-  fi
-  
-  # Run all validations
-  validate_receipt_structure "$receipt_file" || return 1
-  validate_format_version "$receipt_file" || return 1
-  validate_timestamp "$receipt_file" || return 1
-  validate_commit_hash "$receipt_file" || return 1
-  validate_performance_values "$receipt_file" || return 1
-  validate_receipt_integrity "$receipt_file" || return 1
-  
-  echo "✅ All receipt validations passed"
-  return 0
-}
-
-# Script entry point
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-  if [[ $# -eq 0 ]]; then
-    echo "Usage: $0 [receipt_file]"
-    echo "  receipt_file: Path to performance receipt file (default: scripts/bench/perf.json)"
-    exit 1
-  fi
-  
-  validate_receipt "$RECEIPT_FILE"
-fi
+run_cargo run --quiet --manifest-path "$ROOT_DIR/tools/copybook-scripts/Cargo.toml" -- validate-perf-receipt "${1:-scripts/bench/perf.json}"

--- a/tools/clean_merge_conflicts.sh
+++ b/tools/clean_merge_conflicts.sh
@@ -14,9 +14,9 @@ bootstrap_rustup() {
 run_cargo() {
   bootstrap_rustup
 
-  if command -v rustup >/dev/null 2>&1; then
+  if command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q '^stable'; then
     rustup run stable cargo "$@"
-  elif command -v rustup.exe >/dev/null 2>&1; then
+  elif command -v rustup.exe >/dev/null 2>&1 && rustup.exe toolchain list | grep -q '^stable'; then
     rustup.exe run stable cargo "$@"
   else
     cargo "$@"

--- a/tools/clean_merge_conflicts.sh
+++ b/tools/clean_merge_conflicts.sh
@@ -13,11 +13,12 @@ bootstrap_rustup() {
 
 run_cargo() {
   bootstrap_rustup
+  local toolchain="${COPYBOOK_RUST_TOOLCHAIN:-stable}"
 
-  if command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q '^stable'; then
-    rustup run stable cargo "$@"
-  elif command -v rustup.exe >/dev/null 2>&1 && rustup.exe toolchain list | grep -q '^stable'; then
-    rustup.exe run stable cargo "$@"
+  if command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q "^${toolchain}"; then
+    rustup run "$toolchain" cargo "$@"
+  elif command -v rustup.exe >/dev/null 2>&1 && rustup.exe toolchain list | grep -q "^${toolchain}"; then
+    rustup.exe run "$toolchain" cargo "$@"
   else
     cargo "$@"
   fi

--- a/tools/copybook-scripts/Cargo.toml
+++ b/tools/copybook-scripts/Cargo.toml
@@ -22,6 +22,7 @@ clap.workspace = true
 num_cpus = { workspace = true }
 regex.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 
 [lints]
 workspace = true

--- a/tools/copybook-scripts/src/main.rs
+++ b/tools/copybook-scripts/src/main.rs
@@ -51,7 +51,7 @@ fn main() -> Result<()> {
         CommandKind::PerfAnnotateHost => perf_annotate_host(),
         CommandKind::SoakAggregate => soak_aggregate(),
         CommandKind::SoakDispatch => soak_dispatch(),
-        CommandKind::ValidatePerfReceipt { receipt_file } => validate_perf_receipt(receipt_file),
+        CommandKind::ValidatePerfReceipt { receipt_file } => validate_perf_receipt(&receipt_file),
         CommandKind::AuditScriptMigrations => audit_script_migrations(),
         CommandKind::CleanMergeConflicts { file } => clean_merge_conflicts(file),
         CommandKind::AdaptReviewAgents => adapt_review_agents(),
@@ -1154,7 +1154,7 @@ fn canonical_json_without_integrity(receipt: &Value) -> Result<String> {
     Ok(out)
 }
 
-fn validate_perf_receipt(receipt_file: PathBuf) -> Result<()> {
+fn validate_perf_receipt(receipt_file: &Path) -> Result<()> {
     println!(
         "🔍 Validating performance receipt: {}",
         receipt_file.display()
@@ -1165,7 +1165,7 @@ fn validate_perf_receipt(receipt_file: PathBuf) -> Result<()> {
     }
 
     let receipt: Value = serde_json::from_str(
-        &fs::read_to_string(&receipt_file)
+        &fs::read_to_string(receipt_file)
             .with_context(|| format!("failed to read {}", receipt_file.display()))?,
     )
     .context("❌ Invalid JSON format")?;

--- a/tools/copybook-scripts/src/main.rs
+++ b/tools/copybook-scripts/src/main.rs
@@ -32,6 +32,10 @@ enum CommandKind {
         #[arg(value_name = "RECEIPT_FILE", default_value = "scripts/bench/perf.json")]
         receipt_file: PathBuf,
     },
+    SealPerfReceipt {
+        #[arg(value_name = "RECEIPT_FILE", default_value = "scripts/bench/perf.json")]
+        receipt_file: PathBuf,
+    },
     AuditScriptMigrations,
     CleanMergeConflicts {
         #[arg(value_name = "PATH")]
@@ -52,6 +56,7 @@ fn main() -> Result<()> {
         CommandKind::SoakAggregate => soak_aggregate(),
         CommandKind::SoakDispatch => soak_dispatch(),
         CommandKind::ValidatePerfReceipt { receipt_file } => validate_perf_receipt(&receipt_file),
+        CommandKind::SealPerfReceipt { receipt_file } => seal_perf_receipt(&receipt_file),
         CommandKind::AuditScriptMigrations => audit_script_migrations(),
         CommandKind::CleanMergeConflicts { file } => clean_merge_conflicts(file),
         CommandKind::AdaptReviewAgents => adapt_review_agents(),
@@ -1294,8 +1299,7 @@ fn validate_receipt_integrity(receipt: &Value) -> Result<()> {
         .and_then(Value::as_str)
         .context("❌ Missing integrity SHA256 hash")?;
 
-    let canonical = canonical_json_without_integrity(receipt)?;
-    let actual_hash = format!("{:x}", Sha256::digest(canonical.as_bytes()));
+    let actual_hash = receipt_integrity_hash(receipt)?;
 
     if stored_hash != actual_hash {
         bail!(
@@ -1304,6 +1308,46 @@ fn validate_receipt_integrity(receipt: &Value) -> Result<()> {
     }
 
     println!("✅ Receipt integrity validation passed");
+    Ok(())
+}
+
+fn receipt_integrity_hash(receipt: &Value) -> Result<String> {
+    let canonical = canonical_json_without_integrity(receipt)?;
+    Ok(format!("{:x}", Sha256::digest(canonical.as_bytes())))
+}
+
+fn seal_receipt_integrity(receipt: &mut Value) -> Result<String> {
+    let hash = receipt_integrity_hash(receipt)?;
+    let Value::Object(map) = receipt else {
+        bail!("perf receipt root must be a JSON object");
+    };
+
+    let mut integrity = Map::new();
+    integrity.insert("sha256".to_string(), Value::String(hash.clone()));
+    map.insert("integrity".to_string(), Value::Object(integrity));
+    Ok(hash)
+}
+
+fn seal_perf_receipt(receipt_file: &Path) -> Result<()> {
+    if !receipt_file.is_file() {
+        bail!("❌ Receipt file not found: {}", receipt_file.display());
+    }
+
+    let mut receipt: Value = serde_json::from_str(
+        &fs::read_to_string(receipt_file)
+            .with_context(|| format!("failed to read {}", receipt_file.display()))?,
+    )
+    .context("❌ Invalid JSON format")?;
+    let hash = seal_receipt_integrity(&mut receipt)?;
+    let sealed = serde_json::to_string_pretty(&receipt)? + "\n";
+    fs::write(receipt_file, sealed)
+        .with_context(|| format!("failed to write {}", receipt_file.display()))?;
+
+    println!(
+        "✅ receipts: {} (integrity: {}...)",
+        receipt_file.display(),
+        &hash[..16]
+    );
     Ok(())
 }
 
@@ -1588,6 +1632,21 @@ pub fn encode_value(
         assert!(!canonical.contains("integrity"));
         assert!(canonical.starts_with("{\"benchmarks\":"));
         Ok(())
+    }
+
+    #[test]
+    fn seals_receipt_with_validator_hash() -> Result<()> {
+        let mut receipt = valid_receipt();
+        let hash = seal_receipt_integrity(&mut receipt)?;
+        assert_eq!(
+            receipt
+                .get("integrity")
+                .and_then(Value::as_object)
+                .and_then(|integrity| integrity.get("sha256"))
+                .and_then(Value::as_str),
+            Some(hash.as_str())
+        );
+        validate_receipt_integrity(&receipt)
     }
 
     #[test]

--- a/tools/copybook-scripts/src/main.rs
+++ b/tools/copybook-scripts/src/main.rs
@@ -11,6 +11,7 @@ use chrono::SecondsFormat;
 use clap::{Parser, Subcommand};
 use regex::Regex;
 use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
 
 #[derive(Debug, Parser)]
 #[command(name = "copybook-scripts")]
@@ -27,6 +28,11 @@ enum CommandKind {
     PerfAnnotateHost,
     SoakAggregate,
     SoakDispatch,
+    ValidatePerfReceipt {
+        #[arg(value_name = "RECEIPT_FILE", default_value = "scripts/bench/perf.json")]
+        receipt_file: PathBuf,
+    },
+    AuditScriptMigrations,
     CleanMergeConflicts {
         #[arg(value_name = "PATH")]
         file: PathBuf,
@@ -45,6 +51,8 @@ fn main() -> Result<()> {
         CommandKind::PerfAnnotateHost => perf_annotate_host(),
         CommandKind::SoakAggregate => soak_aggregate(),
         CommandKind::SoakDispatch => soak_dispatch(),
+        CommandKind::ValidatePerfReceipt { receipt_file } => validate_perf_receipt(receipt_file),
+        CommandKind::AuditScriptMigrations => audit_script_migrations(),
         CommandKind::CleanMergeConflicts { file } => clean_merge_conflicts(file),
         CommandKind::AdaptReviewAgents => adapt_review_agents(),
         CommandKind::FixAgentIssues => fix_agent_issues(),
@@ -1028,9 +1036,332 @@ fn final_cleanup_agents() -> Result<()> {
     )
 }
 
+fn required_object<'a>(value: &'a Value, name: &str) -> Result<&'a Map<String, Value>> {
+    value
+        .get(name)
+        .and_then(Value::as_object)
+        .with_context(|| format!("missing required object field: {name}"))
+}
+
+fn required_array<'a>(value: &'a Value, name: &str) -> Result<&'a Vec<Value>> {
+    value
+        .get(name)
+        .and_then(Value::as_array)
+        .with_context(|| format!("missing required array field: {name}"))
+}
+
+fn required_number(value: &Value, name: &str) -> Result<f64> {
+    value
+        .get(name)
+        .and_then(Value::as_f64)
+        .with_context(|| format!("missing required numeric field: {name}"))
+}
+
+fn required_string<'a>(value: &'a Value, name: &str) -> Result<&'a str> {
+    value
+        .get(name)
+        .and_then(Value::as_str)
+        .with_context(|| format!("missing required string field: {name}"))
+}
+
+fn has_semver_shape(value: &str) -> bool {
+    let mut pieces = value.split('.');
+    let Some(major) = pieces.next() else {
+        return false;
+    };
+    let Some(minor) = pieces.next() else {
+        return false;
+    };
+    let Some(patch) = pieces.next() else {
+        return false;
+    };
+    pieces.next().is_none()
+        && [major, minor, patch]
+            .iter()
+            .all(|part| !part.is_empty() && part.bytes().all(|b| b.is_ascii_digit()))
+}
+
+fn has_utc_timestamp_shape(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.len() == 20
+        && bytes[4] == b'-'
+        && bytes[7] == b'-'
+        && bytes[10] == b'T'
+        && bytes[13] == b':'
+        && bytes[16] == b':'
+        && bytes[19] == b'Z'
+        && bytes
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| !matches!(idx, 4 | 7 | 10 | 13 | 16 | 19))
+            .all(|(_, byte)| byte.is_ascii_digit())
+}
+
+fn has_commit_hash_shape(value: &str) -> bool {
+    (7..=40).contains(&value.len())
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn write_canonical_json(value: &Value, out: &mut String) -> Result<()> {
+    match value {
+        Value::Null => out.push_str("null"),
+        Value::Bool(value) => out.push_str(if *value { "true" } else { "false" }),
+        Value::Number(number) => out.push_str(&number.to_string()),
+        Value::String(value) => out.push_str(&serde_json::to_string(value)?),
+        Value::Array(values) => {
+            out.push('[');
+            for (idx, item) in values.iter().enumerate() {
+                if idx > 0 {
+                    out.push(',');
+                }
+                write_canonical_json(item, out)?;
+            }
+            out.push(']');
+        }
+        Value::Object(map) => {
+            out.push('{');
+            let mut keys: Vec<_> = map.keys().collect();
+            keys.sort();
+            for (idx, key) in keys.iter().enumerate() {
+                if idx > 0 {
+                    out.push(',');
+                }
+                out.push_str(&serde_json::to_string(key)?);
+                out.push(':');
+                let Some(item) = map.get(*key) else {
+                    bail!("canonical JSON key vanished while serializing: {key}");
+                };
+                write_canonical_json(item, out)?;
+            }
+            out.push('}');
+        }
+    }
+    Ok(())
+}
+
+fn canonical_json_without_integrity(receipt: &Value) -> Result<String> {
+    let mut canonical = receipt.clone();
+    if let Value::Object(map) = &mut canonical {
+        map.remove("integrity");
+    } else {
+        bail!("perf receipt root must be a JSON object");
+    }
+
+    let mut out = String::new();
+    write_canonical_json(&canonical, &mut out)?;
+    Ok(out)
+}
+
+fn validate_perf_receipt(receipt_file: PathBuf) -> Result<()> {
+    println!(
+        "🔍 Validating performance receipt: {}",
+        receipt_file.display()
+    );
+
+    if !receipt_file.is_file() {
+        bail!("❌ Receipt file not found: {}", receipt_file.display());
+    }
+
+    let receipt: Value = serde_json::from_str(
+        &fs::read_to_string(&receipt_file)
+            .with_context(|| format!("failed to read {}", receipt_file.display()))?,
+    )
+    .context("❌ Invalid JSON format")?;
+
+    validate_receipt_structure(&receipt)?;
+    validate_format_version_value(&receipt)?;
+    validate_timestamp_value(&receipt)?;
+    validate_commit_hash_value(&receipt)?;
+    validate_performance_values(&receipt)?;
+    validate_receipt_integrity(&receipt)?;
+
+    println!("✅ All receipt validations passed");
+    Ok(())
+}
+
+fn validate_receipt_structure(receipt: &Value) -> Result<()> {
+    for field in [
+        "format_version",
+        "timestamp",
+        "commit",
+        "build_profile",
+        "target_cpu",
+        "environment",
+        "benchmarks",
+        "summary",
+    ] {
+        if receipt.get(field).is_none() {
+            bail!("❌ Missing required field: {field}");
+        }
+    }
+
+    let environment = required_object(receipt, "environment")?;
+    for field in ["os", "kernel", "cpu_model", "cpu_cores", "wsl2_detected"] {
+        if !environment.contains_key(field) {
+            bail!("❌ Missing required environment field: {field}");
+        }
+    }
+
+    let benchmarks = required_array(receipt, "benchmarks")?;
+    if benchmarks.is_empty() {
+        bail!("❌ Benchmarks missing required fields");
+    }
+    for benchmark in benchmarks {
+        let Some(benchmark) = benchmark.as_object() else {
+            bail!("❌ Benchmarks missing required fields");
+        };
+        for field in ["name", "mean_ns", "bytes_processed", "mean_mibps"] {
+            if !benchmark.contains_key(field) {
+                bail!("❌ Benchmarks missing required fields");
+            }
+        }
+    }
+
+    let summary = required_object(receipt, "summary")?;
+    for field in ["display_mibps", "comp3_mibps", "max_rss_mib"] {
+        if !summary.contains_key(field) {
+            bail!("❌ Missing required summary field: {field}");
+        }
+    }
+
+    let integrity = required_object(receipt, "integrity")?;
+    if !integrity.contains_key("sha256") {
+        bail!("❌ Missing integrity SHA256 hash");
+    }
+
+    println!("✅ Receipt structure validation passed");
+    Ok(())
+}
+
+fn validate_format_version_value(receipt: &Value) -> Result<()> {
+    let format_version = required_string(receipt, "format_version")?;
+    if !has_semver_shape(format_version) {
+        bail!("❌ Invalid format version: {format_version}");
+    }
+    println!("✅ Format version validation passed: {format_version}");
+    Ok(())
+}
+
+fn validate_timestamp_value(receipt: &Value) -> Result<()> {
+    let timestamp = required_string(receipt, "timestamp")?;
+    if !has_utc_timestamp_shape(timestamp) {
+        bail!("❌ Invalid timestamp format: {timestamp}");
+    }
+    println!("✅ Timestamp format validation passed: {timestamp}");
+    Ok(())
+}
+
+fn validate_commit_hash_value(receipt: &Value) -> Result<()> {
+    let commit = required_string(receipt, "commit")?;
+    if !has_commit_hash_shape(commit) {
+        bail!("❌ Invalid commit hash format: {commit}");
+    }
+    println!("✅ Commit hash validation passed: {commit}");
+    Ok(())
+}
+
+fn validate_performance_values(receipt: &Value) -> Result<()> {
+    let summary = receipt
+        .get("summary")
+        .context("missing required object field: summary")?;
+    let display_mibps = required_number(summary, "display_mibps")?;
+    let comp3_mibps = required_number(summary, "comp3_mibps")?;
+
+    if display_mibps < 0.0 {
+        bail!("❌ Invalid DISPLAY throughput: {display_mibps} MiB/s (must be >= 0)");
+    }
+    if comp3_mibps < 0.0 {
+        bail!("❌ Invalid COMP-3 throughput: {comp3_mibps} MiB/s (must be >= 0)");
+    }
+    if display_mibps > 100_000.0 {
+        eprintln!("⚠️  DISPLAY throughput seems unusually high: {display_mibps} MiB/s");
+    }
+    if comp3_mibps > 10_000.0 {
+        eprintln!("⚠️  COMP-3 throughput seems unusually high: {comp3_mibps} MiB/s");
+    }
+
+    println!("✅ Performance values validation passed");
+    Ok(())
+}
+
+fn validate_receipt_integrity(receipt: &Value) -> Result<()> {
+    let stored_hash = receipt
+        .get("integrity")
+        .and_then(Value::as_object)
+        .and_then(|integrity| integrity.get("sha256"))
+        .and_then(Value::as_str)
+        .context("❌ Missing integrity SHA256 hash")?;
+
+    let canonical = canonical_json_without_integrity(receipt)?;
+    let actual_hash = format!("{:x}", Sha256::digest(canonical.as_bytes()));
+
+    if stored_hash != actual_hash {
+        bail!(
+            "❌ Receipt integrity validation failed\n  Stored hash: {stored_hash}\n  Actual hash: {actual_hash}\n  Hint: Receipt may have been modified after hashing"
+        );
+    }
+
+    println!("✅ Receipt integrity validation passed");
+    Ok(())
+}
+
+fn audit_script_migrations() -> Result<()> {
+    let root = workspace_root()?;
+    let mut script_paths = Vec::new();
+    for dir in ["scripts", "tools", "deploy/kubernetes"] {
+        collect_script_paths(&root.join(dir), &mut script_paths)?;
+    }
+    script_paths.sort();
+
+    println!("Rust migration candidates for repository scripts:\n");
+    for path in script_paths {
+        let rel = path.strip_prefix(&root).unwrap_or(&path);
+        let source = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        let status = if source.contains("tools/copybook-scripts/Cargo.toml") {
+            "migrated-wrapper"
+        } else if rel.extension().and_then(|ext| ext.to_str()) == Some("py") {
+            "candidate-python"
+        } else {
+            "candidate-shell"
+        };
+        println!("{status:16} {}", rel.display());
+    }
+
+    Ok(())
+}
+
+fn collect_script_paths(root: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    if !root.exists() {
+        return Ok(());
+    }
+    let mut entries = vec![root.to_path_buf()];
+    while let Some(path) = entries.pop() {
+        for item in fs::read_dir(path)? {
+            let entry = item?;
+            let file_type = entry.file_type()?;
+            let path = entry.path();
+            if file_type.is_dir() {
+                entries.push(path);
+            } else if file_type.is_file()
+                && matches!(
+                    path.extension().and_then(|ext| ext.to_str()),
+                    Some("sh" | "py")
+                )
+            {
+                out.push(path);
+            }
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     fn apply_rules(input: &str, rules: &[super::TextRule]) -> String {
         match apply_text_rules(input.to_string(), rules) {
@@ -1217,5 +1548,61 @@ pub fn encode_value(
         assert_eq!(percentile(&samples, 2, 1), Some(42.0));
         assert_eq!(percentile(&[], 50, 100), None);
         assert_eq!(percentile(&samples, 1, 0), None);
+    }
+
+    fn valid_receipt() -> Value {
+        json!({
+            "format_version": "1.0.0",
+            "timestamp": "2026-05-16T00:00:00Z",
+            "commit": "abcdef1",
+            "build_profile": "release",
+            "target_cpu": "native",
+            "environment": {
+                "os": "linux",
+                "kernel": "test",
+                "cpu_model": "test",
+                "cpu_cores": 8,
+                "wsl2_detected": false
+            },
+            "benchmarks": [{
+                "name": "decode/display",
+                "mean_ns": 1.0,
+                "bytes_processed": 1024,
+                "mean_mibps": 128.0
+            }],
+            "summary": {
+                "display_mibps": 128.0,
+                "comp3_mibps": 64.0,
+                "max_rss_mib": 32.0
+            },
+            "integrity": {
+                "sha256": "placeholder"
+            }
+        })
+    }
+
+    #[test]
+    fn canonical_json_sorts_keys_and_removes_integrity() -> Result<()> {
+        let receipt = valid_receipt();
+        let canonical = canonical_json_without_integrity(&receipt)?;
+        assert!(!canonical.contains("integrity"));
+        assert!(canonical.starts_with("{\"benchmarks\":"));
+        Ok(())
+    }
+
+    #[test]
+    fn validates_semver_timestamp_and_commit_shapes() {
+        assert!(has_semver_shape("1.2.3"));
+        assert!(!has_semver_shape("1.2"));
+        assert!(has_utc_timestamp_shape("2026-05-16T00:00:00Z"));
+        assert!(!has_utc_timestamp_shape("2026-05-16 00:00:00"));
+        assert!(has_commit_hash_shape("abcdef1"));
+        assert!(!has_commit_hash_shape("ABCDEF1"));
+    }
+
+    #[test]
+    fn validates_required_receipt_structure() -> Result<()> {
+        let receipt = valid_receipt();
+        validate_receipt_structure(&receipt)
     }
 }


### PR DESCRIPTION
### Motivation
- Move performance receipt validation into `copybook-scripts` with shell wrappers delegating to Rust.
- Add Rust receipt sealing so generated benchmark receipts use the same canonical hash path as validation.
- Add script migration auditing alongside the existing migrated wrappers.
- Refresh the PR on current `main` without carrying stale shared CI/security churn.

### Description
- Add `validate-perf-receipt`, `seal-perf-receipt`, and `audit-script-migrations` subcommands to `copybook-scripts`.
- Replace the large `scripts/validate-perf-receipt.sh` implementation with a Rust-backed compatibility wrapper.
- Route benchmark receipt sealing through the Rust canonical JSON hash path in `scripts/bench-enhanced.sh`.
- Add `COPYBOOK_RUST_TOOLCHAIN` support to migrated Rust-backed wrappers so local toolchain selection is possible while CI can keep defaulting to `stable`.
- Add unit coverage for canonical JSON, shape validation, receipt structure validation, and seal/validate hash agreement.

### Testing
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 test -p copybook-scripts`
- `cargo +1.95.0 clippy -p copybook-scripts --all-targets --all-features -- -D warnings -W clippy::pedantic`
- Temp receipt smoke test: `seal-perf-receipt` then `COPYBOOK_RUST_TOOLCHAIN=1.95.0 bash scripts/validate-perf-receipt.sh <receipt>`
- `cargo +1.95.0 run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- audit-script-migrations`
- `bash -n scripts/bench-enhanced.sh`
- `bash -n scripts/check_no_unwrap_expect.sh scripts/guard-hotpaths.sh scripts/perf-annotate-host.sh scripts/soak-dispatch.sh scripts/validate-perf-receipt.sh tools/clean_merge_conflicts.sh scripts/bench-enhanced.sh`
- `git diff --check`