### PR TITLE
refactor(scripts): complete public Result docs checker port

### DIFF
--- a/crates/copybook-codec/src/determinism.rs
+++ b/crates/copybook-codec/src/determinism.rs
@@ -26,6 +26,8 @@ fn serialize_json(value: &serde_json::Value, context: &str) -> Result<Vec<u8>> {
 /// # Errors
 ///
 /// Returns an error if decoding or JSON serialization fails.
+#[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn check_decode_determinism(
     schema: &Schema,
     data: &[u8],
@@ -45,6 +47,8 @@ pub fn check_decode_determinism(
 /// # Errors
 ///
 /// Returns an error if encoding fails.
+#[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn check_encode_determinism(
     schema: &Schema,
     json_data: &serde_json::Value,
@@ -65,6 +69,8 @@ pub fn check_encode_determinism(
 /// # Errors
 ///
 /// Returns an error if any decode/encode or JSON serialization step fails.
+#[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn check_round_trip_determinism(
     schema: &Schema,
     data: &[u8],

--- a/crates/copybook-codec/src/edited_pic.rs
+++ b/crates/copybook-codec/src/edited_pic.rs
@@ -85,6 +85,7 @@ pub enum Sign {
 /// Returns error if the PIC pattern is malformed
 #[inline]
 #[allow(clippy::too_many_lines)]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn tokenize_edited_pic(pic_str: &str) -> Result<Vec<PicToken>> {
     let mut tokens = Vec::new();
     let mut chars = pic_str.chars().peekable();
@@ -292,6 +293,7 @@ impl NumericValue {
 /// Returns error if the input doesn't match the pattern
 #[inline]
 #[allow(clippy::too_many_lines)]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn decode_edited_numeric(
     input: &str,
     pattern: &[PicToken],
@@ -639,6 +641,7 @@ fn parse_numeric_value(value: &str) -> Result<ParsedNumeric> {
 /// Returns error if the value cannot be encoded to the pattern
 #[inline]
 #[allow(clippy::too_many_lines)]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn encode_edited_numeric(
     value: &str,
     pattern: &[PicToken],

--- a/crates/copybook-codec/src/numeric.rs
+++ b/crates/copybook-codec/src/numeric.rs
@@ -1326,6 +1326,7 @@ pub fn decode_zoned_decimal_sign_separate(
 /// # Errors
 /// Returns `CBKE530_SIGN_SEPARATE_ENCODE_ERROR` if the value cannot be encoded.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn encode_zoned_decimal_sign_separate(
     value: &str,
     digits: u16,
@@ -4541,6 +4542,7 @@ fn encode_f64_to_ibm_hex_parts(value: f64, bits: u32) -> Result<(u8, u64)> {
 /// # Errors
 /// Returns `CBKD301_RECORD_TOO_SHORT` if the data slice has fewer than 4 bytes.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn decode_float_single_ieee_be(data: &[u8]) -> Result<f32> {
     validate_float_buffer_len(data, 4, "COMP-1")?;
     let bytes: [u8; 4] = [data[0], data[1], data[2], data[3]];
@@ -4552,6 +4554,7 @@ pub fn decode_float_single_ieee_be(data: &[u8]) -> Result<f32> {
 /// # Errors
 /// Returns `CBKD301_RECORD_TOO_SHORT` if the data slice has fewer than 8 bytes.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn decode_float_double_ieee_be(data: &[u8]) -> Result<f64> {
     validate_float_buffer_len(data, 8, "COMP-2")?;
     let bytes: [u8; 8] = [
@@ -4565,6 +4568,7 @@ pub fn decode_float_double_ieee_be(data: &[u8]) -> Result<f64> {
 /// # Errors
 /// Returns `CBKD301_RECORD_TOO_SHORT` if the data slice has fewer than 4 bytes.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn decode_float_single_ibm_hex(data: &[u8]) -> Result<f32> {
     validate_float_buffer_len(data, 4, "COMP-1")?;
     let word = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
@@ -4588,6 +4592,7 @@ pub fn decode_float_single_ibm_hex(data: &[u8]) -> Result<f32> {
 /// # Errors
 /// Returns `CBKD301_RECORD_TOO_SHORT` if the data slice has fewer than 8 bytes.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn decode_float_double_ibm_hex(data: &[u8]) -> Result<f64> {
     validate_float_buffer_len(data, 8, "COMP-2")?;
     let word = u64::from_be_bytes([
@@ -4609,6 +4614,7 @@ pub fn decode_float_double_ibm_hex(data: &[u8]) -> Result<f64> {
 /// # Errors
 /// Returns format-specific decode errors.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn decode_float_single_with_format(data: &[u8], format: FloatFormat) -> Result<f32> {
     match format {
         FloatFormat::IeeeBigEndian => decode_float_single_ieee_be(data),
@@ -4621,6 +4627,7 @@ pub fn decode_float_single_with_format(data: &[u8], format: FloatFormat) -> Resu
 /// # Errors
 /// Returns format-specific decode errors.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn decode_float_double_with_format(data: &[u8], format: FloatFormat) -> Result<f64> {
     match format {
         FloatFormat::IeeeBigEndian => decode_float_double_ieee_be(data),
@@ -4633,6 +4640,7 @@ pub fn decode_float_double_with_format(data: &[u8], format: FloatFormat) -> Resu
 /// # Errors
 /// Returns `CBKD301_RECORD_TOO_SHORT` if the data slice has fewer than 4 bytes.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn decode_float_single(data: &[u8]) -> Result<f32> {
     decode_float_single_ieee_be(data)
 }
@@ -4642,6 +4650,7 @@ pub fn decode_float_single(data: &[u8]) -> Result<f32> {
 /// # Errors
 /// Returns `CBKD301_RECORD_TOO_SHORT` if the data slice has fewer than 8 bytes.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn decode_float_double(data: &[u8]) -> Result<f64> {
     decode_float_double_ieee_be(data)
 }
@@ -4651,6 +4660,7 @@ pub fn decode_float_double(data: &[u8]) -> Result<f64> {
 /// # Errors
 /// Returns `CBKE510_NUMERIC_OVERFLOW` if the buffer has fewer than 4 bytes.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn encode_float_single_ieee_be(value: f32, buffer: &mut [u8]) -> Result<()> {
     validate_float_encode_buffer_len(buffer, 4, "COMP-1")?;
     let bytes = value.to_be_bytes();
@@ -4663,6 +4673,7 @@ pub fn encode_float_single_ieee_be(value: f32, buffer: &mut [u8]) -> Result<()> 
 /// # Errors
 /// Returns `CBKE510_NUMERIC_OVERFLOW` if the buffer has fewer than 8 bytes.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn encode_float_double_ieee_be(value: f64, buffer: &mut [u8]) -> Result<()> {
     validate_float_encode_buffer_len(buffer, 8, "COMP-2")?;
     let bytes = value.to_be_bytes();
@@ -4677,6 +4688,7 @@ pub fn encode_float_double_ieee_be(value: f64, buffer: &mut [u8]) -> Result<()> 
 /// - `CBKE510_NUMERIC_OVERFLOW` if the buffer is too small
 /// - `CBKE510_NUMERIC_OVERFLOW` for non-finite values or exponent overflow
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn encode_float_single_ibm_hex(value: f32, buffer: &mut [u8]) -> Result<()> {
     validate_float_encode_buffer_len(buffer, 4, "COMP-1")?;
     let sign = value.is_sign_negative();
@@ -4701,6 +4713,7 @@ pub fn encode_float_single_ibm_hex(value: f32, buffer: &mut [u8]) -> Result<()> 
 /// - `CBKE510_NUMERIC_OVERFLOW` if the buffer is too small
 /// - `CBKE510_NUMERIC_OVERFLOW` for non-finite values or exponent overflow
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn encode_float_double_ibm_hex(value: f64, buffer: &mut [u8]) -> Result<()> {
     validate_float_encode_buffer_len(buffer, 8, "COMP-2")?;
     let sign = value.is_sign_negative();
@@ -4717,6 +4730,7 @@ pub fn encode_float_double_ibm_hex(value: f64, buffer: &mut [u8]) -> Result<()> 
 /// # Errors
 /// Returns format-specific encode errors.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn encode_float_single_with_format(
     value: f32,
     buffer: &mut [u8],
@@ -4733,6 +4747,7 @@ pub fn encode_float_single_with_format(
 /// # Errors
 /// Returns format-specific encode errors.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn encode_float_double_with_format(
     value: f64,
     buffer: &mut [u8],
@@ -4749,6 +4764,7 @@ pub fn encode_float_double_with_format(
 /// # Errors
 /// Returns `CBKE510_NUMERIC_OVERFLOW` if the buffer has fewer than 4 bytes.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn encode_float_single(value: f32, buffer: &mut [u8]) -> Result<()> {
     encode_float_single_ieee_be(value, buffer)
 }
@@ -4758,6 +4774,7 @@ pub fn encode_float_single(value: f32, buffer: &mut [u8]) -> Result<()> {
 /// # Errors
 /// Returns `CBKE510_NUMERIC_OVERFLOW` if the buffer has fewer than 8 bytes.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn encode_float_double(value: f64, buffer: &mut [u8]) -> Result<()> {
     encode_float_double_ieee_be(value, buffer)
 }

--- a/crates/copybook-core/src/projection.rs
+++ b/crates/copybook-core/src/projection.rs
@@ -44,6 +44,8 @@ use std::collections::HashSet;
 /// assert_eq!(projected.fields[0].children.len(), 1);
 /// assert_eq!(projected.fields[0].children[0].name, "ID");
 /// ```
+#[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn project_schema(schema: &Schema, selections: &[String]) -> Result<Schema> {
     if selections.is_empty() {
         return Ok(Schema::from_fields(Vec::new()));

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,6 +7,11 @@ Automation and utility scripts for copybook-rs development and CI/CD.
 - **bench.sh** / **bench.bat** - Cross-platform benchmark execution
 - **performance_test.rs** - Performance regression testing
 
+## Repository Checks
+- **check-public-result-docs.sh** - Rust-backed public `Result` API documentation and attribute guard
+- **check_no_unwrap_expect.sh** - Rust-backed panic-call guard
+- **guard-hotpaths.sh** - Rust-backed hot-path allocation guard
+
 ## Development Automation
 - **copybook-scripts adapt-review-agents** - Native Rust agent configuration adaptation utility
 - **copybook-scripts final-cleanup-agents** - Native Rust agent cleanup and finalization
@@ -45,7 +50,8 @@ python scripts/fix-agent-issues.py
 - Native Rust utilities in `tools/copybook-scripts` for repository automation
 - Python scripts (.py) are compatibility wrappers for existing automation
 
-These scripts complement the main build system and are used for specialized development tasks.
+These scripts complement the main build system and are used for specialized development tasks. Shell entrypoints are thin compatibility wrappers where a Rust implementation exists under `tools/copybook-scripts`.
+
 ## License
 
 Licensed under **AGPL-3.0-or-later**. See [LICENSE](../LICENSE).

--- a/scripts/check-public-result-docs.sh
+++ b/scripts/check-public-result-docs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-or-later
-# Lists public Result fns missing #[inline]/#[must_use]/# Errors.
+# Lists public Result fns missing #[inline]/#[must_use]/# Errors
 set -euo pipefail
 
 ROOT_DIR="$(git rev-parse --show-toplevel)"
@@ -15,9 +15,9 @@ bootstrap_rustup() {
 run_cargo() {
   bootstrap_rustup
 
-  if command -v rustup >/dev/null 2>&1; then
+  if command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q '^stable'; then
     rustup run stable cargo "$@"
-  elif command -v rustup.exe >/dev/null 2>&1; then
+  elif command -v rustup.exe >/dev/null 2>&1 && rustup.exe toolchain list | grep -q '^stable'; then
     rustup.exe run stable cargo "$@"
   else
     cargo "$@"

--- a/scripts/check-public-result-docs.sh
+++ b/scripts/check-public-result-docs.sh
@@ -1,25 +1,27 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-or-later
-# Lists public Result fns missing #[inline]/#[must_use]/# Errors
+# Lists public Result fns missing #[inline]/#[must_use]/# Errors.
 set -euo pipefail
 
-scan_dirs=("crates/copybook-codec/src" "crates/copybook-core/src")
-miss=0
+ROOT_DIR="$(git rev-parse --show-toplevel)"
 
-for dir in "${scan_dirs[@]}"; do
-  while IFS=: read -r file line sig; do
-    # Inspect a small window above the signature for attrs/docs
-    hdr="$(sed -n "$((line-4)),$((line-1))p" "$file")"
-    if ! printf '%s\n' "$hdr" | rg -q '^\s*#\[\s*inline\s*\]'; then
-      echo "missing #[inline]      @ $file:$line"; miss=1
-    fi
-    if ! printf '%s\n' "$hdr" | rg -q '^\s*#\[\s*must_use[^\]]*\]'; then
-      echo "missing #[must_use]    @ $file:$line"; miss=1
-    fi
-    if ! printf '%s\n' "$hdr" | rg -q '^\s*///\s*#\s*Errors'; then
-      echo "missing doc '# Errors' @ $file:$line"; miss=1
-    fi
-  done < <(rg -n '^\s*pub\s+fn\s+\w+.*->\s*Result<' "$dir")
-done
+bootstrap_rustup() {
+  if [ -n "${HOME:-}" ] && [ -f "$HOME/.cargo/env" ]; then
+    # Non-login bash shells may not populate Rust's shims on PATH.
+    . "$HOME/.cargo/env"
+  fi
+}
 
-exit $miss
+run_cargo() {
+  bootstrap_rustup
+
+  if command -v rustup >/dev/null 2>&1; then
+    rustup run stable cargo "$@"
+  elif command -v rustup.exe >/dev/null 2>&1; then
+    rustup.exe run stable cargo "$@"
+  else
+    cargo "$@"
+  fi
+}
+
+run_cargo run --quiet --manifest-path "$ROOT_DIR/tools/copybook-scripts/Cargo.toml" -- check-public-result-docs

--- a/scripts/check-public-result-docs.sh
+++ b/scripts/check-public-result-docs.sh
@@ -14,11 +14,12 @@ bootstrap_rustup() {
 
 run_cargo() {
   bootstrap_rustup
+  local toolchain="${COPYBOOK_RUST_TOOLCHAIN:-stable}"
 
-  if command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q '^stable'; then
-    rustup run stable cargo "$@"
-  elif command -v rustup.exe >/dev/null 2>&1 && rustup.exe toolchain list | grep -q '^stable'; then
-    rustup.exe run stable cargo "$@"
+  if command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q "^${toolchain}"; then
+    rustup run "$toolchain" cargo "$@"
+  elif command -v rustup.exe >/dev/null 2>&1 && rustup.exe toolchain list | grep -q "^${toolchain}"; then
+    rustup.exe run "$toolchain" cargo "$@"
   else
     cargo "$@"
   fi

--- a/tools/README.md
+++ b/tools/README.md
@@ -31,6 +31,7 @@ Small Rust-native replacements for repository-maintenance shell scripts.
 ```bash
 cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- check-no-unwrap-expect
 cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- guard-hotpaths
+cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- check-public-result-docs
 cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- perf-annotate-host
 cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- soak-dispatch
 cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- clean-merge-conflicts path/to/file.rs

--- a/tools/copybook-scripts/src/main.rs
+++ b/tools/copybook-scripts/src/main.rs
@@ -26,6 +26,7 @@ enum CommandKind {
     GuardHotpaths,
     PerfAnnotateHost,
     SoakDispatch,
+    CheckPublicResultDocs,
     CleanMergeConflicts {
         #[arg(value_name = "PATH")]
         file: PathBuf,
@@ -42,6 +43,7 @@ fn main() -> Result<()> {
         CommandKind::GuardHotpaths => guard_hotpaths(),
         CommandKind::PerfAnnotateHost => perf_annotate_host(),
         CommandKind::SoakDispatch => soak_dispatch(),
+        CommandKind::CheckPublicResultDocs => check_public_result_docs(),
         CommandKind::CleanMergeConflicts { file } => clean_merge_conflicts(file),
         CommandKind::AdaptReviewAgents => adapt_review_agents(),
         CommandKind::FixAgentIssues => fix_agent_issues(),
@@ -148,6 +150,112 @@ fn collect_rs_paths(root: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
             }
 
             if has_component(&entry_path, "src") {
+                out.push(entry_path);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn looks_like_public_result_fn(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.starts_with("pub fn ") && trimmed.contains("->") && trimmed.contains("Result<")
+}
+
+fn header_window(lines: &[&str], line_index: usize) -> String {
+    let start = line_index.saturating_sub(4);
+    lines[start..line_index].join("\n")
+}
+
+fn has_inline_attr(header: &str) -> bool {
+    header
+        .lines()
+        .any(|line| line.trim_start().starts_with("#[inline"))
+}
+
+fn has_must_use_attr(header: &str) -> bool {
+    header
+        .lines()
+        .any(|line| line.trim_start().starts_with("#[must_use"))
+}
+
+fn has_errors_doc(header: &str) -> bool {
+    header.lines().any(|line| {
+        let trimmed = line.trim_start();
+        trimmed.starts_with("///") && trimmed[3..].trim_start().starts_with("# Errors")
+    })
+}
+
+fn check_public_result_docs() -> Result<()> {
+    let root = workspace_root()?;
+    let scan_dirs = [
+        root.join("crates").join("copybook-codec").join("src"),
+        root.join("crates").join("copybook-core").join("src"),
+    ];
+    let mut miss = false;
+
+    for dir in scan_dirs {
+        let mut paths = Vec::new();
+        collect_rs_paths_under(&dir, &mut paths)?;
+        paths.sort();
+
+        for path in paths {
+            let source = fs::read_to_string(&path)
+                .with_context(|| format!("failed to read {}", path.display()))?;
+            let lines: Vec<&str> = source.lines().collect();
+            let rel = path.strip_prefix(&root).unwrap_or(&path);
+
+            for (idx, line) in lines.iter().enumerate() {
+                if !looks_like_public_result_fn(line) {
+                    continue;
+                }
+
+                let header = header_window(&lines, idx);
+                let line_no = idx + 1;
+
+                if !has_inline_attr(&header) {
+                    println!("missing #[inline]      @ {}:{line_no}", rel.display());
+                    miss = true;
+                }
+                if !has_must_use_attr(&header) {
+                    println!("missing #[must_use]    @ {}:{line_no}", rel.display());
+                    miss = true;
+                }
+                if !has_errors_doc(&header) {
+                    println!("missing doc '# Errors' @ {}:{line_no}", rel.display());
+                    miss = true;
+                }
+            }
+        }
+    }
+
+    if miss {
+        bail!("public Result function docs check failed");
+    }
+
+    Ok(())
+}
+
+fn collect_rs_paths_under(root: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    let mut entries = vec![root.to_path_buf()];
+
+    while let Some(path) = entries.pop() {
+        for item in fs::read_dir(&path)? {
+            let entry = item?;
+            let file_type = entry.file_type()?;
+            let entry_path = entry.path();
+
+            if file_type.is_dir() {
+                entries.push(entry_path);
+                continue;
+            }
+
+            if !file_type.is_file() {
+                continue;
+            }
+
+            if entry_path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
                 out.push(entry_path);
             }
         }

--- a/tools/copybook-scripts/src/main.rs
+++ b/tools/copybook-scripts/src/main.rs
@@ -26,7 +26,6 @@ enum CommandKind {
     GuardHotpaths,
     PerfAnnotateHost,
     SoakDispatch,
-    CheckPublicResultDocs,
     CleanMergeConflicts {
         #[arg(value_name = "PATH")]
         file: PathBuf,
@@ -34,6 +33,7 @@ enum CommandKind {
     AdaptReviewAgents,
     FixAgentIssues,
     FinalCleanupAgents,
+    CheckPublicResultDocs,
 }
 
 fn main() -> Result<()> {
@@ -43,11 +43,11 @@ fn main() -> Result<()> {
         CommandKind::GuardHotpaths => guard_hotpaths(),
         CommandKind::PerfAnnotateHost => perf_annotate_host(),
         CommandKind::SoakDispatch => soak_dispatch(),
-        CommandKind::CheckPublicResultDocs => check_public_result_docs(),
         CommandKind::CleanMergeConflicts { file } => clean_merge_conflicts(file),
         CommandKind::AdaptReviewAgents => adapt_review_agents(),
         CommandKind::FixAgentIssues => fix_agent_issues(),
         CommandKind::FinalCleanupAgents => final_cleanup_agents(),
+        CommandKind::CheckPublicResultDocs => check_public_result_docs(),
     }
 }
 
@@ -158,112 +158,6 @@ fn collect_rs_paths(root: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
     Ok(())
 }
 
-fn looks_like_public_result_fn(line: &str) -> bool {
-    let trimmed = line.trim_start();
-    trimmed.starts_with("pub fn ") && trimmed.contains("->") && trimmed.contains("Result<")
-}
-
-fn header_window(lines: &[&str], line_index: usize) -> String {
-    let start = line_index.saturating_sub(4);
-    lines[start..line_index].join("\n")
-}
-
-fn has_inline_attr(header: &str) -> bool {
-    header
-        .lines()
-        .any(|line| line.trim_start().starts_with("#[inline"))
-}
-
-fn has_must_use_attr(header: &str) -> bool {
-    header
-        .lines()
-        .any(|line| line.trim_start().starts_with("#[must_use"))
-}
-
-fn has_errors_doc(header: &str) -> bool {
-    header.lines().any(|line| {
-        let trimmed = line.trim_start();
-        trimmed.starts_with("///") && trimmed[3..].trim_start().starts_with("# Errors")
-    })
-}
-
-fn check_public_result_docs() -> Result<()> {
-    let root = workspace_root()?;
-    let scan_dirs = [
-        root.join("crates").join("copybook-codec").join("src"),
-        root.join("crates").join("copybook-core").join("src"),
-    ];
-    let mut miss = false;
-
-    for dir in scan_dirs {
-        let mut paths = Vec::new();
-        collect_rs_paths_under(&dir, &mut paths)?;
-        paths.sort();
-
-        for path in paths {
-            let source = fs::read_to_string(&path)
-                .with_context(|| format!("failed to read {}", path.display()))?;
-            let lines: Vec<&str> = source.lines().collect();
-            let rel = path.strip_prefix(&root).unwrap_or(&path);
-
-            for (idx, line) in lines.iter().enumerate() {
-                if !looks_like_public_result_fn(line) {
-                    continue;
-                }
-
-                let header = header_window(&lines, idx);
-                let line_no = idx + 1;
-
-                if !has_inline_attr(&header) {
-                    println!("missing #[inline]      @ {}:{line_no}", rel.display());
-                    miss = true;
-                }
-                if !has_must_use_attr(&header) {
-                    println!("missing #[must_use]    @ {}:{line_no}", rel.display());
-                    miss = true;
-                }
-                if !has_errors_doc(&header) {
-                    println!("missing doc '# Errors' @ {}:{line_no}", rel.display());
-                    miss = true;
-                }
-            }
-        }
-    }
-
-    if miss {
-        bail!("public Result function docs check failed");
-    }
-
-    Ok(())
-}
-
-fn collect_rs_paths_under(root: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
-    let mut entries = vec![root.to_path_buf()];
-
-    while let Some(path) = entries.pop() {
-        for item in fs::read_dir(&path)? {
-            let entry = item?;
-            let file_type = entry.file_type()?;
-            let entry_path = entry.path();
-
-            if file_type.is_dir() {
-                entries.push(entry_path);
-                continue;
-            }
-
-            if !file_type.is_file() {
-                continue;
-            }
-
-            if entry_path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
-                out.push(entry_path);
-            }
-        }
-    }
-
-    Ok(())
-}
-
 fn guard_hotpaths() -> Result<()> {
     let root = workspace_root()?;
     let lib_api = root
@@ -319,6 +213,211 @@ fn guard_hotpaths() -> Result<()> {
     }
 
     println!("✅ Hot-path allocation guard clean");
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PublicResultDocCheck {
+    Inline,
+    MustUse,
+    ErrorsDoc,
+}
+
+impl PublicResultDocCheck {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Inline => "missing #[inline]",
+            Self::MustUse => "missing #[must_use]",
+            Self::ErrorsDoc => "missing doc '# Errors'",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PublicResultDocFinding {
+    check: PublicResultDocCheck,
+    path: PathBuf,
+    line: usize,
+}
+
+fn rust_item_header(lines: &[&str], function_line_index: usize) -> Vec<String> {
+    let mut header = Vec::new();
+    let mut cursor = function_line_index;
+
+    while cursor > 0 {
+        cursor -= 1;
+        let line = lines[cursor];
+        let trimmed = line.trim_start();
+
+        if trimmed.starts_with("///")
+            || trimmed.starts_with("#[")
+            || trimmed.is_empty()
+            || trimmed.starts_with("//")
+        {
+            header.push(line.to_string());
+            continue;
+        }
+
+        break;
+    }
+
+    header.reverse();
+    header
+}
+
+fn missing_public_result_docs_for_source(
+    path: &Path,
+    source: &str,
+    function_start_regex: &Regex,
+    result_signature_regex: &Regex,
+) -> Vec<PublicResultDocFinding> {
+    let lines: Vec<&str> = source.lines().collect();
+    let mut findings = Vec::new();
+
+    for (index, line) in lines.iter().enumerate() {
+        if !function_start_regex.is_match(line) {
+            continue;
+        }
+
+        let signature = collect_function_signature(&lines, index);
+        if !result_signature_regex.is_match(&signature) {
+            continue;
+        }
+
+        let header = rust_item_header(&lines, index);
+        let line_number = index + 1;
+
+        if !header.iter().any(|line| {
+            let trimmed = line.trim_start();
+            trimmed.starts_with("#[inline]") || trimmed.starts_with("#[inline(")
+        }) {
+            findings.push(PublicResultDocFinding {
+                check: PublicResultDocCheck::Inline,
+                path: path.to_path_buf(),
+                line: line_number,
+            });
+        }
+
+        if !header.iter().any(|line| {
+            let trimmed = line.trim_start();
+            trimmed.starts_with("#[must_use")
+        }) {
+            findings.push(PublicResultDocFinding {
+                check: PublicResultDocCheck::MustUse,
+                path: path.to_path_buf(),
+                line: line_number,
+            });
+        }
+
+        if !header
+            .iter()
+            .any(|line| line.trim_start().starts_with("/// # Errors"))
+        {
+            findings.push(PublicResultDocFinding {
+                check: PublicResultDocCheck::ErrorsDoc,
+                path: path.to_path_buf(),
+                line: line_number,
+            });
+        }
+    }
+
+    findings
+}
+
+fn collect_function_signature(lines: &[&str], function_line_index: usize) -> String {
+    let mut signature = String::new();
+
+    for line in &lines[function_line_index..] {
+        if !signature.is_empty() {
+            signature.push(' ');
+        }
+        signature.push_str(line.trim());
+
+        if line.contains('{') || line.contains(';') {
+            break;
+        }
+    }
+
+    signature
+}
+
+fn collect_public_result_docs_findings(root: &Path) -> Result<Vec<PublicResultDocFinding>> {
+    let function_start_regex = Regex::new(r"^\s*pub\s+fn\s+\w+")?;
+    let result_signature_regex =
+        Regex::new(r"^\s*pub\s+fn\s+\w+.*->\s*(?:[A-Za-z_]\w*::)*Result<")?;
+    let scan_dirs = [
+        root.join("crates").join("copybook-codec").join("src"),
+        root.join("crates").join("copybook-core").join("src"),
+    ];
+    let mut findings = Vec::new();
+
+    for scan_dir in scan_dirs {
+        let mut paths = Vec::new();
+        collect_rs_files(&scan_dir, &mut paths)?;
+        paths.sort();
+
+        for path in paths {
+            let source = fs::read_to_string(&path)
+                .with_context(|| format!("failed to read {}", path.display()))?;
+            findings.extend(missing_public_result_docs_for_source(
+                &path,
+                &source,
+                &function_start_regex,
+                &result_signature_regex,
+            ));
+        }
+    }
+
+    Ok(findings)
+}
+
+fn collect_rs_files(root: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    let mut entries = vec![root.to_path_buf()];
+
+    while let Some(path) = entries.pop() {
+        for item in fs::read_dir(&path)? {
+            let entry = item?;
+            let file_type = entry.file_type()?;
+            let entry_path = entry.path();
+
+            if file_type.is_dir() {
+                entries.push(entry_path);
+                continue;
+            }
+
+            if file_type.is_file()
+                && entry_path.extension().and_then(|ext| ext.to_str()) == Some("rs")
+            {
+                out.push(entry_path);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn check_public_result_docs() -> Result<()> {
+    let root = workspace_root()?;
+    let findings = collect_public_result_docs_findings(&root)?;
+
+    for finding in &findings {
+        let rel = finding.path.strip_prefix(&root).unwrap_or(&finding.path);
+        println!(
+            "{:<23} @ {}:{}",
+            finding.check.label(),
+            rel.display(),
+            finding.line
+        );
+    }
+
+    if !findings.is_empty() {
+        bail!(
+            "public Result function documentation check found {} issue(s)",
+            findings.len()
+        );
+    }
+
+    println!("✅ Public Result function documentation clean");
     Ok(())
 }
 
@@ -753,16 +852,107 @@ fn final_cleanup_agents() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        ADAPT_REVIEW_AGENT_RULES, FINAL_CLEANUP_AGENT_RULES, FIX_AGENT_ISSUE_RULES,
-        apply_text_rules, replace_bitnet_crate_names,
-    };
+    use super::*;
 
     fn apply_rules(input: &str, rules: &[super::TextRule]) -> String {
         match apply_text_rules(input.to_string(), rules) {
             Ok(output) => output,
             Err(error) => panic!("{error}"),
         }
+    }
+
+    fn signature_regex() -> Regex {
+        match Regex::new(r"^\s*pub\s+fn\s+\w+.*->\s*(?:[A-Za-z_]\w*::)*Result<") {
+            Ok(regex) => regex,
+            Err(err) => panic!("test regex must compile: {err}"),
+        }
+    }
+
+    fn function_start_regex() -> Regex {
+        match Regex::new(r"^\s*pub\s+fn\s+\w+") {
+            Ok(regex) => regex,
+            Err(err) => panic!("test regex must compile: {err}"),
+        }
+    }
+
+    #[test]
+    fn public_result_doc_check_accepts_full_rust_item_header() {
+        let source = r#"
+/// Decode a value.
+///
+/// # Errors
+/// Returns a decode error.
+#[inline]
+#[allow(clippy::too_many_lines)]
+#[must_use = "Handle the Result or propagate the error"]
+pub fn decode_value() -> Result<()> {
+    Ok(())
+}
+"#;
+
+        let findings = missing_public_result_docs_for_source(
+            Path::new("src/lib.rs"),
+            source,
+            &function_start_regex(),
+            &signature_regex(),
+        );
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn public_result_doc_check_reports_missing_contract_items() {
+        let source = r#"
+/// Decode a value.
+pub fn decode_value() -> Result<()> {
+    Ok(())
+}
+"#;
+
+        let findings = missing_public_result_docs_for_source(
+            Path::new("src/lib.rs"),
+            source,
+            &function_start_regex(),
+            &signature_regex(),
+        );
+        let checks: Vec<PublicResultDocCheck> =
+            findings.iter().map(|finding| finding.check).collect();
+
+        assert_eq!(
+            checks,
+            vec![
+                PublicResultDocCheck::Inline,
+                PublicResultDocCheck::MustUse,
+                PublicResultDocCheck::ErrorsDoc,
+            ]
+        );
+    }
+
+    #[test]
+    fn public_result_doc_check_reports_multiline_result_signatures() {
+        let source = r#"
+/// Encode a value.
+///
+/// # Errors
+/// Returns an encode error.
+#[inline]
+pub fn encode_value(
+    value: u32,
+    buffer: &mut [u8],
+) -> std::result::Result<(), Error> {
+    Ok(())
+}
+"#;
+
+        let findings = missing_public_result_docs_for_source(
+            Path::new("src/lib.rs"),
+            source,
+            &function_start_regex(),
+            &signature_regex(),
+        );
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].check, PublicResultDocCheck::MustUse);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Move the public `Result` docs advisory from a brittle shell scan into the Rust-native `copybook-scripts` tool.
- Make the checker actionable by bringing existing public `Result` APIs into compliance and covering multiline signatures.
- Refresh the PR on current `main` without carrying stale shared CI/security churn.

### Description
- Add the `check-public-result-docs` subcommand with regex-backed signature scanning, Rust item-header detection, and unit coverage for missing attributes/docs plus multiline signatures.
- Keep `scripts/check-public-result-docs.sh` as a compatibility wrapper around the Rust tool, with a `COPYBOOK_RUST_TOOLCHAIN` override for local toolchain selection while defaulting to `stable`.
- Document the Rust-backed checker in `scripts/README.md` and `tools/README.md`.
- Add missing `#[inline]`, `#[must_use]`, and `# Errors` coverage surfaced by the checker in `copybook-core` and `copybook-codec`.

### Testing
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 test -p copybook-scripts`
- `cargo +1.95.0 run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- check-public-result-docs`
- `COPYBOOK_RUST_TOOLCHAIN=1.95.0 bash scripts/check-public-result-docs.sh`
- `cargo +1.95.0 clippy -p copybook-scripts --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `cargo +1.95.0 clippy -p copybook-core -p copybook-codec --lib --bins --examples --all-features -- -D warnings -W clippy::pedantic`
- `git diff --check`