### PR TITLE
refactor(scripts): port public Result docs check to Rust

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -14,6 +14,7 @@ on:
       - 'tests/**'
       - 'Cargo.*'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches: [ main, develop ]
     paths:
       - 'crates/**'
@@ -30,9 +31,13 @@ env:
 
 jobs:
   coverage:
-    name: Code Coverage
+    name: Tarpaulin Coverage
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'coverage') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     steps:
     - name: Checkout code

--- a/.github/workflows/leak-detection.yml
+++ b/.github/workflows/leak-detection.yml
@@ -6,6 +6,7 @@ on:
   schedule:
     - cron: "0 4 * * 0"  # Weekly on Sunday at 04:00 UTC
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - "crates/copybook-codec/**"
       - "crates/copybook-core/**"
@@ -24,6 +25,10 @@ jobs:
     name: Memory Leak Detection (LSAN)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'leak-check') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     steps:
       - uses: actions/checkout@v6
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,6 +1227,7 @@ dependencies = [
  "chrono",
  "clap",
  "num_cpus",
+ "regex",
  "serde_json",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
  "hex",
  "logos",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "serde_plain",
@@ -1049,7 +1049,7 @@ dependencies = [
  "copybook-codec",
  "copybook-core",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "sha2",
@@ -1156,7 +1156,7 @@ dependencies = [
  "copybook-support-matrix",
  "crossbeam-channel",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
 ]
@@ -3070,9 +3070,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -3365,9 +3365,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3781,7 +3781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/crates/copybook-cli/src/commands/audit.rs
+++ b/crates/copybook-cli/src/commands/audit.rs
@@ -2701,12 +2701,11 @@ fn run_audit_health_check_impl(
         );
     }
 
-    let overall_health_score = if checks_executed == 0 {
-        0
-    } else {
-        let failed_penalty = (checks_failed * 100) / checks_executed;
-        (100u32.saturating_sub(failed_penalty)).min(100)
-    };
+    let overall_health_score = (checks_failed * 100)
+        .checked_div(checks_executed)
+        .map_or(0, |failed_penalty| {
+            (100u32.saturating_sub(failed_penalty)).min(100)
+        });
 
     let status_code = if checks_failed > 0 || !parse_issues.is_empty() {
         ExitCode::Data

--- a/crates/copybook-cli/src/main.rs
+++ b/crates/copybook-cli/src/main.rs
@@ -554,13 +554,10 @@ fn main() -> ProcessExitCode {
 
 #[allow(clippy::too_many_lines)]
 fn run() -> anyhow::Result<ExitCode> {
-    #[allow(clippy::panic)]
-    if std::env::var("COPYBOOK_TEST_PANIC")
-        .map(|v| v == "1")
-        .unwrap_or(false)
-    {
-        panic!("COPYBOOK_TEST_PANIC triggered");
-    }
+    assert!(
+        !std::env::var("COPYBOOK_TEST_PANIC").is_ok_and(|v| v == "1"),
+        "COPYBOOK_TEST_PANIC triggered"
+    );
 
     let cli = match Cli::try_parse() {
         Ok(cli) => cli,

--- a/crates/copybook-codec/src/determinism.rs
+++ b/crates/copybook-codec/src/determinism.rs
@@ -26,6 +26,8 @@ fn serialize_json(value: &serde_json::Value, context: &str) -> Result<Vec<u8>> {
 /// # Errors
 ///
 /// Returns an error if decoding or JSON serialization fails.
+#[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn check_decode_determinism(
     schema: &Schema,
     data: &[u8],
@@ -45,6 +47,8 @@ pub fn check_decode_determinism(
 /// # Errors
 ///
 /// Returns an error if encoding fails.
+#[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn check_encode_determinism(
     schema: &Schema,
     json_data: &serde_json::Value,
@@ -65,6 +69,8 @@ pub fn check_encode_determinism(
 /// # Errors
 ///
 /// Returns an error if any decode/encode or JSON serialization step fails.
+#[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn check_round_trip_determinism(
     schema: &Schema,
     data: &[u8],

--- a/crates/copybook-codec/src/edited_pic.rs
+++ b/crates/copybook-codec/src/edited_pic.rs
@@ -85,6 +85,7 @@ pub enum Sign {
 /// Returns error if the PIC pattern is malformed
 #[inline]
 #[allow(clippy::too_many_lines)]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn tokenize_edited_pic(pic_str: &str) -> Result<Vec<PicToken>> {
     let mut tokens = Vec::new();
     let mut chars = pic_str.chars().peekable();

--- a/crates/copybook-codec/src/edited_pic.rs
+++ b/crates/copybook-codec/src/edited_pic.rs
@@ -293,6 +293,7 @@ impl NumericValue {
 /// Returns error if the input doesn't match the pattern
 #[inline]
 #[allow(clippy::too_many_lines)]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn decode_edited_numeric(
     input: &str,
     pattern: &[PicToken],
@@ -640,6 +641,7 @@ fn parse_numeric_value(value: &str) -> Result<ParsedNumeric> {
 /// Returns error if the value cannot be encoded to the pattern
 #[inline]
 #[allow(clippy::too_many_lines)]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn encode_edited_numeric(
     value: &str,
     pattern: &[PicToken],

--- a/crates/copybook-codec/src/fidelity.rs
+++ b/crates/copybook-codec/src/fidelity.rs
@@ -948,11 +948,9 @@ pub mod utils {
             .map(|p| p.validation_time_ms)
             .sum();
         let total_records_u64 = u64::try_from(total_records).unwrap_or(u64::MAX);
-        let average_validation_time = if total_records_u64 == 0 {
-            0
-        } else {
-            total_validation_time / total_records_u64
-        };
+        let average_validation_time = total_validation_time
+            .checked_div(total_records_u64)
+            .unwrap_or(0);
 
         BatchFidelityMetrics {
             total_records,

--- a/crates/copybook-codec/src/numeric.rs
+++ b/crates/copybook-codec/src/numeric.rs
@@ -1326,6 +1326,7 @@ pub fn decode_zoned_decimal_sign_separate(
 /// # Errors
 /// Returns `CBKE530_SIGN_SEPARATE_ENCODE_ERROR` if the value cannot be encoded.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn encode_zoned_decimal_sign_separate(
     value: &str,
     digits: u16,
@@ -4729,6 +4730,7 @@ pub fn encode_float_double_ibm_hex(value: f64, buffer: &mut [u8]) -> Result<()> 
 /// # Errors
 /// Returns format-specific encode errors.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn encode_float_single_with_format(
     value: f32,
     buffer: &mut [u8],
@@ -4745,6 +4747,7 @@ pub fn encode_float_single_with_format(
 /// # Errors
 /// Returns format-specific encode errors.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn encode_float_double_with_format(
     value: f64,
     buffer: &mut [u8],

--- a/crates/copybook-codec/src/numeric.rs
+++ b/crates/copybook-codec/src/numeric.rs
@@ -4541,6 +4541,7 @@ fn encode_f64_to_ibm_hex_parts(value: f64, bits: u32) -> Result<(u8, u64)> {
 /// # Errors
 /// Returns `CBKD301_RECORD_TOO_SHORT` if the data slice has fewer than 4 bytes.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn decode_float_single_ieee_be(data: &[u8]) -> Result<f32> {
     validate_float_buffer_len(data, 4, "COMP-1")?;
     let bytes: [u8; 4] = [data[0], data[1], data[2], data[3]];
@@ -4552,6 +4553,7 @@ pub fn decode_float_single_ieee_be(data: &[u8]) -> Result<f32> {
 /// # Errors
 /// Returns `CBKD301_RECORD_TOO_SHORT` if the data slice has fewer than 8 bytes.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn decode_float_double_ieee_be(data: &[u8]) -> Result<f64> {
     validate_float_buffer_len(data, 8, "COMP-2")?;
     let bytes: [u8; 8] = [
@@ -4565,6 +4567,7 @@ pub fn decode_float_double_ieee_be(data: &[u8]) -> Result<f64> {
 /// # Errors
 /// Returns `CBKD301_RECORD_TOO_SHORT` if the data slice has fewer than 4 bytes.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn decode_float_single_ibm_hex(data: &[u8]) -> Result<f32> {
     validate_float_buffer_len(data, 4, "COMP-1")?;
     let word = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
@@ -4588,6 +4591,7 @@ pub fn decode_float_single_ibm_hex(data: &[u8]) -> Result<f32> {
 /// # Errors
 /// Returns `CBKD301_RECORD_TOO_SHORT` if the data slice has fewer than 8 bytes.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn decode_float_double_ibm_hex(data: &[u8]) -> Result<f64> {
     validate_float_buffer_len(data, 8, "COMP-2")?;
     let word = u64::from_be_bytes([
@@ -4609,6 +4613,7 @@ pub fn decode_float_double_ibm_hex(data: &[u8]) -> Result<f64> {
 /// # Errors
 /// Returns format-specific decode errors.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn decode_float_single_with_format(data: &[u8], format: FloatFormat) -> Result<f32> {
     match format {
         FloatFormat::IeeeBigEndian => decode_float_single_ieee_be(data),
@@ -4621,6 +4626,7 @@ pub fn decode_float_single_with_format(data: &[u8], format: FloatFormat) -> Resu
 /// # Errors
 /// Returns format-specific decode errors.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn decode_float_double_with_format(data: &[u8], format: FloatFormat) -> Result<f64> {
     match format {
         FloatFormat::IeeeBigEndian => decode_float_double_ieee_be(data),
@@ -4633,6 +4639,7 @@ pub fn decode_float_double_with_format(data: &[u8], format: FloatFormat) -> Resu
 /// # Errors
 /// Returns `CBKD301_RECORD_TOO_SHORT` if the data slice has fewer than 4 bytes.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn decode_float_single(data: &[u8]) -> Result<f32> {
     decode_float_single_ieee_be(data)
 }
@@ -4642,6 +4649,7 @@ pub fn decode_float_single(data: &[u8]) -> Result<f32> {
 /// # Errors
 /// Returns `CBKD301_RECORD_TOO_SHORT` if the data slice has fewer than 8 bytes.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn decode_float_double(data: &[u8]) -> Result<f64> {
     decode_float_double_ieee_be(data)
 }
@@ -4651,6 +4659,7 @@ pub fn decode_float_double(data: &[u8]) -> Result<f64> {
 /// # Errors
 /// Returns `CBKE510_NUMERIC_OVERFLOW` if the buffer has fewer than 4 bytes.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn encode_float_single_ieee_be(value: f32, buffer: &mut [u8]) -> Result<()> {
     validate_float_encode_buffer_len(buffer, 4, "COMP-1")?;
     let bytes = value.to_be_bytes();
@@ -4663,6 +4672,7 @@ pub fn encode_float_single_ieee_be(value: f32, buffer: &mut [u8]) -> Result<()> 
 /// # Errors
 /// Returns `CBKE510_NUMERIC_OVERFLOW` if the buffer has fewer than 8 bytes.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn encode_float_double_ieee_be(value: f64, buffer: &mut [u8]) -> Result<()> {
     validate_float_encode_buffer_len(buffer, 8, "COMP-2")?;
     let bytes = value.to_be_bytes();
@@ -4677,6 +4687,7 @@ pub fn encode_float_double_ieee_be(value: f64, buffer: &mut [u8]) -> Result<()> 
 /// - `CBKE510_NUMERIC_OVERFLOW` if the buffer is too small
 /// - `CBKE510_NUMERIC_OVERFLOW` for non-finite values or exponent overflow
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn encode_float_single_ibm_hex(value: f32, buffer: &mut [u8]) -> Result<()> {
     validate_float_encode_buffer_len(buffer, 4, "COMP-1")?;
     let sign = value.is_sign_negative();
@@ -4701,6 +4712,7 @@ pub fn encode_float_single_ibm_hex(value: f32, buffer: &mut [u8]) -> Result<()> 
 /// - `CBKE510_NUMERIC_OVERFLOW` if the buffer is too small
 /// - `CBKE510_NUMERIC_OVERFLOW` for non-finite values or exponent overflow
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn encode_float_double_ibm_hex(value: f64, buffer: &mut [u8]) -> Result<()> {
     validate_float_encode_buffer_len(buffer, 8, "COMP-2")?;
     let sign = value.is_sign_negative();
@@ -4749,6 +4761,7 @@ pub fn encode_float_double_with_format(
 /// # Errors
 /// Returns `CBKE510_NUMERIC_OVERFLOW` if the buffer has fewer than 4 bytes.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn encode_float_single(value: f32, buffer: &mut [u8]) -> Result<()> {
     encode_float_single_ieee_be(value, buffer)
 }
@@ -4758,6 +4771,7 @@ pub fn encode_float_single(value: f32, buffer: &mut [u8]) -> Result<()> {
 /// # Errors
 /// Returns `CBKE510_NUMERIC_OVERFLOW` if the buffer has fewer than 8 bytes.
 #[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn encode_float_double(value: f64, buffer: &mut [u8]) -> Result<()> {
     encode_float_double_ieee_be(value, buffer)
 }

--- a/crates/copybook-contracts/src/feature_flags.rs
+++ b/crates/copybook-contracts/src/feature_flags.rs
@@ -530,8 +530,7 @@ impl FeatureFlagsHandle {
     pub fn is_enabled(&self, feature: Feature) -> bool {
         self.flags
             .read()
-            .map(|flags| flags.is_enabled(feature))
-            .unwrap_or(false)
+            .is_ok_and(|flags| flags.is_enabled(feature))
     }
 
     /// Enable a feature flag through the handle.

--- a/crates/copybook-core/src/audit/security.rs
+++ b/crates/copybook-core/src/audit/security.rs
@@ -421,8 +421,7 @@ impl SecurityMonitor {
         let priority = 16 * 8 + 4; // 132
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_secs());
         format!(
             "<{}>1 {} copybook-rs SecurityMonitor - {} - {}",
             priority, timestamp, violation.violation_id, violation.description

--- a/crates/copybook-core/src/projection.rs
+++ b/crates/copybook-core/src/projection.rs
@@ -44,6 +44,8 @@ use std::collections::HashSet;
 /// assert_eq!(projected.fields[0].children.len(), 1);
 /// assert_eq!(projected.fields[0].children[0].name, "ID");
 /// ```
+#[inline]
+#[must_use = "Handle the Result or propagate the error"]
 pub fn project_schema(schema: &Schema, selections: &[String]) -> Result<Schema> {
     if selections.is_empty() {
         return Ok(Schema::from_fields(Vec::new()));

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,6 +7,11 @@ Automation and utility scripts for copybook-rs development and CI/CD.
 - **bench.sh** / **bench.bat** - Cross-platform benchmark execution
 - **performance_test.rs** - Performance regression testing
 
+## Repository Checks
+- **check-public-result-docs.sh** - Rust-backed public `Result` API documentation and attribute guard
+- **check_no_unwrap_expect.sh** - Rust-backed panic-call guard
+- **guard-hotpaths.sh** - Rust-backed hot-path allocation guard
+
 ## Development Automation
 - **adapt-review-agents.py** - Agent configuration adaptation utility
 - **final-cleanup-agents.py** - Agent cleanup and finalization
@@ -39,7 +44,8 @@ python scripts/fix-agent-issues.py
 - Batch files (.bat) for Windows
 - Python scripts (.py) for cross-platform automation
 
-These scripts complement the main build system and are used for specialized development tasks.
+These scripts complement the main build system and are used for specialized development tasks. Shell entrypoints are thin compatibility wrappers where a Rust implementation exists under `tools/copybook-scripts`.
+
 ## License
 
 Licensed under **AGPL-3.0-or-later**. See [LICENSE](../LICENSE).

--- a/scripts/check-public-result-docs.sh
+++ b/scripts/check-public-result-docs.sh
@@ -3,23 +3,25 @@
 # Lists public Result fns missing #[inline]/#[must_use]/# Errors
 set -euo pipefail
 
-scan_dirs=("crates/copybook-codec/src" "crates/copybook-core/src")
-miss=0
+ROOT_DIR="$(git rev-parse --show-toplevel)"
 
-for dir in "${scan_dirs[@]}"; do
-  while IFS=: read -r file line sig; do
-    # Inspect a small window above the signature for attrs/docs
-    hdr="$(sed -n "$((line-4)),$((line-1))p" "$file")"
-    if ! printf '%s\n' "$hdr" | rg -q '^\s*#\[\s*inline\s*\]'; then
-      echo "missing #[inline]      @ $file:$line"; miss=1
-    fi
-    if ! printf '%s\n' "$hdr" | rg -q '^\s*#\[\s*must_use[^\]]*\]'; then
-      echo "missing #[must_use]    @ $file:$line"; miss=1
-    fi
-    if ! printf '%s\n' "$hdr" | rg -q '^\s*///\s*#\s*Errors'; then
-      echo "missing doc '# Errors' @ $file:$line"; miss=1
-    fi
-  done < <(rg -n '^\s*pub\s+fn\s+\w+.*->\s*Result<' "$dir")
-done
+bootstrap_rustup() {
+  if [ -n "${HOME:-}" ] && [ -f "$HOME/.cargo/env" ]; then
+    # Non-login bash shells may not populate Rust's shims on PATH.
+    . "$HOME/.cargo/env"
+  fi
+}
 
-exit $miss
+run_cargo() {
+  bootstrap_rustup
+
+  if command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q '^stable'; then
+    rustup run stable cargo "$@"
+  elif command -v rustup.exe >/dev/null 2>&1 && rustup.exe toolchain list | grep -q '^stable'; then
+    rustup.exe run stable cargo "$@"
+  else
+    cargo "$@"
+  fi
+}
+
+run_cargo run --quiet --manifest-path "$ROOT_DIR/tools/copybook-scripts/Cargo.toml" -- check-public-result-docs

--- a/tools/README.md
+++ b/tools/README.md
@@ -31,6 +31,7 @@ Small Rust-native replacements for repository-maintenance shell scripts.
 ```bash
 cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- check-no-unwrap-expect
 cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- guard-hotpaths
+cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- check-public-result-docs
 cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- perf-annotate-host
 cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- soak-dispatch
 cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- clean-merge-conflicts path/to/file.rs

--- a/tools/copybook-scripts/Cargo.toml
+++ b/tools/copybook-scripts/Cargo.toml
@@ -20,6 +20,7 @@ anyhow.workspace = true
 chrono = { workspace = true }
 clap.workspace = true
 num_cpus = { workspace = true }
+regex.workspace = true
 serde_json.workspace = true
 
 [lints]

--- a/tools/copybook-scripts/src/main.rs
+++ b/tools/copybook-scripts/src/main.rs
@@ -262,13 +262,19 @@ fn rust_item_header(lines: &[&str], function_line_index: usize) -> Vec<String> {
 fn missing_public_result_docs_for_source(
     path: &Path,
     source: &str,
-    signature_regex: &Regex,
+    function_start_regex: &Regex,
+    result_signature_regex: &Regex,
 ) -> Vec<PublicResultDocFinding> {
     let lines: Vec<&str> = source.lines().collect();
     let mut findings = Vec::new();
 
     for (index, line) in lines.iter().enumerate() {
-        if !signature_regex.is_match(line) {
+        if !function_start_regex.is_match(line) {
+            continue;
+        }
+
+        let signature = collect_function_signature(&lines, index);
+        if !result_signature_regex.is_match(&signature) {
             continue;
         }
 
@@ -312,8 +318,27 @@ fn missing_public_result_docs_for_source(
     findings
 }
 
+fn collect_function_signature(lines: &[&str], function_line_index: usize) -> String {
+    let mut signature = String::new();
+
+    for line in &lines[function_line_index..] {
+        if !signature.is_empty() {
+            signature.push(' ');
+        }
+        signature.push_str(line.trim());
+
+        if line.contains('{') || line.contains(';') {
+            break;
+        }
+    }
+
+    signature
+}
+
 fn collect_public_result_docs_findings(root: &Path) -> Result<Vec<PublicResultDocFinding>> {
-    let signature_regex = Regex::new(r"^\s*pub\s+fn\s+\w+.*->\s*Result<")?;
+    let function_start_regex = Regex::new(r"^\s*pub\s+fn\s+\w+")?;
+    let result_signature_regex =
+        Regex::new(r"^\s*pub\s+fn\s+\w+.*->\s*(?:[A-Za-z_]\w*::)*Result<")?;
     let scan_dirs = [
         root.join("crates").join("copybook-codec").join("src"),
         root.join("crates").join("copybook-core").join("src"),
@@ -331,7 +356,8 @@ fn collect_public_result_docs_findings(root: &Path) -> Result<Vec<PublicResultDo
             findings.extend(missing_public_result_docs_for_source(
                 &path,
                 &source,
-                &signature_regex,
+                &function_start_regex,
+                &result_signature_regex,
             ));
         }
     }
@@ -524,7 +550,14 @@ mod tests {
     use super::*;
 
     fn signature_regex() -> Regex {
-        match Regex::new(r"^\s*pub\s+fn\s+\w+.*->\s*Result<") {
+        match Regex::new(r"^\s*pub\s+fn\s+\w+.*->\s*(?:[A-Za-z_]\w*::)*Result<") {
+            Ok(regex) => regex,
+            Err(err) => panic!("test regex must compile: {err}"),
+        }
+    }
+
+    fn function_start_regex() -> Regex {
+        match Regex::new(r"^\s*pub\s+fn\s+\w+") {
             Ok(regex) => regex,
             Err(err) => panic!("test regex must compile: {err}"),
         }
@@ -548,6 +581,7 @@ pub fn decode_value() -> Result<()> {
         let findings = missing_public_result_docs_for_source(
             Path::new("src/lib.rs"),
             source,
+            &function_start_regex(),
             &signature_regex(),
         );
 
@@ -566,6 +600,7 @@ pub fn decode_value() -> Result<()> {
         let findings = missing_public_result_docs_for_source(
             Path::new("src/lib.rs"),
             source,
+            &function_start_regex(),
             &signature_regex(),
         );
         let checks: Vec<PublicResultDocCheck> =
@@ -579,5 +614,32 @@ pub fn decode_value() -> Result<()> {
                 PublicResultDocCheck::ErrorsDoc,
             ]
         );
+    }
+
+    #[test]
+    fn public_result_doc_check_reports_multiline_result_signatures() {
+        let source = r#"
+/// Encode a value.
+///
+/// # Errors
+/// Returns an encode error.
+#[inline]
+pub fn encode_value(
+    value: u32,
+    buffer: &mut [u8],
+) -> std::result::Result<(), Error> {
+    Ok(())
+}
+"#;
+
+        let findings = missing_public_result_docs_for_source(
+            Path::new("src/lib.rs"),
+            source,
+            &function_start_regex(),
+            &signature_regex(),
+        );
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].check, PublicResultDocCheck::MustUse);
     }
 }

--- a/tools/copybook-scripts/src/main.rs
+++ b/tools/copybook-scripts/src/main.rs
@@ -9,6 +9,7 @@ use std::process::Command;
 use anyhow::{Context, Result, bail};
 use chrono::SecondsFormat;
 use clap::{Parser, Subcommand};
+use regex::Regex;
 use serde_json::{Map, Value};
 
 #[derive(Debug, Parser)]
@@ -29,6 +30,7 @@ enum CommandKind {
         #[arg(value_name = "PATH")]
         file: PathBuf,
     },
+    CheckPublicResultDocs,
 }
 
 fn main() -> Result<()> {
@@ -39,6 +41,7 @@ fn main() -> Result<()> {
         CommandKind::PerfAnnotateHost => perf_annotate_host(),
         CommandKind::SoakDispatch => soak_dispatch(),
         CommandKind::CleanMergeConflicts { file } => clean_merge_conflicts(file),
+        CommandKind::CheckPublicResultDocs => check_public_result_docs(),
     }
 }
 
@@ -207,6 +210,185 @@ fn guard_hotpaths() -> Result<()> {
     Ok(())
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PublicResultDocCheck {
+    Inline,
+    MustUse,
+    ErrorsDoc,
+}
+
+impl PublicResultDocCheck {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Inline => "missing #[inline]",
+            Self::MustUse => "missing #[must_use]",
+            Self::ErrorsDoc => "missing doc '# Errors'",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PublicResultDocFinding {
+    check: PublicResultDocCheck,
+    path: PathBuf,
+    line: usize,
+}
+
+fn rust_item_header(lines: &[&str], function_line_index: usize) -> Vec<String> {
+    let mut header = Vec::new();
+    let mut cursor = function_line_index;
+
+    while cursor > 0 {
+        cursor -= 1;
+        let line = lines[cursor];
+        let trimmed = line.trim_start();
+
+        if trimmed.starts_with("///")
+            || trimmed.starts_with("#[")
+            || trimmed.is_empty()
+            || trimmed.starts_with("//")
+        {
+            header.push(line.to_string());
+            continue;
+        }
+
+        break;
+    }
+
+    header.reverse();
+    header
+}
+
+fn missing_public_result_docs_for_source(
+    path: &Path,
+    source: &str,
+    signature_regex: &Regex,
+) -> Vec<PublicResultDocFinding> {
+    let lines: Vec<&str> = source.lines().collect();
+    let mut findings = Vec::new();
+
+    for (index, line) in lines.iter().enumerate() {
+        if !signature_regex.is_match(line) {
+            continue;
+        }
+
+        let header = rust_item_header(&lines, index);
+        let line_number = index + 1;
+
+        if !header.iter().any(|line| {
+            let trimmed = line.trim_start();
+            trimmed.starts_with("#[inline]") || trimmed.starts_with("#[inline(")
+        }) {
+            findings.push(PublicResultDocFinding {
+                check: PublicResultDocCheck::Inline,
+                path: path.to_path_buf(),
+                line: line_number,
+            });
+        }
+
+        if !header.iter().any(|line| {
+            let trimmed = line.trim_start();
+            trimmed.starts_with("#[must_use")
+        }) {
+            findings.push(PublicResultDocFinding {
+                check: PublicResultDocCheck::MustUse,
+                path: path.to_path_buf(),
+                line: line_number,
+            });
+        }
+
+        if !header
+            .iter()
+            .any(|line| line.trim_start().starts_with("/// # Errors"))
+        {
+            findings.push(PublicResultDocFinding {
+                check: PublicResultDocCheck::ErrorsDoc,
+                path: path.to_path_buf(),
+                line: line_number,
+            });
+        }
+    }
+
+    findings
+}
+
+fn collect_public_result_docs_findings(root: &Path) -> Result<Vec<PublicResultDocFinding>> {
+    let signature_regex = Regex::new(r"^\s*pub\s+fn\s+\w+.*->\s*Result<")?;
+    let scan_dirs = [
+        root.join("crates").join("copybook-codec").join("src"),
+        root.join("crates").join("copybook-core").join("src"),
+    ];
+    let mut findings = Vec::new();
+
+    for scan_dir in scan_dirs {
+        let mut paths = Vec::new();
+        collect_rs_files(&scan_dir, &mut paths)?;
+        paths.sort();
+
+        for path in paths {
+            let source = fs::read_to_string(&path)
+                .with_context(|| format!("failed to read {}", path.display()))?;
+            findings.extend(missing_public_result_docs_for_source(
+                &path,
+                &source,
+                &signature_regex,
+            ));
+        }
+    }
+
+    Ok(findings)
+}
+
+fn collect_rs_files(root: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    let mut entries = vec![root.to_path_buf()];
+
+    while let Some(path) = entries.pop() {
+        for item in fs::read_dir(&path)? {
+            let entry = item?;
+            let file_type = entry.file_type()?;
+            let entry_path = entry.path();
+
+            if file_type.is_dir() {
+                entries.push(entry_path);
+                continue;
+            }
+
+            if file_type.is_file()
+                && entry_path.extension().and_then(|ext| ext.to_str()) == Some("rs")
+            {
+                out.push(entry_path);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn check_public_result_docs() -> Result<()> {
+    let root = workspace_root()?;
+    let findings = collect_public_result_docs_findings(&root)?;
+
+    for finding in &findings {
+        let rel = finding.path.strip_prefix(&root).unwrap_or(&finding.path);
+        println!(
+            "{:<23} @ {}:{}",
+            finding.check.label(),
+            rel.display(),
+            finding.line
+        );
+    }
+
+    if !findings.is_empty() {
+        bail!(
+            "public Result function documentation check found {} issue(s)",
+            findings.len()
+        );
+    }
+
+    println!("✅ Public Result function documentation clean");
+    Ok(())
+}
+
 fn parse_cpu_model() -> String {
     fs::read_to_string("/proc/cpuinfo")
         .ok()
@@ -335,4 +517,67 @@ fn clean_merge_conflicts(file: PathBuf) -> Result<()> {
 
     fs::write(&target, out).with_context(|| format!("failed to write {}", target.display()))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn signature_regex() -> Regex {
+        match Regex::new(r"^\s*pub\s+fn\s+\w+.*->\s*Result<") {
+            Ok(regex) => regex,
+            Err(err) => panic!("test regex must compile: {err}"),
+        }
+    }
+
+    #[test]
+    fn public_result_doc_check_accepts_full_rust_item_header() {
+        let source = r#"
+/// Decode a value.
+///
+/// # Errors
+/// Returns a decode error.
+#[inline]
+#[allow(clippy::too_many_lines)]
+#[must_use = "Handle the Result or propagate the error"]
+pub fn decode_value() -> Result<()> {
+    Ok(())
+}
+"#;
+
+        let findings = missing_public_result_docs_for_source(
+            Path::new("src/lib.rs"),
+            source,
+            &signature_regex(),
+        );
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn public_result_doc_check_reports_missing_contract_items() {
+        let source = r#"
+/// Decode a value.
+pub fn decode_value() -> Result<()> {
+    Ok(())
+}
+"#;
+
+        let findings = missing_public_result_docs_for_source(
+            Path::new("src/lib.rs"),
+            source,
+            &signature_regex(),
+        );
+        let checks: Vec<PublicResultDocCheck> =
+            findings.iter().map(|finding| finding.check).collect();
+
+        assert_eq!(
+            checks,
+            vec![
+                PublicResultDocCheck::Inline,
+                PublicResultDocCheck::MustUse,
+                PublicResultDocCheck::ErrorsDoc,
+            ]
+        );
+    }
 }


### PR DESCRIPTION
### Motivation

- Replace the shell/RG public `Result` API guard with a Rust-native checker that is easier to test and maintain.
- Keep the public API contract explicit: `#[inline]`, `#[must_use]`, and `/// # Errors` docs on public `Result` functions in `copybook-core` and `copybook-codec`.
- Refresh this older branch with the current CI/security baseline so checks run against the same gates as the newer cleanup PRs.

### Description

- Added `check-public-result-docs` to `tools/copybook-scripts` and kept `scripts/check-public-result-docs.sh` as a compatibility wrapper.
- Added Rust tests for complete item headers, missing contract items, and multi-line public `Result` signatures.
- Fixed the scanner to collect full function signatures before matching `Result`, including qualified `std::result::Result`-style returns.
- Annotated public `Result` APIs surfaced by the stricter scanner, including determinism helpers, edited PIC helpers, sign-separate encoding, and float format encoders.
- Applied the shared CI/security baseline commits used by the surrounding PR cleanup stack.

### Testing

- `cargo +1.95.0 fmt --all --check`
- `cargo +1.95.0 test -p copybook-scripts`
- `bash scripts/check-public-result-docs.sh`
- `cargo +1.95.0 clippy -p copybook-scripts --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `cargo +1.95.0 clippy -p copybook-core -p copybook-codec --lib --bins --examples --all-features -- -D warnings -W clippy::pedantic`
- `cargo +1.95.0 clippy -p copybook-core -p copybook-codec --tests --all-features -- -D warnings -A clippy::unwrap_used -A clippy::expect_used -A clippy::panic -A clippy::dbg_macro -A clippy::print_stdout -A clippy::print_stderr -A clippy::missing_inline_in_public_items -A clippy::duplicated_attributes -A deprecated`
- `cargo +1.95.0 test -p copybook-core -p copybook-codec`
- `cargo +1.95.0 clippy --workspace --lib --bins --examples --all-features -- -D warnings -W clippy::pedantic`
- `cargo +1.95.0 clippy --workspace --tests --all-features -- -D warnings -A clippy::unwrap_used -A clippy::expect_used -A clippy::panic -A clippy::dbg_macro -A clippy::print_stdout -A clippy::print_stderr -A clippy::missing_inline_in_public_items -A clippy::duplicated_attributes -A deprecated`
- `cargo deny --workspace --all-features check`
- `git diff --check origin/main...HEAD`
- `git diff --check`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d189207c833382950f8ecfaa8287)