### PR TITLE
refactor(scripts): port agent maintenance utilities to Rust

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -14,6 +14,7 @@ on:
       - 'tests/**'
       - 'Cargo.*'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches: [ main, develop ]
     paths:
       - 'crates/**'
@@ -30,9 +31,13 @@ env:
 
 jobs:
   coverage:
-    name: Code Coverage
+    name: Tarpaulin Coverage
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'coverage') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     steps:
     - name: Checkout code

--- a/.github/workflows/leak-detection.yml
+++ b/.github/workflows/leak-detection.yml
@@ -6,6 +6,7 @@ on:
   schedule:
     - cron: "0 4 * * 0"  # Weekly on Sunday at 04:00 UTC
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - "crates/copybook-codec/**"
       - "crates/copybook-core/**"
@@ -24,6 +25,10 @@ jobs:
     name: Memory Leak Detection (LSAN)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'leak-check') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     steps:
       - uses: actions/checkout@v6
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,6 +1227,7 @@ dependencies = [
  "chrono",
  "clap",
  "num_cpus",
+ "regex",
  "serde_json",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
  "hex",
  "logos",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "serde_plain",
@@ -1049,7 +1049,7 @@ dependencies = [
  "copybook-codec",
  "copybook-core",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "sha2",
@@ -1156,7 +1156,7 @@ dependencies = [
  "copybook-support-matrix",
  "crossbeam-channel",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
 ]
@@ -3070,9 +3070,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -3365,9 +3365,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3781,7 +3781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/crates/copybook-cli/src/commands/audit.rs
+++ b/crates/copybook-cli/src/commands/audit.rs
@@ -2701,12 +2701,11 @@ fn run_audit_health_check_impl(
         );
     }
 
-    let overall_health_score = if checks_executed == 0 {
-        0
-    } else {
-        let failed_penalty = (checks_failed * 100) / checks_executed;
-        (100u32.saturating_sub(failed_penalty)).min(100)
-    };
+    let overall_health_score = (checks_failed * 100)
+        .checked_div(checks_executed)
+        .map_or(0, |failed_penalty| {
+            (100u32.saturating_sub(failed_penalty)).min(100)
+        });
 
     let status_code = if checks_failed > 0 || !parse_issues.is_empty() {
         ExitCode::Data

--- a/crates/copybook-cli/src/main.rs
+++ b/crates/copybook-cli/src/main.rs
@@ -554,13 +554,10 @@ fn main() -> ProcessExitCode {
 
 #[allow(clippy::too_many_lines)]
 fn run() -> anyhow::Result<ExitCode> {
-    #[allow(clippy::panic)]
-    if std::env::var("COPYBOOK_TEST_PANIC")
-        .map(|v| v == "1")
-        .unwrap_or(false)
-    {
-        panic!("COPYBOOK_TEST_PANIC triggered");
-    }
+    assert!(
+        !std::env::var("COPYBOOK_TEST_PANIC").is_ok_and(|v| v == "1"),
+        "COPYBOOK_TEST_PANIC triggered"
+    );
 
     let cli = match Cli::try_parse() {
         Ok(cli) => cli,

--- a/crates/copybook-codec/src/fidelity.rs
+++ b/crates/copybook-codec/src/fidelity.rs
@@ -948,11 +948,9 @@ pub mod utils {
             .map(|p| p.validation_time_ms)
             .sum();
         let total_records_u64 = u64::try_from(total_records).unwrap_or(u64::MAX);
-        let average_validation_time = if total_records_u64 == 0 {
-            0
-        } else {
-            total_validation_time / total_records_u64
-        };
+        let average_validation_time = total_validation_time
+            .checked_div(total_records_u64)
+            .unwrap_or(0);
 
         BatchFidelityMetrics {
             total_records,

--- a/crates/copybook-contracts/src/feature_flags.rs
+++ b/crates/copybook-contracts/src/feature_flags.rs
@@ -530,8 +530,7 @@ impl FeatureFlagsHandle {
     pub fn is_enabled(&self, feature: Feature) -> bool {
         self.flags
             .read()
-            .map(|flags| flags.is_enabled(feature))
-            .unwrap_or(false)
+            .is_ok_and(|flags| flags.is_enabled(feature))
     }
 
     /// Enable a feature flag through the handle.

--- a/crates/copybook-core/src/audit/security.rs
+++ b/crates/copybook-core/src/audit/security.rs
@@ -421,8 +421,7 @@ impl SecurityMonitor {
         let priority = 16 * 8 + 4; // 132
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_secs());
         format!(
             "<{}>1 {} copybook-rs SecurityMonitor - {} - {}",
             priority, timestamp, violation.violation_id, violation.description

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,9 +8,10 @@ Automation and utility scripts for copybook-rs development and CI/CD.
 - **performance_test.rs** - Performance regression testing
 
 ## Development Automation
-- **adapt-review-agents.py** - Compatibility wrapper for the Rust-native `copybook-scripts adapt-review-agents` command
-- **final-cleanup-agents.py** - Compatibility wrapper for the Rust-native `copybook-scripts final-cleanup-agents` command
-- **fix-agent-issues.py** - Compatibility wrapper for the Rust-native `copybook-scripts fix-agent-issues` command
+- **copybook-scripts adapt-review-agents** - Native Rust agent configuration adaptation utility
+- **copybook-scripts final-cleanup-agents** - Native Rust agent cleanup and finalization
+- **copybook-scripts fix-agent-issues** - Native Rust agent configuration repair tool
+- **adapt-review-agents.py**, **final-cleanup-agents.py**, and **fix-agent-issues.py** - Compatibility wrappers that delegate to the Rust tool
 
 ## Usage
 
@@ -28,19 +29,21 @@ Scripts are typically run as part of development workflows:
 ### Agent Management
 ```bash
 # Adapt agent configurations
-scripts/adapt-review-agents.py
+cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- adapt-review-agents
 
 # Fix agent configuration issues
-scripts/fix-agent-issues.py
+cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- fix-agent-issues
 
-# Run final cleanup
-scripts/final-cleanup-agents.py
+# Compatibility wrappers remain available for existing automation
+python scripts/adapt-review-agents.py
+python scripts/fix-agent-issues.py
 ```
 
 ## Platform Support
 - Shell scripts (.sh) for Unix-like systems
 - Batch files (.bat) for Windows
-- Rust-native maintenance logic in `tools/copybook-scripts` with small compatibility wrappers in `scripts/`
+- Native Rust utilities in `tools/copybook-scripts` for repository automation
+- Python scripts (.py) are compatibility wrappers for existing automation
 
 These scripts complement the main build system and are used for specialized development tasks.
 ## License

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,9 +8,9 @@ Automation and utility scripts for copybook-rs development and CI/CD.
 - **performance_test.rs** - Performance regression testing
 
 ## Development Automation
-- **adapt-review-agents.py** - Agent configuration adaptation utility
-- **final-cleanup-agents.py** - Agent cleanup and finalization
-- **fix-agent-issues.py** - Agent configuration repair tool
+- **adapt-review-agents.py** - Compatibility wrapper for the Rust-native `copybook-scripts adapt-review-agents` command
+- **final-cleanup-agents.py** - Compatibility wrapper for the Rust-native `copybook-scripts final-cleanup-agents` command
+- **fix-agent-issues.py** - Compatibility wrapper for the Rust-native `copybook-scripts fix-agent-issues` command
 
 ## Usage
 
@@ -28,16 +28,19 @@ Scripts are typically run as part of development workflows:
 ### Agent Management
 ```bash
 # Adapt agent configurations
-python scripts/adapt-review-agents.py
+scripts/adapt-review-agents.py
 
 # Fix agent configuration issues
-python scripts/fix-agent-issues.py
+scripts/fix-agent-issues.py
+
+# Run final cleanup
+scripts/final-cleanup-agents.py
 ```
 
 ## Platform Support
 - Shell scripts (.sh) for Unix-like systems
 - Batch files (.bat) for Windows
-- Python scripts (.py) for cross-platform automation
+- Rust-native maintenance logic in `tools/copybook-scripts` with small compatibility wrappers in `scripts/`
 
 These scripts complement the main build system and are used for specialized development tasks.
 ## License

--- a/scripts/adapt-review-agents.py
+++ b/scripts/adapt-review-agents.py
@@ -1,37 +1,18 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Compatibility launcher for the Rust-native copybook-scripts command."""
+"""Compatibility wrapper for the native Rust copybook-scripts implementation."""
 
 import subprocess
 import sys
-from pathlib import Path
 
-COMMAND = "adapt-review-agents"
-
-
-def workspace_root() -> Path:
-    return Path(
-        subprocess.check_output(
-            ["git", "rev-parse", "--show-toplevel"],
-            text=True,
-        ).strip()
-    )
-
-
-def main() -> int:
-    root = workspace_root()
-    cmd = [
+sys.exit(
+    subprocess.call([
         "cargo",
         "run",
         "--quiet",
         "--manifest-path",
-        str(root / "tools" / "copybook-scripts" / "Cargo.toml"),
+        "tools/copybook-scripts/Cargo.toml",
         "--",
-        COMMAND,
-        *sys.argv[1:],
-    ]
-    return subprocess.run(cmd, check=False).returncode
-
-
-if __name__ == "__main__":
-    raise SystemExit(main())
+        "adapt-review-agents",
+    ])
+)

--- a/scripts/adapt-review-agents.py
+++ b/scripts/adapt-review-agents.py
@@ -1,146 +1,37 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""
-Script to adapt all review agents in .claude/agents4/review/ to copybook-rs standards.
-This replaces BitNet.rs-specific content with copybook-rs enterprise mainframe patterns.
-"""
+"""Compatibility launcher for the Rust-native copybook-scripts command."""
 
-import os
-import re
+import subprocess
+import sys
 from pathlib import Path
 
-# Base directory for review agents
-AGENTS_DIR = Path(".claude/agents4/review/")
+COMMAND = "adapt-review-agents"
 
-# Mapping of BitNet.rs terms to copybook-rs terms
-REPLACEMENTS = {
-    # Core domain replacement
-    "BitNet.rs neural network inference": "copybook-rs enterprise mainframe data processing",
-    "BitNet neural network": "copybook-rs enterprise mainframe",
-    "BitNet.rs": "copybook-rs",
-    "neural network": "COBOL parsing",
-    "quantization": "COBOL parsing",
-    "inference": "data conversion",
-    "GPU": "enterprise performance",
 
-    # Technical replacements
-    "I2S, TL1, TL2": "DISPLAY, COMP, COMP-3",
-    "quantization accuracy": "COBOL parsing accuracy",
-    "cross-validation": "mainframe compatibility",
-    "GGUF": "EBCDIC",
-    "tensor": "field",
-    "model": "copybook",
-    "CUDA": "SIMD",
-
-    # Performance targets
-    ">99% accuracy": "enterprise performance targets (DISPLAY ≥ 4.1 GiB/s, COMP-3 ≥ 560 MiB/s)",
-    "99.8%": "4.1 GiB/s",
-    "99.6%": "560 MiB/s",
-
-    # Crate names
-    "bitnet-quantization": "copybook-core",
-    "bitnet-kernels": "copybook-codec",
-    "bitnet-inference": "copybook-cli",
-    "bitnet-wasm": "copybook-gen",
-    "bitnet-tokenizers": "copybook-bench",
-
-    # Commands
-    "--no-default-features --features cpu": "--workspace",
-    "--no-default-features --features gpu": "--workspace --release",
-    "cargo run -p xtask -- crossval": "cargo xtask ci",
-    "cargo run -p xtask -- benchmark": "cargo bench --package copybook-bench",
-    "./scripts/verify-tests.sh": "cargo xtask ci --quick",
-
-    # Error patterns
-    "CUDA unavailable": "xtask unavailable",
-    "GPU memory": "parsing memory",
-    "C++ reference": "mainframe compatibility",
-
-    # Evidence patterns
-    "CPU: ok, GPU: ok": "workspace release ok",
-    "tokens/sec": "records/sec",
-    "I2S: 99.X%": "DISPLAY: X.Y GiB/s",
-
-    # Architecture
-    "quantization kernels": "COBOL parsing kernels",
-    "inference pipeline": "data processing pipeline",
-    "1-bit neural networks": "enterprise mainframe data processing",
-}
-
-def adapt_agent_file(filepath):
-    """Adapt a single agent file to copybook-rs standards."""
-    print(f"Processing {filepath.name}...")
-
-    with open(filepath, 'r') as f:
-        content = f.read()
-
-    # Apply replacements
-    original_content = content
-    for old_term, new_term in REPLACEMENTS.items():
-        content = content.replace(old_term, new_term)
-
-    # Specific patterns for workspace structure
-    content = re.sub(
-        r'bitnet-[a-zA-Z]+',
-        lambda m: {
-            'bitnet-quantization': 'copybook-core',
-            'bitnet-kernels': 'copybook-codec',
-            'bitnet-inference': 'copybook-cli',
-            'bitnet-wasm': 'copybook-gen',
-            'bitnet-tokenizers': 'copybook-bench'
-        }.get(m.group(0), 'copybook-core'),
-        content
+def workspace_root() -> Path:
+    return Path(
+        subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            text=True,
+        ).strip()
     )
 
-    # Update command patterns
-    content = re.sub(
-        r'cargo test --workspace --no-default-features --features \w+',
-        'cargo test --workspace',
-        content
-    )
 
-    content = re.sub(
-        r'cargo build --release --no-default-features --features \w+',
-        'cargo build --workspace --release',
-        content
-    )
+def main() -> int:
+    root = workspace_root()
+    cmd = [
+        "cargo",
+        "run",
+        "--quiet",
+        "--manifest-path",
+        str(root / "tools" / "copybook-scripts" / "Cargo.toml"),
+        "--",
+        COMMAND,
+        *sys.argv[1:],
+    ]
+    return subprocess.run(cmd, check=False).returncode
 
-    # Update evidence patterns
-    content = re.sub(
-        r'tests: cargo test: (\d+)/(\d+) pass; CPU: (\d+)/(\d+), GPU: (\d+)/(\d+); quarantined: (\d+) \(linked\)',
-        r'tests: nextest: \1/\2 pass; enterprise validation: \3/\4; quarantined: \7 (linked)',
-        content
-    )
-
-    # Only write if content changed
-    if content != original_content:
-        with open(filepath, 'w') as f:
-            f.write(content)
-        print(f"  ✓ Updated {filepath.name}")
-        return True
-    else:
-        print(f"  - No changes needed for {filepath.name}")
-        return False
-
-def main():
-    """Process all agent files in the review directory."""
-    if not AGENTS_DIR.exists():
-        print(f"Error: Directory {AGENTS_DIR} does not exist")
-        return
-
-    agent_files = list(AGENTS_DIR.glob("*.md"))
-    if not agent_files:
-        print(f"No .md files found in {AGENTS_DIR}")
-        return
-
-    print(f"Found {len(agent_files)} agent files to process")
-
-    updated_count = 0
-    for agent_file in sorted(agent_files):
-        if adapt_agent_file(agent_file):
-            updated_count += 1
-
-    print(f"\nCompleted! Updated {updated_count} of {len(agent_files)} agent files.")
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/final-cleanup-agents.py
+++ b/scripts/final-cleanup-agents.py
@@ -1,105 +1,37 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""
-Final comprehensive cleanup script for review agents.
-"""
+"""Compatibility launcher for the Rust-native copybook-scripts command."""
 
-import os
-import re
+import subprocess
+import sys
 from pathlib import Path
 
-# Base directory for review agents
-AGENTS_DIR = Path(".claude/agents4/review/")
+COMMAND = "final-cleanup-agents"
 
-def final_cleanup_agent(filepath):
-    """Perform final cleanup of agent file."""
-    print(f"Final cleanup of {filepath.name}...")
 
-    with open(filepath, 'r') as f:
-        content = f.read()
+def workspace_root() -> Path:
+    return Path(
+        subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            text=True,
+        ).strip()
+    )
 
-    original_content = content
 
-    # Fix remaining garbled terms
-    content = content.replace("1-bit quantized COBOL parsings", "enterprise mainframe data processing")
-    content = content.replace("Neural Network Security Testing (NNST)", "COBOL Parsing Security Testing")
-    content = content.replace("HuggingFace tokens", "mainframe authentication tokens")
-    content = content.replace("copybook poisoning attacks", "malicious copybook attacks")
+def main() -> int:
+    root = workspace_root()
+    cmd = [
+        "cargo",
+        "run",
+        "--quiet",
+        "--manifest-path",
+        str(root / "tools" / "copybook-scripts" / "Cargo.toml"),
+        "--",
+        COMMAND,
+        *sys.argv[1:],
+    ]
+    return subprocess.run(cmd, check=False).returncode
 
-    # Fix workspace references
-    content = content.replace("copybook-rs workspace crates", "copybook-rs 5-crate workspace (core, codec, cli, gen, bench)")
-
-    # Fix command patterns
-    content = content.replace("cargo clippy --workspace --all-targets --workspace", "cargo clippy --workspace --all-targets")
-    content = content.replace("--workspace -- -D warnings", "-- -D warnings -W clippy::pedantic")
-
-    # Fix technical descriptions
-    content = content.replace("COBOL parsing COBOL parsing", "COBOL parsing")
-    content = content.replace("enterprise performance/CPU", "high-performance")
-    content = content.replace("enterprise performance memory", "memory")
-    content = content.replace("SIMD enterprise performance", "SIMD CPU")
-
-    # Fix performance metrics formatting
-    content = content.replace("GiB/s for DISPLAY, MiB/s for COMP-3ond", "records/second")
-    content = content.replace("GiB/s for DISPLAY, MiB/s for COMP-3", "GiB/s (DISPLAY), MiB/s (COMP-3)")
-
-    # Fix duplicate workspace patterns
-    content = content.replace("cargo bench --workspace --workspace", "cargo bench --package copybook-bench")
-    content = content.replace("cargo test --workspace --workspace", "cargo test --workspace")
-
-    # Fix evidence patterns
-    content = content.replace("I2S ≥4.1 GiB/s, TL1 ≥560 MiB/s, TL2 ≥99.7%", "DISPLAY ≥4.1 GiB/s, COMP-3 ≥560 MiB/s")
-    content = content.replace("I2S: 4.1 GiB/s", "DISPLAY: 4.1+ GiB/s")
-    content = content.replace("TL1: 560 MiB/s", "COMP-3: 560+ MiB/s")
-
-    # Fix specific technical terms
-    content = content.replace("copybook weight handling", "copybook field handling")
-    content = content.replace("weight data conversion", "field layout computation")
-    content = content.replace("Tensor Core acceleration", "SIMD acceleration")
-    content = content.replace("mixed precision", "high-precision")
-
-    # Fix command examples
-    content = content.replace("--tokens 128", "--batch-size 128")
-    content = content.replace("--copybook examples/copybook.cpy --tokens", "--input examples/data.bin --copybook examples/schema.cpy --records")
-
-    # Fix remaining neural network references
-    content = content.replace("Neural Network Validation", "COBOL Parsing Validation")
-    content = content.replace("attention computation", "field processing")
-    content = content.replace("KV cache", "field cache")
-
-    # Clean up garbled validation patterns
-    content = re.sub(r'test_dequantize_cpu_and_gpu_paths', 'enterprise_performance_validation', content)
-    content = re.sub(r'COPYBOOK_DATA="[^"]*"', 'COPYBOOK_TEST_DATA="examples/test.cpy"', content)
-
-    # Only write if content changed
-    if content != original_content:
-        with open(filepath, 'w') as f:
-            f.write(content)
-        print(f"  ✓ Cleaned up {filepath.name}")
-        return True
-    else:
-        print(f"  - No cleanup needed for {filepath.name}")
-        return False
-
-def main():
-    """Process all agent files for final cleanup."""
-    if not AGENTS_DIR.exists():
-        print(f"Error: Directory {AGENTS_DIR} does not exist")
-        return
-
-    agent_files = list(AGENTS_DIR.glob("*.md"))
-    if not agent_files:
-        print(f"No .md files found in {AGENTS_DIR}")
-        return
-
-    print(f"Found {len(agent_files)} agent files for final cleanup")
-
-    cleaned_count = 0
-    for agent_file in sorted(agent_files):
-        if final_cleanup_agent(agent_file):
-            cleaned_count += 1
-
-    print(f"\nCompleted! Final cleanup applied to {cleaned_count} of {len(agent_files)} agent files.")
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/final-cleanup-agents.py
+++ b/scripts/final-cleanup-agents.py
@@ -1,37 +1,18 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Compatibility launcher for the Rust-native copybook-scripts command."""
+"""Compatibility wrapper for the native Rust copybook-scripts implementation."""
 
 import subprocess
 import sys
-from pathlib import Path
 
-COMMAND = "final-cleanup-agents"
-
-
-def workspace_root() -> Path:
-    return Path(
-        subprocess.check_output(
-            ["git", "rev-parse", "--show-toplevel"],
-            text=True,
-        ).strip()
-    )
-
-
-def main() -> int:
-    root = workspace_root()
-    cmd = [
+sys.exit(
+    subprocess.call([
         "cargo",
         "run",
         "--quiet",
         "--manifest-path",
-        str(root / "tools" / "copybook-scripts" / "Cargo.toml"),
+        "tools/copybook-scripts/Cargo.toml",
         "--",
-        COMMAND,
-        *sys.argv[1:],
-    ]
-    return subprocess.run(cmd, check=False).returncode
-
-
-if __name__ == "__main__":
-    raise SystemExit(main())
+        "final-cleanup-agents",
+    ])
+)

--- a/scripts/fix-agent-issues.py
+++ b/scripts/fix-agent-issues.py
@@ -1,37 +1,18 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Compatibility launcher for the Rust-native copybook-scripts command."""
+"""Compatibility wrapper for the native Rust copybook-scripts implementation."""
 
 import subprocess
 import sys
-from pathlib import Path
 
-COMMAND = "fix-agent-issues"
-
-
-def workspace_root() -> Path:
-    return Path(
-        subprocess.check_output(
-            ["git", "rev-parse", "--show-toplevel"],
-            text=True,
-        ).strip()
-    )
-
-
-def main() -> int:
-    root = workspace_root()
-    cmd = [
+sys.exit(
+    subprocess.call([
         "cargo",
         "run",
         "--quiet",
         "--manifest-path",
-        str(root / "tools" / "copybook-scripts" / "Cargo.toml"),
+        "tools/copybook-scripts/Cargo.toml",
         "--",
-        COMMAND,
-        *sys.argv[1:],
-    ]
-    return subprocess.run(cmd, check=False).returncode
-
-
-if __name__ == "__main__":
-    raise SystemExit(main())
+        "fix-agent-issues",
+    ])
+)

--- a/scripts/fix-agent-issues.py
+++ b/scripts/fix-agent-issues.py
@@ -1,86 +1,37 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""
-Script to fix issues introduced by the bulk agent adaptation.
-"""
+"""Compatibility launcher for the Rust-native copybook-scripts command."""
 
-import os
-import re
+import subprocess
+import sys
 from pathlib import Path
 
-# Base directory for review agents
-AGENTS_DIR = Path(".claude/agents4/review/")
+COMMAND = "fix-agent-issues"
 
-def fix_agent_file(filepath):
-    """Fix specific issues in agent files."""
-    print(f"Fixing {filepath.name}...")
 
-    with open(filepath, 'r') as f:
-        content = f.read()
+def workspace_root() -> Path:
+    return Path(
+        subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            text=True,
+        ).strip()
+    )
 
-    original_content = content
 
-    # Fix incorrect "copybook:" entries in YAML frontmatter
-    content = re.sub(r'^copybook: sonnet$', 'model: sonnet', content, flags=re.MULTILINE)
+def main() -> int:
+    root = workspace_root()
+    cmd = [
+        "cargo",
+        "run",
+        "--quiet",
+        "--manifest-path",
+        str(root / "tools" / "copybook-scripts" / "Cargo.toml"),
+        "--",
+        COMMAND,
+        *sys.argv[1:],
+    ]
+    return subprocess.run(cmd, check=False).returncode
 
-    # Fix doubled workspace flags
-    content = content.replace('--workspace --workspace', '--workspace')
-    content = content.replace('--workspace --release --workspace', '--workspace --release')
-
-    # Fix garbled command patterns
-    content = content.replace('copybook-core parsing', 'copybook-core')
-    content = content.replace('copybook-codec parsing', 'copybook-codec')
-    content = content.replace('deCOBOL parsing', 'data conversion')
-
-    # Fix specific performance patterns
-    content = content.replace('I2S: 4.1 GiB/s, TL1: 560 MiB/s, TL2: 99.7%', 'DISPLAY: ≥4.1 GiB/s, COMP-3: ≥560 MiB/s')
-    content = content.replace('copybook.gguf', 'copybook.cpy')
-    content = content.replace('copybooks/bitnet/', 'examples/')
-
-    # Fix garbled technical terms
-    content = content.replace('weight deCOBOL parsing', 'field layout computation')
-    content = content.replace('COBOL parsing/deCOBOL parsing', 'COBOL parsing/data conversion')
-    content = content.replace('COBOL parsing kernels (DISPLAY, COMP, COMP-3)', 'COBOL parsing engines (lexer, parser, AST)')
-
-    # Fix evidence patterns
-    content = content.replace('records/sec', 'GiB/s for DISPLAY, MiB/s for COMP-3')
-
-    # Fix specific technical terms
-    content = content.replace('BITNET_DETERMINISTIC=1', 'deterministic parsing')
-    content = content.replace('BITNET_EBCDIC', 'COPYBOOK_DATA')
-
-    # Fix workspace crate references
-    content = re.sub(r'bitnet-\*', 'copybook-*', content)
-
-    # Only write if content changed
-    if content != original_content:
-        with open(filepath, 'w') as f:
-            f.write(content)
-        print(f"  ✓ Fixed {filepath.name}")
-        return True
-    else:
-        print(f"  - No fixes needed for {filepath.name}")
-        return False
-
-def main():
-    """Process all agent files in the review directory."""
-    if not AGENTS_DIR.exists():
-        print(f"Error: Directory {AGENTS_DIR} does not exist")
-        return
-
-    agent_files = list(AGENTS_DIR.glob("*.md"))
-    if not agent_files:
-        print(f"No .md files found in {AGENTS_DIR}")
-        return
-
-    print(f"Found {len(agent_files)} agent files to fix")
-
-    fixed_count = 0
-    for agent_file in sorted(agent_files):
-        if fix_agent_file(agent_file):
-            fixed_count += 1
-
-    print(f"\nCompleted! Fixed {fixed_count} of {len(agent_files)} agent files.")
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tools/README.md
+++ b/tools/README.md
@@ -26,7 +26,7 @@ cargo run --package copybook-gen -- generate-golden-fixtures --enterprise --outp
 
 ### copybook-scripts
 
-Small Rust-native replacements for repository-maintenance shell scripts.
+Small Rust-native replacements for repository-maintenance shell and Python scripts.
 
 ```bash
 cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- check-no-unwrap-expect
@@ -34,6 +34,9 @@ cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- guard-hot
 cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- perf-annotate-host
 cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- soak-dispatch
 cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- clean-merge-conflicts path/to/file.rs
+cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- adapt-review-agents
+cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- fix-agent-issues
+cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- final-cleanup-agents
 ```
 
 ### xtask

--- a/tools/README.md
+++ b/tools/README.md
@@ -26,7 +26,7 @@ cargo run --package copybook-gen -- generate-golden-fixtures --enterprise --outp
 
 ### copybook-scripts
 
-Small Rust-native replacements for repository-maintenance shell and Python scripts.
+Small Rust-native replacements for repository-maintenance shell scripts.
 
 ```bash
 cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- check-no-unwrap-expect
@@ -34,9 +34,6 @@ cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- guard-hot
 cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- perf-annotate-host
 cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- soak-dispatch
 cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- clean-merge-conflicts path/to/file.rs
-cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- adapt-review-agents
-cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- fix-agent-issues
-cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- final-cleanup-agents
 ```
 
 ### xtask

--- a/tools/copybook-scripts/Cargo.toml
+++ b/tools/copybook-scripts/Cargo.toml
@@ -20,6 +20,7 @@ anyhow.workspace = true
 chrono = { workspace = true }
 clap.workspace = true
 num_cpus = { workspace = true }
+regex.workspace = true
 serde_json.workspace = true
 
 [lints]

--- a/tools/copybook-scripts/src/main.rs
+++ b/tools/copybook-scripts/src/main.rs
@@ -9,7 +9,7 @@ use std::process::Command;
 use anyhow::{Context, Result, bail};
 use chrono::SecondsFormat;
 use clap::{Parser, Subcommand};
-use regex::{Captures, Regex};
+use regex::Regex;
 use serde_json::{Map, Value};
 
 #[derive(Debug, Parser)]
@@ -30,18 +30,9 @@ enum CommandKind {
         #[arg(value_name = "PATH")]
         file: PathBuf,
     },
-    AdaptReviewAgents {
-        #[arg(long, default_value = ".claude/agents4/review", value_name = "DIR")]
-        agents_dir: PathBuf,
-    },
-    FixAgentIssues {
-        #[arg(long, default_value = ".claude/agents4/review", value_name = "DIR")]
-        agents_dir: PathBuf,
-    },
-    FinalCleanupAgents {
-        #[arg(long, default_value = ".claude/agents4/review", value_name = "DIR")]
-        agents_dir: PathBuf,
-    },
+    AdaptReviewAgents,
+    FixAgentIssues,
+    FinalCleanupAgents,
 }
 
 fn main() -> Result<()> {
@@ -52,9 +43,9 @@ fn main() -> Result<()> {
         CommandKind::PerfAnnotateHost => perf_annotate_host(),
         CommandKind::SoakDispatch => soak_dispatch(),
         CommandKind::CleanMergeConflicts { file } => clean_merge_conflicts(file),
-        CommandKind::AdaptReviewAgents { agents_dir } => adapt_review_agents(agents_dir),
-        CommandKind::FixAgentIssues { agents_dir } => fix_agent_issues(agents_dir),
-        CommandKind::FinalCleanupAgents { agents_dir } => final_cleanup_agents(agents_dir),
+        CommandKind::AdaptReviewAgents => adapt_review_agents(),
+        CommandKind::FixAgentIssues => fix_agent_issues(),
+        CommandKind::FinalCleanupAgents => final_cleanup_agents(),
     }
 }
 
@@ -353,346 +344,383 @@ fn clean_merge_conflicts(file: PathBuf) -> Result<()> {
     Ok(())
 }
 
-#[derive(Debug, Clone, Copy)]
-enum AgentTransform {
-    Adapt,
-    Fix,
-    FinalCleanup,
+const AGENTS_REVIEW_DIR: &str = ".claude/agents4/review";
+
+#[derive(Clone, Copy)]
+enum TextRule {
+    Literal(&'static str, &'static str),
+    Regex(&'static str, &'static str),
+    BitnetCrate,
 }
 
-#[derive(Debug, Clone, Copy)]
-enum ReplacementKind {
-    Literal,
-    Regex,
+fn bitnet_crate_replacement(hit: &str) -> &str {
+    match hit {
+        "bitnet-kernels" => "copybook-codec",
+        "bitnet-inference" => "copybook-cli",
+        "bitnet-wasm" => "copybook-gen",
+        "bitnet-tokenizers" => "copybook-bench",
+        _ => "copybook-core",
+    }
 }
 
-#[derive(Debug, Clone, Copy)]
-struct ReplacementRule {
-    kind: ReplacementKind,
-    from: &'static str,
-    to: &'static str,
-}
+fn replace_bitnet_crate_names(content: &str) -> String {
+    let mut output = String::with_capacity(content.len());
+    let mut cursor = 0usize;
 
-fn adapt_review_agents(agents_dir: PathBuf) -> Result<()> {
-    process_agent_files(agents_dir, AgentTransform::Adapt)
-}
+    while let Some(relative_start) = content[cursor..].find("bitnet-") {
+        let start = cursor + relative_start;
+        output.push_str(&content[cursor..start]);
 
-fn fix_agent_issues(agents_dir: PathBuf) -> Result<()> {
-    process_agent_files(agents_dir, AgentTransform::Fix)
-}
+        let mut end = start + "bitnet-".len();
+        for (offset, ch) in content[end..].char_indices() {
+            if !ch.is_ascii_alphabetic() {
+                break;
+            }
+            end = start + "bitnet-".len() + offset + ch.len_utf8();
+        }
 
-fn final_cleanup_agents(agents_dir: PathBuf) -> Result<()> {
-    process_agent_files(agents_dir, AgentTransform::FinalCleanup)
-}
-
-fn process_agent_files(agents_dir: PathBuf, transform: AgentTransform) -> Result<()> {
-    let root = workspace_root()?;
-    let dir = if agents_dir.is_absolute() {
-        agents_dir
-    } else {
-        root.join(agents_dir)
-    };
-
-    if !dir.exists() {
-        bail!("Error: Directory {} does not exist", dir.display());
+        output.push_str(bitnet_crate_replacement(&content[start..end]));
+        cursor = end;
     }
 
-    let mut agent_files = Vec::new();
-    for entry in fs::read_dir(&dir).with_context(|| format!("failed to read {}", dir.display()))? {
-        let entry = entry?;
-        let path = entry.path();
-        if entry.file_type()?.is_file()
-            && path.extension().and_then(|ext| ext.to_str()) == Some("md")
-        {
-            agent_files.push(path);
+    output.push_str(&content[cursor..]);
+    output
+}
+
+fn apply_text_rules(mut content: String, rules: &[TextRule]) -> Result<String> {
+    for rule in rules {
+        match rule {
+            TextRule::Literal(from, to) => {
+                content = content.replace(from, to);
+            }
+            TextRule::Regex(pattern, replacement) => {
+                let re = Regex::new(pattern)
+                    .with_context(|| format!("invalid cleanup regex: {pattern}"))?;
+                content = re.replace_all(&content, *replacement).into_owned();
+            }
+            TextRule::BitnetCrate => {
+                content = replace_bitnet_crate_names(&content);
+            }
         }
     }
-    agent_files.sort();
 
-    if agent_files.is_empty() {
-        bail!("No .md files found in {}", dir.display());
+    Ok(content)
+}
+
+fn agent_markdown_files(root: &Path) -> Result<Vec<PathBuf>> {
+    if !root.exists() {
+        bail!("Error: Directory {} does not exist", root.display());
     }
 
-    println!("Found {} agent files to process", agent_files.len());
+    let mut paths = Vec::new();
+    for item in fs::read_dir(root).with_context(|| format!("failed to read {}", root.display()))? {
+        let entry = item?;
+        let path = entry.path();
+        if entry.file_type()?.is_file() && path.extension().and_then(OsStr::to_str) == Some("md") {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+
+    if paths.is_empty() {
+        bail!("No .md files found in {}", root.display());
+    }
+
+    Ok(paths)
+}
+
+fn process_agent_files(action: &str, intro: &str, rules: &[TextRule]) -> Result<()> {
+    let root = workspace_root()?.join(AGENTS_REVIEW_DIR);
+    let agent_files = agent_markdown_files(&root)?;
+    println!("Found {} agent files {}", agent_files.len(), intro);
 
     let mut changed_count = 0usize;
-    for file in &agent_files {
-        if apply_agent_transform(file, transform)? {
-            changed_count += 1;
+    for path in agent_files {
+        let name = path
+            .file_name()
+            .and_then(OsStr::to_str)
+            .unwrap_or("<unknown>");
+        println!("{action} {name}...");
+
+        let original = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        let updated = apply_text_rules(original.clone(), rules)?;
+
+        if updated == original {
+            println!("  - No changes needed for {name}");
+            continue;
         }
+
+        fs::write(&path, updated).with_context(|| format!("failed to write {}", path.display()))?;
+        changed_count += 1;
+        println!("  ✓ Updated {name}");
     }
 
-    let action = match transform {
-        AgentTransform::Adapt => "Updated",
-        AgentTransform::Fix => "Fixed",
-        AgentTransform::FinalCleanup => "Cleaned up",
-    };
-    println!(
-        "\nCompleted! {action} {changed_count} of {} agent files.",
-        agent_files.len()
-    );
+    println!("\nCompleted! Updated {changed_count} agent files.");
     Ok(())
 }
 
-fn apply_agent_transform(path: &Path, transform: AgentTransform) -> Result<bool> {
-    let name = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("<unknown>");
-    let verb = match transform {
-        AgentTransform::Adapt => "Processing",
-        AgentTransform::Fix => "Fixing",
-        AgentTransform::FinalCleanup => "Final cleanup of",
-    };
-    println!("{verb} {name}...");
-
-    let original =
-        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
-    let mut content = original.clone();
-
-    match transform {
-        AgentTransform::Adapt => apply_adapt_review_agent_rules(&mut content)?,
-        AgentTransform::Fix => apply_rules(&mut content, FIX_AGENT_RULES)?,
-        AgentTransform::FinalCleanup => apply_rules(&mut content, FINAL_CLEANUP_AGENT_RULES)?,
-    }
-
-    if content == original {
-        println!("  - No changes needed for {name}");
-        return Ok(false);
-    }
-
-    fs::write(path, content).with_context(|| format!("failed to write {}", path.display()))?;
-    let action = match transform {
-        AgentTransform::Adapt => "Updated",
-        AgentTransform::Fix => "Fixed",
-        AgentTransform::FinalCleanup => "Cleaned up",
-    };
-    println!("  ✓ {action} {name}");
-    Ok(true)
-}
-
-fn apply_adapt_review_agent_rules(content: &mut String) -> Result<()> {
-    apply_rules(content, ADAPT_AGENT_REGEX_RULES)?;
-    apply_rules(content, ADAPT_AGENT_LITERAL_RULES)?;
-
-    replace_regex_with(content, r"bitnet-[a-zA-Z]+", |captures: &Captures<'_>| {
-        let matched = captures.get(0).map(|m| m.as_str()).unwrap_or_default();
-        match matched {
-            "bitnet-quantization" => "copybook-core".to_string(),
-            "bitnet-kernels" => "copybook-codec".to_string(),
-            "bitnet-inference" => "copybook-cli".to_string(),
-            "bitnet-wasm" => "copybook-gen".to_string(),
-            "bitnet-tokenizers" => "copybook-bench".to_string(),
-            _ => "copybook-core".to_string(),
-        }
-    })?;
-
-    Ok(())
-}
-
-fn apply_rules(content: &mut String, rules: &[ReplacementRule]) -> Result<()> {
-    for rule in rules {
-        match rule.kind {
-            ReplacementKind::Literal => {
-                *content = content.replace(rule.from, rule.to);
-            }
-            ReplacementKind::Regex => {
-                let regex = Regex::new(rule.from)
-                    .with_context(|| format!("invalid regex replacement pattern: {}", rule.from))?;
-                *content = regex.replace_all(content, rule.to).into_owned();
-            }
-        }
-    }
-    Ok(())
-}
-
-fn replace_regex_with<F>(content: &mut String, pattern: &str, replacer: F) -> Result<()>
-where
-    F: Fn(&Captures<'_>) -> String,
-{
-    let regex = Regex::new(pattern)
-        .with_context(|| format!("invalid regex replacement pattern: {pattern}"))?;
-    *content = regex.replace_all(content, replacer).into_owned();
-    Ok(())
-}
-
-const fn literal(from: &'static str, to: &'static str) -> ReplacementRule {
-    ReplacementRule {
-        kind: ReplacementKind::Literal,
-        from,
-        to,
-    }
-}
-
-const fn regex_rule(from: &'static str, to: &'static str) -> ReplacementRule {
-    ReplacementRule {
-        kind: ReplacementKind::Regex,
-        from,
-        to,
-    }
-}
-
-const ADAPT_AGENT_LITERAL_RULES: &[ReplacementRule] = &[
-    literal(
+const ADAPT_REVIEW_AGENT_RULES: &[TextRule] = &[
+    TextRule::Literal(
         "BitNet.rs neural network inference",
         "copybook-rs enterprise mainframe data processing",
     ),
-    literal("BitNet neural network", "copybook-rs enterprise mainframe"),
-    literal("BitNet.rs", "copybook-rs"),
-    literal("neural network", "COBOL parsing"),
-    literal("quantization", "COBOL parsing"),
-    literal("inference", "data conversion"),
-    literal("GPU", "enterprise performance"),
-    literal("I2S, TL1, TL2", "DISPLAY, COMP, COMP-3"),
-    literal("quantization accuracy", "COBOL parsing accuracy"),
-    literal("cross-validation", "mainframe compatibility"),
-    literal("GGUF", "EBCDIC"),
-    literal("tensor", "field"),
-    literal("model", "copybook"),
-    literal("CUDA", "SIMD"),
-    literal(
-        ">99% accuracy",
-        "enterprise performance targets (DISPLAY ≥ 4.1 GiB/s, COMP-3 ≥ 560 MiB/s)",
-    ),
-    literal("99.8%", "4.1 GiB/s"),
-    literal("99.6%", "560 MiB/s"),
-    literal("bitnet-quantization", "copybook-core"),
-    literal("bitnet-kernels", "copybook-codec"),
-    literal("bitnet-inference", "copybook-cli"),
-    literal("bitnet-wasm", "copybook-gen"),
-    literal("bitnet-tokenizers", "copybook-bench"),
-    literal("--no-default-features --features cpu", "--workspace"),
-    literal(
-        "--no-default-features --features gpu",
-        "--workspace --release",
-    ),
-    literal("cargo run -p xtask -- crossval", "cargo xtask ci"),
-    literal(
-        "cargo run -p xtask -- benchmark",
-        "cargo bench --package copybook-bench",
-    ),
-    literal("./scripts/verify-tests.sh", "cargo xtask ci --quick"),
-    literal("CUDA unavailable", "xtask unavailable"),
-    literal("GPU memory", "parsing memory"),
-    literal("C++ reference", "mainframe compatibility"),
-    literal("CPU: ok, GPU: ok", "workspace release ok"),
-    literal("tokens/sec", "records/sec"),
-    literal("I2S: 99.X%", "DISPLAY: X.Y GiB/s"),
-    literal("quantization kernels", "COBOL parsing kernels"),
-    literal("inference pipeline", "data processing pipeline"),
-    literal(
-        "1-bit neural networks",
-        "enterprise mainframe data processing",
-    ),
-];
-
-const ADAPT_AGENT_REGEX_RULES: &[ReplacementRule] = &[
-    regex_rule(
+    TextRule::Regex(
         r"cargo test --workspace --no-default-features --features \w+",
         "cargo test --workspace",
     ),
-    regex_rule(
+    TextRule::Regex(
         r"cargo build --release --no-default-features --features \w+",
         "cargo build --workspace --release",
     ),
-    regex_rule(
+    TextRule::Regex(
         r"tests: cargo test: (\d+)/(\d+) pass; CPU: (\d+)/(\d+), GPU: (\d+)/(\d+); quarantined: (\d+) \(linked\)",
         "tests: nextest: $1/$2 pass; enterprise validation: $3/$4; quarantined: $7 (linked)",
     ),
+    TextRule::Literal("BitNet neural network", "copybook-rs enterprise mainframe"),
+    TextRule::Literal("BitNet.rs", "copybook-rs"),
+    TextRule::Literal("neural network", "COBOL parsing"),
+    TextRule::Literal("quantization", "COBOL parsing"),
+    TextRule::Literal("inference", "data conversion"),
+    TextRule::Literal("GPU", "enterprise performance"),
+    TextRule::Literal("I2S, TL1, TL2", "DISPLAY, COMP, COMP-3"),
+    TextRule::Literal("quantization accuracy", "COBOL parsing accuracy"),
+    TextRule::Literal("cross-validation", "mainframe compatibility"),
+    TextRule::Literal("GGUF", "EBCDIC"),
+    TextRule::Literal("tensor", "field"),
+    TextRule::Literal("model", "copybook"),
+    TextRule::Literal("CUDA", "SIMD"),
+    TextRule::Literal(
+        ">99% accuracy",
+        "enterprise performance targets (DISPLAY ≥ 4.1 GiB/s, COMP-3 ≥ 560 MiB/s)",
+    ),
+    TextRule::Literal("99.8%", "4.1 GiB/s"),
+    TextRule::Literal("99.6%", "560 MiB/s"),
+    TextRule::Literal("bitnet-quantization", "copybook-core"),
+    TextRule::Literal("bitnet-kernels", "copybook-codec"),
+    TextRule::Literal("bitnet-inference", "copybook-cli"),
+    TextRule::Literal("bitnet-wasm", "copybook-gen"),
+    TextRule::Literal("bitnet-tokenizers", "copybook-bench"),
+    TextRule::Literal("--no-default-features --features cpu", "--workspace"),
+    TextRule::Literal(
+        "--no-default-features --features gpu",
+        "--workspace --release",
+    ),
+    TextRule::Literal("cargo run -p xtask -- crossval", "cargo xtask ci"),
+    TextRule::Literal(
+        "cargo run -p xtask -- benchmark",
+        "cargo bench --package copybook-bench",
+    ),
+    TextRule::Literal("./scripts/verify-tests.sh", "cargo xtask ci --quick"),
+    TextRule::Literal("CUDA unavailable", "xtask unavailable"),
+    TextRule::Literal("GPU memory", "parsing memory"),
+    TextRule::Literal("C++ reference", "mainframe compatibility"),
+    TextRule::Literal("CPU: ok, GPU: ok", "workspace release ok"),
+    TextRule::Literal("tokens/sec", "records/sec"),
+    TextRule::Literal("I2S: 99.X%", "DISPLAY: X.Y GiB/s"),
+    TextRule::Literal("quantization kernels", "COBOL parsing kernels"),
+    TextRule::Literal("inference pipeline", "data processing pipeline"),
+    TextRule::Literal(
+        "1-bit neural networks",
+        "enterprise mainframe data processing",
+    ),
+    TextRule::BitnetCrate,
 ];
 
-const FIX_AGENT_RULES: &[ReplacementRule] = &[
-    regex_rule(r"(?m)^copybook: sonnet$", "model: sonnet"),
-    literal("--workspace --workspace", "--workspace"),
-    literal("--workspace --release --workspace", "--workspace --release"),
-    literal("copybook-core parsing", "copybook-core"),
-    literal("copybook-codec parsing", "copybook-codec"),
-    literal("deCOBOL parsing", "data conversion"),
-    literal(
+const FIX_AGENT_ISSUE_RULES: &[TextRule] = &[
+    TextRule::Regex(r"(?m)^copybook: sonnet$", "model: sonnet"),
+    TextRule::Literal("--workspace --workspace", "--workspace"),
+    TextRule::Literal("--workspace --release --workspace", "--workspace --release"),
+    TextRule::Literal("copybook-core parsing", "copybook-core"),
+    TextRule::Literal("copybook-codec parsing", "copybook-codec"),
+    TextRule::Literal("deCOBOL parsing", "data conversion"),
+    TextRule::Literal(
         "I2S: 4.1 GiB/s, TL1: 560 MiB/s, TL2: 99.7%",
         "DISPLAY: ≥4.1 GiB/s, COMP-3: ≥560 MiB/s",
     ),
-    literal("copybook.gguf", "copybook.cpy"),
-    literal("copybooks/bitnet/", "examples/"),
-    literal("weight deCOBOL parsing", "field layout computation"),
-    literal(
+    TextRule::Literal("copybook.gguf", "copybook.cpy"),
+    TextRule::Literal("copybooks/bitnet/", "examples/"),
+    TextRule::Literal("weight deCOBOL parsing", "field layout computation"),
+    TextRule::Literal(
         "COBOL parsing/deCOBOL parsing",
         "COBOL parsing/data conversion",
     ),
-    literal(
+    TextRule::Literal(
         "COBOL parsing kernels (DISPLAY, COMP, COMP-3)",
         "COBOL parsing engines (lexer, parser, AST)",
     ),
-    literal("records/sec", "GiB/s for DISPLAY, MiB/s for COMP-3"),
-    literal("BITNET_DETERMINISTIC=1", "deterministic parsing"),
-    literal("BITNET_EBCDIC", "COPYBOOK_DATA"),
-    regex_rule(r"bitnet-\*", "copybook-*"),
+    TextRule::Literal("records/sec", "GiB/s for DISPLAY, MiB/s for COMP-3"),
+    TextRule::Literal("BITNET_DETERMINISTIC=1", "deterministic parsing"),
+    TextRule::Literal("BITNET_EBCDIC", "COPYBOOK_DATA"),
+    TextRule::Regex(r"bitnet-\*", "copybook-*"),
 ];
 
-const FINAL_CLEANUP_AGENT_RULES: &[ReplacementRule] = &[
-    literal(
+const FINAL_CLEANUP_AGENT_RULES: &[TextRule] = &[
+    TextRule::Literal(
         "1-bit quantized COBOL parsings",
         "enterprise mainframe data processing",
     ),
-    literal(
+    TextRule::Literal(
         "Neural Network Security Testing (NNST)",
         "COBOL Parsing Security Testing",
     ),
-    literal("HuggingFace tokens", "mainframe authentication tokens"),
-    literal("copybook poisoning attacks", "malicious copybook attacks"),
-    literal(
+    TextRule::Literal("HuggingFace tokens", "mainframe authentication tokens"),
+    TextRule::Literal("copybook poisoning attacks", "malicious copybook attacks"),
+    TextRule::Literal(
         "copybook-rs workspace crates",
         "copybook-rs 5-crate workspace (core, codec, cli, gen, bench)",
     ),
-    literal(
+    TextRule::Literal(
         "cargo clippy --workspace --all-targets --workspace",
         "cargo clippy --workspace --all-targets",
     ),
-    literal(
+    TextRule::Literal(
         "--workspace -- -D warnings",
         "-- -D warnings -W clippy::pedantic",
     ),
-    literal("COBOL parsing COBOL parsing", "COBOL parsing"),
-    literal("enterprise performance/CPU", "high-performance"),
-    literal("enterprise performance memory", "memory"),
-    literal("SIMD enterprise performance", "SIMD CPU"),
-    literal("GiB/s for DISPLAY, MiB/s for COMP-3ond", "records/second"),
-    literal(
+    TextRule::Literal("COBOL parsing COBOL parsing", "COBOL parsing"),
+    TextRule::Literal("enterprise performance/CPU", "high-performance"),
+    TextRule::Literal("enterprise performance memory", "memory"),
+    TextRule::Literal("SIMD enterprise performance", "SIMD CPU"),
+    TextRule::Literal("GiB/s for DISPLAY, MiB/s for COMP-3ond", "records/second"),
+    TextRule::Literal(
         "GiB/s for DISPLAY, MiB/s for COMP-3",
         "GiB/s (DISPLAY), MiB/s (COMP-3)",
     ),
-    literal(
+    TextRule::Literal(
         "cargo bench --workspace --workspace",
         "cargo bench --package copybook-bench",
     ),
-    literal(
+    TextRule::Literal(
+        "cargo bench --workspace",
+        "cargo bench --package copybook-bench",
+    ),
+    TextRule::Literal(
         "cargo test --workspace --workspace",
         "cargo test --workspace",
     ),
-    literal(
+    TextRule::Literal(
         "I2S ≥4.1 GiB/s, TL1 ≥560 MiB/s, TL2 ≥99.7%",
         "DISPLAY ≥4.1 GiB/s, COMP-3 ≥560 MiB/s",
     ),
-    literal("I2S: 4.1 GiB/s", "DISPLAY: 4.1+ GiB/s"),
-    literal("TL1: 560 MiB/s", "COMP-3: 560+ MiB/s"),
-    literal("copybook weight handling", "copybook field handling"),
-    literal("weight data conversion", "field layout computation"),
-    literal("Tensor Core acceleration", "SIMD acceleration"),
-    literal("mixed precision", "high-precision"),
-    literal("--tokens 128", "--batch-size 128"),
-    literal(
+    TextRule::Literal("I2S: 4.1 GiB/s", "DISPLAY: 4.1+ GiB/s"),
+    TextRule::Literal("TL1: 560 MiB/s", "COMP-3: 560+ MiB/s"),
+    TextRule::Literal("copybook weight handling", "copybook field handling"),
+    TextRule::Literal("weight data conversion", "field layout computation"),
+    TextRule::Literal("Tensor Core acceleration", "SIMD acceleration"),
+    TextRule::Literal("mixed precision", "high-precision"),
+    TextRule::Literal("--tokens 128", "--batch-size 128"),
+    TextRule::Literal(
         "--copybook examples/copybook.cpy --tokens",
         "--input examples/data.bin --copybook examples/schema.cpy --records",
     ),
-    literal("Neural Network Validation", "COBOL Parsing Validation"),
-    literal("attention computation", "field processing"),
-    literal("KV cache", "field cache"),
-    regex_rule(
+    TextRule::Literal("Neural Network Validation", "COBOL Parsing Validation"),
+    TextRule::Literal("attention computation", "field processing"),
+    TextRule::Literal("KV cache", "field cache"),
+    TextRule::Regex(
         r"test_dequantize_cpu_and_gpu_paths",
         "enterprise_performance_validation",
     ),
-    regex_rule(
+    TextRule::Regex(
         r#"COPYBOOK_DATA="[^"]*""#,
         "COPYBOOK_TEST_DATA=\"examples/test.cpy\"",
     ),
 ];
+
+fn adapt_review_agents() -> Result<()> {
+    process_agent_files("Processing", "to process", ADAPT_REVIEW_AGENT_RULES)
+}
+
+fn fix_agent_issues() -> Result<()> {
+    process_agent_files("Fixing", "to fix", FIX_AGENT_ISSUE_RULES)
+}
+
+fn final_cleanup_agents() -> Result<()> {
+    process_agent_files(
+        "Final cleanup of",
+        "for final cleanup",
+        FINAL_CLEANUP_AGENT_RULES,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ADAPT_REVIEW_AGENT_RULES, FINAL_CLEANUP_AGENT_RULES, FIX_AGENT_ISSUE_RULES,
+        apply_text_rules, replace_bitnet_crate_names,
+    };
+
+    fn apply_rules(input: &str, rules: &[super::TextRule]) -> String {
+        match apply_text_rules(input.to_string(), rules) {
+            Ok(output) => output,
+            Err(error) => panic!("{error}"),
+        }
+    }
+
+    #[test]
+    fn bitnet_crate_mapper_handles_known_and_default_crates() {
+        let input =
+            "bitnet-kernels bitnet-inference bitnet-quantization bitnet-tokenizers bitnet-extra";
+
+        assert_eq!(
+            replace_bitnet_crate_names(input),
+            "copybook-codec copybook-cli copybook-core copybook-bench copybook-core"
+        );
+    }
+
+    #[test]
+    fn adapt_review_rules_rewrite_commands_and_evidence() {
+        let input = concat!(
+            "BitNet.rs neural network inference\n",
+            "cargo test --workspace --no-default-features --features gpu\n",
+            "tests: cargo test: 9/10 pass; CPU: 4/5, GPU: 6/7; quarantined: 1 (linked)\n",
+        );
+
+        let output = apply_rules(input, ADAPT_REVIEW_AGENT_RULES);
+
+        assert!(output.contains("copybook-rs enterprise mainframe data processing"));
+        assert!(output.contains("cargo test --workspace"));
+        assert!(output.contains(
+            "tests: nextest: 9/10 pass; enterprise validation: 4/5; quarantined: 1 (linked)"
+        ));
+    }
+
+    #[test]
+    fn fix_agent_issue_rules_repair_frontmatter_and_workspace_terms() {
+        let input = concat!(
+            "---\n",
+            "copybook: sonnet\n",
+            "---\n",
+            "cargo test --workspace --workspace\n",
+            "bitnet-* copybook.gguf BITNET_EBCDIC\n",
+        );
+
+        let output = apply_rules(input, FIX_AGENT_ISSUE_RULES);
+
+        assert!(output.contains("model: sonnet"));
+        assert!(output.contains("cargo test --workspace"));
+        assert!(output.contains("copybook-* copybook.cpy COPYBOOK_DATA"));
+    }
+
+    #[test]
+    fn final_cleanup_rules_rewrite_remaining_agent_terms() {
+        let input = concat!(
+            "Neural Network Validation uses COPYBOOK_DATA=\"fixtures/demo.cpy\"\n",
+            "attention computation and KV cache\n",
+            "cargo bench --workspace --workspace\n",
+            "cargo bench --workspace\n",
+        );
+
+        let output = apply_rules(input, FINAL_CLEANUP_AGENT_RULES);
+
+        assert!(output.contains("COBOL Parsing Validation"));
+        assert!(output.contains("COPYBOOK_TEST_DATA=\"examples/test.cpy\""));
+        assert!(output.contains("field processing and field cache"));
+        assert_eq!(
+            output
+                .matches("cargo bench --package copybook-bench")
+                .count(),
+            2
+        );
+    }
+}

--- a/tools/copybook-scripts/src/main.rs
+++ b/tools/copybook-scripts/src/main.rs
@@ -9,6 +9,7 @@ use std::process::Command;
 use anyhow::{Context, Result, bail};
 use chrono::SecondsFormat;
 use clap::{Parser, Subcommand};
+use regex::{Captures, Regex};
 use serde_json::{Map, Value};
 
 #[derive(Debug, Parser)]
@@ -29,6 +30,18 @@ enum CommandKind {
         #[arg(value_name = "PATH")]
         file: PathBuf,
     },
+    AdaptReviewAgents {
+        #[arg(long, default_value = ".claude/agents4/review", value_name = "DIR")]
+        agents_dir: PathBuf,
+    },
+    FixAgentIssues {
+        #[arg(long, default_value = ".claude/agents4/review", value_name = "DIR")]
+        agents_dir: PathBuf,
+    },
+    FinalCleanupAgents {
+        #[arg(long, default_value = ".claude/agents4/review", value_name = "DIR")]
+        agents_dir: PathBuf,
+    },
 }
 
 fn main() -> Result<()> {
@@ -39,6 +52,9 @@ fn main() -> Result<()> {
         CommandKind::PerfAnnotateHost => perf_annotate_host(),
         CommandKind::SoakDispatch => soak_dispatch(),
         CommandKind::CleanMergeConflicts { file } => clean_merge_conflicts(file),
+        CommandKind::AdaptReviewAgents { agents_dir } => adapt_review_agents(agents_dir),
+        CommandKind::FixAgentIssues { agents_dir } => fix_agent_issues(agents_dir),
+        CommandKind::FinalCleanupAgents { agents_dir } => final_cleanup_agents(agents_dir),
     }
 }
 
@@ -336,3 +352,347 @@ fn clean_merge_conflicts(file: PathBuf) -> Result<()> {
     fs::write(&target, out).with_context(|| format!("failed to write {}", target.display()))?;
     Ok(())
 }
+
+#[derive(Debug, Clone, Copy)]
+enum AgentTransform {
+    Adapt,
+    Fix,
+    FinalCleanup,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ReplacementKind {
+    Literal,
+    Regex,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ReplacementRule {
+    kind: ReplacementKind,
+    from: &'static str,
+    to: &'static str,
+}
+
+fn adapt_review_agents(agents_dir: PathBuf) -> Result<()> {
+    process_agent_files(agents_dir, AgentTransform::Adapt)
+}
+
+fn fix_agent_issues(agents_dir: PathBuf) -> Result<()> {
+    process_agent_files(agents_dir, AgentTransform::Fix)
+}
+
+fn final_cleanup_agents(agents_dir: PathBuf) -> Result<()> {
+    process_agent_files(agents_dir, AgentTransform::FinalCleanup)
+}
+
+fn process_agent_files(agents_dir: PathBuf, transform: AgentTransform) -> Result<()> {
+    let root = workspace_root()?;
+    let dir = if agents_dir.is_absolute() {
+        agents_dir
+    } else {
+        root.join(agents_dir)
+    };
+
+    if !dir.exists() {
+        bail!("Error: Directory {} does not exist", dir.display());
+    }
+
+    let mut agent_files = Vec::new();
+    for entry in fs::read_dir(&dir).with_context(|| format!("failed to read {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        if entry.file_type()?.is_file()
+            && path.extension().and_then(|ext| ext.to_str()) == Some("md")
+        {
+            agent_files.push(path);
+        }
+    }
+    agent_files.sort();
+
+    if agent_files.is_empty() {
+        bail!("No .md files found in {}", dir.display());
+    }
+
+    println!("Found {} agent files to process", agent_files.len());
+
+    let mut changed_count = 0usize;
+    for file in &agent_files {
+        if apply_agent_transform(file, transform)? {
+            changed_count += 1;
+        }
+    }
+
+    let action = match transform {
+        AgentTransform::Adapt => "Updated",
+        AgentTransform::Fix => "Fixed",
+        AgentTransform::FinalCleanup => "Cleaned up",
+    };
+    println!(
+        "\nCompleted! {action} {changed_count} of {} agent files.",
+        agent_files.len()
+    );
+    Ok(())
+}
+
+fn apply_agent_transform(path: &Path, transform: AgentTransform) -> Result<bool> {
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("<unknown>");
+    let verb = match transform {
+        AgentTransform::Adapt => "Processing",
+        AgentTransform::Fix => "Fixing",
+        AgentTransform::FinalCleanup => "Final cleanup of",
+    };
+    println!("{verb} {name}...");
+
+    let original =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    let mut content = original.clone();
+
+    match transform {
+        AgentTransform::Adapt => apply_adapt_review_agent_rules(&mut content)?,
+        AgentTransform::Fix => apply_rules(&mut content, FIX_AGENT_RULES)?,
+        AgentTransform::FinalCleanup => apply_rules(&mut content, FINAL_CLEANUP_AGENT_RULES)?,
+    }
+
+    if content == original {
+        println!("  - No changes needed for {name}");
+        return Ok(false);
+    }
+
+    fs::write(path, content).with_context(|| format!("failed to write {}", path.display()))?;
+    let action = match transform {
+        AgentTransform::Adapt => "Updated",
+        AgentTransform::Fix => "Fixed",
+        AgentTransform::FinalCleanup => "Cleaned up",
+    };
+    println!("  ✓ {action} {name}");
+    Ok(true)
+}
+
+fn apply_adapt_review_agent_rules(content: &mut String) -> Result<()> {
+    apply_rules(content, ADAPT_AGENT_REGEX_RULES)?;
+    apply_rules(content, ADAPT_AGENT_LITERAL_RULES)?;
+
+    replace_regex_with(content, r"bitnet-[a-zA-Z]+", |captures: &Captures<'_>| {
+        let matched = captures.get(0).map(|m| m.as_str()).unwrap_or_default();
+        match matched {
+            "bitnet-quantization" => "copybook-core".to_string(),
+            "bitnet-kernels" => "copybook-codec".to_string(),
+            "bitnet-inference" => "copybook-cli".to_string(),
+            "bitnet-wasm" => "copybook-gen".to_string(),
+            "bitnet-tokenizers" => "copybook-bench".to_string(),
+            _ => "copybook-core".to_string(),
+        }
+    })?;
+
+    Ok(())
+}
+
+fn apply_rules(content: &mut String, rules: &[ReplacementRule]) -> Result<()> {
+    for rule in rules {
+        match rule.kind {
+            ReplacementKind::Literal => {
+                *content = content.replace(rule.from, rule.to);
+            }
+            ReplacementKind::Regex => {
+                let regex = Regex::new(rule.from)
+                    .with_context(|| format!("invalid regex replacement pattern: {}", rule.from))?;
+                *content = regex.replace_all(content, rule.to).into_owned();
+            }
+        }
+    }
+    Ok(())
+}
+
+fn replace_regex_with<F>(content: &mut String, pattern: &str, replacer: F) -> Result<()>
+where
+    F: Fn(&Captures<'_>) -> String,
+{
+    let regex = Regex::new(pattern)
+        .with_context(|| format!("invalid regex replacement pattern: {pattern}"))?;
+    *content = regex.replace_all(content, replacer).into_owned();
+    Ok(())
+}
+
+const fn literal(from: &'static str, to: &'static str) -> ReplacementRule {
+    ReplacementRule {
+        kind: ReplacementKind::Literal,
+        from,
+        to,
+    }
+}
+
+const fn regex_rule(from: &'static str, to: &'static str) -> ReplacementRule {
+    ReplacementRule {
+        kind: ReplacementKind::Regex,
+        from,
+        to,
+    }
+}
+
+const ADAPT_AGENT_LITERAL_RULES: &[ReplacementRule] = &[
+    literal(
+        "BitNet.rs neural network inference",
+        "copybook-rs enterprise mainframe data processing",
+    ),
+    literal("BitNet neural network", "copybook-rs enterprise mainframe"),
+    literal("BitNet.rs", "copybook-rs"),
+    literal("neural network", "COBOL parsing"),
+    literal("quantization", "COBOL parsing"),
+    literal("inference", "data conversion"),
+    literal("GPU", "enterprise performance"),
+    literal("I2S, TL1, TL2", "DISPLAY, COMP, COMP-3"),
+    literal("quantization accuracy", "COBOL parsing accuracy"),
+    literal("cross-validation", "mainframe compatibility"),
+    literal("GGUF", "EBCDIC"),
+    literal("tensor", "field"),
+    literal("model", "copybook"),
+    literal("CUDA", "SIMD"),
+    literal(
+        ">99% accuracy",
+        "enterprise performance targets (DISPLAY ≥ 4.1 GiB/s, COMP-3 ≥ 560 MiB/s)",
+    ),
+    literal("99.8%", "4.1 GiB/s"),
+    literal("99.6%", "560 MiB/s"),
+    literal("bitnet-quantization", "copybook-core"),
+    literal("bitnet-kernels", "copybook-codec"),
+    literal("bitnet-inference", "copybook-cli"),
+    literal("bitnet-wasm", "copybook-gen"),
+    literal("bitnet-tokenizers", "copybook-bench"),
+    literal("--no-default-features --features cpu", "--workspace"),
+    literal(
+        "--no-default-features --features gpu",
+        "--workspace --release",
+    ),
+    literal("cargo run -p xtask -- crossval", "cargo xtask ci"),
+    literal(
+        "cargo run -p xtask -- benchmark",
+        "cargo bench --package copybook-bench",
+    ),
+    literal("./scripts/verify-tests.sh", "cargo xtask ci --quick"),
+    literal("CUDA unavailable", "xtask unavailable"),
+    literal("GPU memory", "parsing memory"),
+    literal("C++ reference", "mainframe compatibility"),
+    literal("CPU: ok, GPU: ok", "workspace release ok"),
+    literal("tokens/sec", "records/sec"),
+    literal("I2S: 99.X%", "DISPLAY: X.Y GiB/s"),
+    literal("quantization kernels", "COBOL parsing kernels"),
+    literal("inference pipeline", "data processing pipeline"),
+    literal(
+        "1-bit neural networks",
+        "enterprise mainframe data processing",
+    ),
+];
+
+const ADAPT_AGENT_REGEX_RULES: &[ReplacementRule] = &[
+    regex_rule(
+        r"cargo test --workspace --no-default-features --features \w+",
+        "cargo test --workspace",
+    ),
+    regex_rule(
+        r"cargo build --release --no-default-features --features \w+",
+        "cargo build --workspace --release",
+    ),
+    regex_rule(
+        r"tests: cargo test: (\d+)/(\d+) pass; CPU: (\d+)/(\d+), GPU: (\d+)/(\d+); quarantined: (\d+) \(linked\)",
+        "tests: nextest: $1/$2 pass; enterprise validation: $3/$4; quarantined: $7 (linked)",
+    ),
+];
+
+const FIX_AGENT_RULES: &[ReplacementRule] = &[
+    regex_rule(r"(?m)^copybook: sonnet$", "model: sonnet"),
+    literal("--workspace --workspace", "--workspace"),
+    literal("--workspace --release --workspace", "--workspace --release"),
+    literal("copybook-core parsing", "copybook-core"),
+    literal("copybook-codec parsing", "copybook-codec"),
+    literal("deCOBOL parsing", "data conversion"),
+    literal(
+        "I2S: 4.1 GiB/s, TL1: 560 MiB/s, TL2: 99.7%",
+        "DISPLAY: ≥4.1 GiB/s, COMP-3: ≥560 MiB/s",
+    ),
+    literal("copybook.gguf", "copybook.cpy"),
+    literal("copybooks/bitnet/", "examples/"),
+    literal("weight deCOBOL parsing", "field layout computation"),
+    literal(
+        "COBOL parsing/deCOBOL parsing",
+        "COBOL parsing/data conversion",
+    ),
+    literal(
+        "COBOL parsing kernels (DISPLAY, COMP, COMP-3)",
+        "COBOL parsing engines (lexer, parser, AST)",
+    ),
+    literal("records/sec", "GiB/s for DISPLAY, MiB/s for COMP-3"),
+    literal("BITNET_DETERMINISTIC=1", "deterministic parsing"),
+    literal("BITNET_EBCDIC", "COPYBOOK_DATA"),
+    regex_rule(r"bitnet-\*", "copybook-*"),
+];
+
+const FINAL_CLEANUP_AGENT_RULES: &[ReplacementRule] = &[
+    literal(
+        "1-bit quantized COBOL parsings",
+        "enterprise mainframe data processing",
+    ),
+    literal(
+        "Neural Network Security Testing (NNST)",
+        "COBOL Parsing Security Testing",
+    ),
+    literal("HuggingFace tokens", "mainframe authentication tokens"),
+    literal("copybook poisoning attacks", "malicious copybook attacks"),
+    literal(
+        "copybook-rs workspace crates",
+        "copybook-rs 5-crate workspace (core, codec, cli, gen, bench)",
+    ),
+    literal(
+        "cargo clippy --workspace --all-targets --workspace",
+        "cargo clippy --workspace --all-targets",
+    ),
+    literal(
+        "--workspace -- -D warnings",
+        "-- -D warnings -W clippy::pedantic",
+    ),
+    literal("COBOL parsing COBOL parsing", "COBOL parsing"),
+    literal("enterprise performance/CPU", "high-performance"),
+    literal("enterprise performance memory", "memory"),
+    literal("SIMD enterprise performance", "SIMD CPU"),
+    literal("GiB/s for DISPLAY, MiB/s for COMP-3ond", "records/second"),
+    literal(
+        "GiB/s for DISPLAY, MiB/s for COMP-3",
+        "GiB/s (DISPLAY), MiB/s (COMP-3)",
+    ),
+    literal(
+        "cargo bench --workspace --workspace",
+        "cargo bench --package copybook-bench",
+    ),
+    literal(
+        "cargo test --workspace --workspace",
+        "cargo test --workspace",
+    ),
+    literal(
+        "I2S ≥4.1 GiB/s, TL1 ≥560 MiB/s, TL2 ≥99.7%",
+        "DISPLAY ≥4.1 GiB/s, COMP-3 ≥560 MiB/s",
+    ),
+    literal("I2S: 4.1 GiB/s", "DISPLAY: 4.1+ GiB/s"),
+    literal("TL1: 560 MiB/s", "COMP-3: 560+ MiB/s"),
+    literal("copybook weight handling", "copybook field handling"),
+    literal("weight data conversion", "field layout computation"),
+    literal("Tensor Core acceleration", "SIMD acceleration"),
+    literal("mixed precision", "high-precision"),
+    literal("--tokens 128", "--batch-size 128"),
+    literal(
+        "--copybook examples/copybook.cpy --tokens",
+        "--input examples/data.bin --copybook examples/schema.cpy --records",
+    ),
+    literal("Neural Network Validation", "COBOL Parsing Validation"),
+    literal("attention computation", "field processing"),
+    literal("KV cache", "field cache"),
+    regex_rule(
+        r"test_dequantize_cpu_and_gpu_paths",
+        "enterprise_performance_validation",
+    ),
+    regex_rule(
+        r#"COPYBOOK_DATA="[^"]*""#,
+        "COPYBOOK_TEST_DATA=\"examples/test.cpy\"",
+    ),
+];


### PR DESCRIPTION
### Motivation
- Consolidate the ad-hoc agent maintenance scripts into the native Rust maintenance tool.
- Keep existing Python entry points working while moving the real rewrite logic into typed, testable Rust.
- Refresh the shared CI/security baseline so the PR is evaluated by the current gate set.

### Description
- Add `copybook-scripts` subcommands for `adapt-review-agents`, `fix-agent-issues`, and `final-cleanup-agents`.
- Port the agent text cleanup rules to a Rust rule engine supporting literal, regex, and BitNet crate-name replacements.
- Keep the Python scripts as compatibility wrappers that delegate to the Rust subcommands.
- Fix rule ordering for command/evidence rewrites and add unit coverage for the migrated rule sets.
- Include the current CI baseline updates for Rust 1.95 clippy, cargo-deny security metadata, and label-gated heavyweight advisory jobs.

### Testing
- `cargo +1.95.0 fmt --all --check`
- `cargo +1.95.0 test -p copybook-scripts`
- `cargo +1.95.0 clippy -p copybook-scripts --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `cargo +1.95.0 clippy --workspace --lib --bins --examples --all-features -- -D warnings -W clippy::pedantic`
- `cargo +1.95.0 clippy --workspace --tests --all-features -- -D warnings -A clippy::unwrap_used -A clippy::expect_used -A clippy::panic -A clippy::dbg_macro -A clippy::print_stdout -A clippy::print_stderr -A clippy::missing_inline_in_public_items -A clippy::duplicated_attributes -A deprecated`
- `cargo deny --workspace --all-features check`
- `git diff --check origin/main...HEAD`
- `git diff --check`