### PR TITLE
refactor(scripts): port agent cleanup utilities to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,6 +1256,7 @@ dependencies = [
  "chrono",
  "clap",
  "num_cpus",
+ "regex",
  "serde_json",
 ]
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,9 +8,10 @@ Automation and utility scripts for copybook-rs development and CI/CD.
 - **performance_test.rs** - Performance regression testing
 
 ## Development Automation
-- **adapt-review-agents.py** - Agent configuration adaptation utility
-- **final-cleanup-agents.py** - Agent cleanup and finalization
-- **fix-agent-issues.py** - Agent configuration repair tool
+- **copybook-scripts adapt-review-agents** - Native Rust agent configuration adaptation utility
+- **copybook-scripts final-cleanup-agents** - Native Rust agent cleanup and finalization
+- **copybook-scripts fix-agent-issues** - Native Rust agent configuration repair tool
+- **adapt-review-agents.py**, **final-cleanup-agents.py**, and **fix-agent-issues.py** - Compatibility wrappers that delegate to the Rust tool
 
 ## Usage
 
@@ -28,16 +29,21 @@ Scripts are typically run as part of development workflows:
 ### Agent Management
 ```bash
 # Adapt agent configurations
-python scripts/adapt-review-agents.py
+cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- adapt-review-agents
 
 # Fix agent configuration issues
+cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- fix-agent-issues
+
+# Compatibility wrappers remain available for existing automation
+python scripts/adapt-review-agents.py
 python scripts/fix-agent-issues.py
 ```
 
 ## Platform Support
 - Shell scripts (.sh) for Unix-like systems
 - Batch files (.bat) for Windows
-- Python scripts (.py) for cross-platform automation
+- Native Rust utilities in `tools/copybook-scripts` for repository automation
+- Python scripts (.py) are compatibility wrappers for existing automation
 
 These scripts complement the main build system and are used for specialized development tasks.
 ## License

--- a/scripts/adapt-review-agents.py
+++ b/scripts/adapt-review-agents.py
@@ -4,15 +4,21 @@
 
 import subprocess
 import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 sys.exit(
-    subprocess.call([
-        "cargo",
-        "run",
-        "--quiet",
-        "--manifest-path",
-        "tools/copybook-scripts/Cargo.toml",
-        "--",
-        "adapt-review-agents",
-    ])
+    subprocess.call(
+        [
+            "cargo",
+            "run",
+            "--quiet",
+            "--manifest-path",
+            "tools/copybook-scripts/Cargo.toml",
+            "--",
+            "adapt-review-agents",
+        ],
+        cwd=REPO_ROOT,
+    )
 )

--- a/scripts/adapt-review-agents.py
+++ b/scripts/adapt-review-agents.py
@@ -1,146 +1,18 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""
-Script to adapt all review agents in .claude/agents4/review/ to copybook-rs standards.
-This replaces BitNet.rs-specific content with copybook-rs enterprise mainframe patterns.
-"""
+"""Compatibility wrapper for the native Rust copybook-scripts implementation."""
 
-import os
-import re
-from pathlib import Path
+import subprocess
+import sys
 
-# Base directory for review agents
-AGENTS_DIR = Path(".claude/agents4/review/")
-
-# Mapping of BitNet.rs terms to copybook-rs terms
-REPLACEMENTS = {
-    # Core domain replacement
-    "BitNet.rs neural network inference": "copybook-rs enterprise mainframe data processing",
-    "BitNet neural network": "copybook-rs enterprise mainframe",
-    "BitNet.rs": "copybook-rs",
-    "neural network": "COBOL parsing",
-    "quantization": "COBOL parsing",
-    "inference": "data conversion",
-    "GPU": "enterprise performance",
-
-    # Technical replacements
-    "I2S, TL1, TL2": "DISPLAY, COMP, COMP-3",
-    "quantization accuracy": "COBOL parsing accuracy",
-    "cross-validation": "mainframe compatibility",
-    "GGUF": "EBCDIC",
-    "tensor": "field",
-    "model": "copybook",
-    "CUDA": "SIMD",
-
-    # Performance targets
-    ">99% accuracy": "enterprise performance targets (DISPLAY ≥ 4.1 GiB/s, COMP-3 ≥ 560 MiB/s)",
-    "99.8%": "4.1 GiB/s",
-    "99.6%": "560 MiB/s",
-
-    # Crate names
-    "bitnet-quantization": "copybook-core",
-    "bitnet-kernels": "copybook-codec",
-    "bitnet-inference": "copybook-cli",
-    "bitnet-wasm": "copybook-gen",
-    "bitnet-tokenizers": "copybook-bench",
-
-    # Commands
-    "--no-default-features --features cpu": "--workspace",
-    "--no-default-features --features gpu": "--workspace --release",
-    "cargo run -p xtask -- crossval": "cargo xtask ci",
-    "cargo run -p xtask -- benchmark": "cargo bench --package copybook-bench",
-    "./scripts/verify-tests.sh": "cargo xtask ci --quick",
-
-    # Error patterns
-    "CUDA unavailable": "xtask unavailable",
-    "GPU memory": "parsing memory",
-    "C++ reference": "mainframe compatibility",
-
-    # Evidence patterns
-    "CPU: ok, GPU: ok": "workspace release ok",
-    "tokens/sec": "records/sec",
-    "I2S: 99.X%": "DISPLAY: X.Y GiB/s",
-
-    # Architecture
-    "quantization kernels": "COBOL parsing kernels",
-    "inference pipeline": "data processing pipeline",
-    "1-bit neural networks": "enterprise mainframe data processing",
-}
-
-def adapt_agent_file(filepath):
-    """Adapt a single agent file to copybook-rs standards."""
-    print(f"Processing {filepath.name}...")
-
-    with open(filepath, 'r') as f:
-        content = f.read()
-
-    # Apply replacements
-    original_content = content
-    for old_term, new_term in REPLACEMENTS.items():
-        content = content.replace(old_term, new_term)
-
-    # Specific patterns for workspace structure
-    content = re.sub(
-        r'bitnet-[a-zA-Z]+',
-        lambda m: {
-            'bitnet-quantization': 'copybook-core',
-            'bitnet-kernels': 'copybook-codec',
-            'bitnet-inference': 'copybook-cli',
-            'bitnet-wasm': 'copybook-gen',
-            'bitnet-tokenizers': 'copybook-bench'
-        }.get(m.group(0), 'copybook-core'),
-        content
-    )
-
-    # Update command patterns
-    content = re.sub(
-        r'cargo test --workspace --no-default-features --features \w+',
-        'cargo test --workspace',
-        content
-    )
-
-    content = re.sub(
-        r'cargo build --release --no-default-features --features \w+',
-        'cargo build --workspace --release',
-        content
-    )
-
-    # Update evidence patterns
-    content = re.sub(
-        r'tests: cargo test: (\d+)/(\d+) pass; CPU: (\d+)/(\d+), GPU: (\d+)/(\d+); quarantined: (\d+) \(linked\)',
-        r'tests: nextest: \1/\2 pass; enterprise validation: \3/\4; quarantined: \7 (linked)',
-        content
-    )
-
-    # Only write if content changed
-    if content != original_content:
-        with open(filepath, 'w') as f:
-            f.write(content)
-        print(f"  ✓ Updated {filepath.name}")
-        return True
-    else:
-        print(f"  - No changes needed for {filepath.name}")
-        return False
-
-def main():
-    """Process all agent files in the review directory."""
-    if not AGENTS_DIR.exists():
-        print(f"Error: Directory {AGENTS_DIR} does not exist")
-        return
-
-    agent_files = list(AGENTS_DIR.glob("*.md"))
-    if not agent_files:
-        print(f"No .md files found in {AGENTS_DIR}")
-        return
-
-    print(f"Found {len(agent_files)} agent files to process")
-
-    updated_count = 0
-    for agent_file in sorted(agent_files):
-        if adapt_agent_file(agent_file):
-            updated_count += 1
-
-    print(f"\nCompleted! Updated {updated_count} of {len(agent_files)} agent files.")
-
-if __name__ == "__main__":
-    main()
+sys.exit(
+    subprocess.call([
+        "cargo",
+        "run",
+        "--quiet",
+        "--manifest-path",
+        "tools/copybook-scripts/Cargo.toml",
+        "--",
+        "adapt-review-agents",
+    ])
+)

--- a/scripts/final-cleanup-agents.py
+++ b/scripts/final-cleanup-agents.py
@@ -4,15 +4,21 @@
 
 import subprocess
 import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 sys.exit(
-    subprocess.call([
-        "cargo",
-        "run",
-        "--quiet",
-        "--manifest-path",
-        "tools/copybook-scripts/Cargo.toml",
-        "--",
-        "final-cleanup-agents",
-    ])
+    subprocess.call(
+        [
+            "cargo",
+            "run",
+            "--quiet",
+            "--manifest-path",
+            "tools/copybook-scripts/Cargo.toml",
+            "--",
+            "final-cleanup-agents",
+        ],
+        cwd=REPO_ROOT,
+    )
 )

--- a/scripts/final-cleanup-agents.py
+++ b/scripts/final-cleanup-agents.py
@@ -1,105 +1,18 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""
-Final comprehensive cleanup script for review agents.
-"""
+"""Compatibility wrapper for the native Rust copybook-scripts implementation."""
 
-import os
-import re
-from pathlib import Path
+import subprocess
+import sys
 
-# Base directory for review agents
-AGENTS_DIR = Path(".claude/agents4/review/")
-
-def final_cleanup_agent(filepath):
-    """Perform final cleanup of agent file."""
-    print(f"Final cleanup of {filepath.name}...")
-
-    with open(filepath, 'r') as f:
-        content = f.read()
-
-    original_content = content
-
-    # Fix remaining garbled terms
-    content = content.replace("1-bit quantized COBOL parsings", "enterprise mainframe data processing")
-    content = content.replace("Neural Network Security Testing (NNST)", "COBOL Parsing Security Testing")
-    content = content.replace("HuggingFace tokens", "mainframe authentication tokens")
-    content = content.replace("copybook poisoning attacks", "malicious copybook attacks")
-
-    # Fix workspace references
-    content = content.replace("copybook-rs workspace crates", "copybook-rs 5-crate workspace (core, codec, cli, gen, bench)")
-
-    # Fix command patterns
-    content = content.replace("cargo clippy --workspace --all-targets --workspace", "cargo clippy --workspace --all-targets")
-    content = content.replace("--workspace -- -D warnings", "-- -D warnings -W clippy::pedantic")
-
-    # Fix technical descriptions
-    content = content.replace("COBOL parsing COBOL parsing", "COBOL parsing")
-    content = content.replace("enterprise performance/CPU", "high-performance")
-    content = content.replace("enterprise performance memory", "memory")
-    content = content.replace("SIMD enterprise performance", "SIMD CPU")
-
-    # Fix performance metrics formatting
-    content = content.replace("GiB/s for DISPLAY, MiB/s for COMP-3ond", "records/second")
-    content = content.replace("GiB/s for DISPLAY, MiB/s for COMP-3", "GiB/s (DISPLAY), MiB/s (COMP-3)")
-
-    # Fix duplicate workspace patterns
-    content = content.replace("cargo bench --workspace --workspace", "cargo bench --package copybook-bench")
-    content = content.replace("cargo test --workspace --workspace", "cargo test --workspace")
-
-    # Fix evidence patterns
-    content = content.replace("I2S ≥4.1 GiB/s, TL1 ≥560 MiB/s, TL2 ≥99.7%", "DISPLAY ≥4.1 GiB/s, COMP-3 ≥560 MiB/s")
-    content = content.replace("I2S: 4.1 GiB/s", "DISPLAY: 4.1+ GiB/s")
-    content = content.replace("TL1: 560 MiB/s", "COMP-3: 560+ MiB/s")
-
-    # Fix specific technical terms
-    content = content.replace("copybook weight handling", "copybook field handling")
-    content = content.replace("weight data conversion", "field layout computation")
-    content = content.replace("Tensor Core acceleration", "SIMD acceleration")
-    content = content.replace("mixed precision", "high-precision")
-
-    # Fix command examples
-    content = content.replace("--tokens 128", "--batch-size 128")
-    content = content.replace("--copybook examples/copybook.cpy --tokens", "--input examples/data.bin --copybook examples/schema.cpy --records")
-
-    # Fix remaining neural network references
-    content = content.replace("Neural Network Validation", "COBOL Parsing Validation")
-    content = content.replace("attention computation", "field processing")
-    content = content.replace("KV cache", "field cache")
-
-    # Clean up garbled validation patterns
-    content = re.sub(r'test_dequantize_cpu_and_gpu_paths', 'enterprise_performance_validation', content)
-    content = re.sub(r'COPYBOOK_DATA="[^"]*"', 'COPYBOOK_TEST_DATA="examples/test.cpy"', content)
-
-    # Only write if content changed
-    if content != original_content:
-        with open(filepath, 'w') as f:
-            f.write(content)
-        print(f"  ✓ Cleaned up {filepath.name}")
-        return True
-    else:
-        print(f"  - No cleanup needed for {filepath.name}")
-        return False
-
-def main():
-    """Process all agent files for final cleanup."""
-    if not AGENTS_DIR.exists():
-        print(f"Error: Directory {AGENTS_DIR} does not exist")
-        return
-
-    agent_files = list(AGENTS_DIR.glob("*.md"))
-    if not agent_files:
-        print(f"No .md files found in {AGENTS_DIR}")
-        return
-
-    print(f"Found {len(agent_files)} agent files for final cleanup")
-
-    cleaned_count = 0
-    for agent_file in sorted(agent_files):
-        if final_cleanup_agent(agent_file):
-            cleaned_count += 1
-
-    print(f"\nCompleted! Final cleanup applied to {cleaned_count} of {len(agent_files)} agent files.")
-
-if __name__ == "__main__":
-    main()
+sys.exit(
+    subprocess.call([
+        "cargo",
+        "run",
+        "--quiet",
+        "--manifest-path",
+        "tools/copybook-scripts/Cargo.toml",
+        "--",
+        "final-cleanup-agents",
+    ])
+)

--- a/scripts/fix-agent-issues.py
+++ b/scripts/fix-agent-issues.py
@@ -1,86 +1,18 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""
-Script to fix issues introduced by the bulk agent adaptation.
-"""
+"""Compatibility wrapper for the native Rust copybook-scripts implementation."""
 
-import os
-import re
-from pathlib import Path
+import subprocess
+import sys
 
-# Base directory for review agents
-AGENTS_DIR = Path(".claude/agents4/review/")
-
-def fix_agent_file(filepath):
-    """Fix specific issues in agent files."""
-    print(f"Fixing {filepath.name}...")
-
-    with open(filepath, 'r') as f:
-        content = f.read()
-
-    original_content = content
-
-    # Fix incorrect "copybook:" entries in YAML frontmatter
-    content = re.sub(r'^copybook: sonnet$', 'model: sonnet', content, flags=re.MULTILINE)
-
-    # Fix doubled workspace flags
-    content = content.replace('--workspace --workspace', '--workspace')
-    content = content.replace('--workspace --release --workspace', '--workspace --release')
-
-    # Fix garbled command patterns
-    content = content.replace('copybook-core parsing', 'copybook-core')
-    content = content.replace('copybook-codec parsing', 'copybook-codec')
-    content = content.replace('deCOBOL parsing', 'data conversion')
-
-    # Fix specific performance patterns
-    content = content.replace('I2S: 4.1 GiB/s, TL1: 560 MiB/s, TL2: 99.7%', 'DISPLAY: ≥4.1 GiB/s, COMP-3: ≥560 MiB/s')
-    content = content.replace('copybook.gguf', 'copybook.cpy')
-    content = content.replace('copybooks/bitnet/', 'examples/')
-
-    # Fix garbled technical terms
-    content = content.replace('weight deCOBOL parsing', 'field layout computation')
-    content = content.replace('COBOL parsing/deCOBOL parsing', 'COBOL parsing/data conversion')
-    content = content.replace('COBOL parsing kernels (DISPLAY, COMP, COMP-3)', 'COBOL parsing engines (lexer, parser, AST)')
-
-    # Fix evidence patterns
-    content = content.replace('records/sec', 'GiB/s for DISPLAY, MiB/s for COMP-3')
-
-    # Fix specific technical terms
-    content = content.replace('BITNET_DETERMINISTIC=1', 'deterministic parsing')
-    content = content.replace('BITNET_EBCDIC', 'COPYBOOK_DATA')
-
-    # Fix workspace crate references
-    content = re.sub(r'bitnet-\*', 'copybook-*', content)
-
-    # Only write if content changed
-    if content != original_content:
-        with open(filepath, 'w') as f:
-            f.write(content)
-        print(f"  ✓ Fixed {filepath.name}")
-        return True
-    else:
-        print(f"  - No fixes needed for {filepath.name}")
-        return False
-
-def main():
-    """Process all agent files in the review directory."""
-    if not AGENTS_DIR.exists():
-        print(f"Error: Directory {AGENTS_DIR} does not exist")
-        return
-
-    agent_files = list(AGENTS_DIR.glob("*.md"))
-    if not agent_files:
-        print(f"No .md files found in {AGENTS_DIR}")
-        return
-
-    print(f"Found {len(agent_files)} agent files to fix")
-
-    fixed_count = 0
-    for agent_file in sorted(agent_files):
-        if fix_agent_file(agent_file):
-            fixed_count += 1
-
-    print(f"\nCompleted! Fixed {fixed_count} of {len(agent_files)} agent files.")
-
-if __name__ == "__main__":
-    main()
+sys.exit(
+    subprocess.call([
+        "cargo",
+        "run",
+        "--quiet",
+        "--manifest-path",
+        "tools/copybook-scripts/Cargo.toml",
+        "--",
+        "fix-agent-issues",
+    ])
+)

--- a/scripts/fix-agent-issues.py
+++ b/scripts/fix-agent-issues.py
@@ -4,15 +4,21 @@
 
 import subprocess
 import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 sys.exit(
-    subprocess.call([
-        "cargo",
-        "run",
-        "--quiet",
-        "--manifest-path",
-        "tools/copybook-scripts/Cargo.toml",
-        "--",
-        "fix-agent-issues",
-    ])
+    subprocess.call(
+        [
+            "cargo",
+            "run",
+            "--quiet",
+            "--manifest-path",
+            "tools/copybook-scripts/Cargo.toml",
+            "--",
+            "fix-agent-issues",
+        ],
+        cwd=REPO_ROOT,
+    )
 )

--- a/tools/copybook-scripts/Cargo.toml
+++ b/tools/copybook-scripts/Cargo.toml
@@ -20,6 +20,7 @@ anyhow.workspace = true
 chrono = { workspace = true }
 clap.workspace = true
 num_cpus = { workspace = true }
+regex.workspace = true
 serde_json.workspace = true
 
 [lints]

--- a/tools/copybook-scripts/src/main.rs
+++ b/tools/copybook-scripts/src/main.rs
@@ -9,6 +9,7 @@ use std::process::Command;
 use anyhow::{Context, Result, bail};
 use chrono::SecondsFormat;
 use clap::{Parser, Subcommand};
+use regex::Regex;
 use serde_json::{Map, Value};
 
 #[derive(Debug, Parser)]
@@ -29,6 +30,9 @@ enum CommandKind {
         #[arg(value_name = "PATH")]
         file: PathBuf,
     },
+    AdaptReviewAgents,
+    FixAgentIssues,
+    FinalCleanupAgents,
 }
 
 fn main() -> Result<()> {
@@ -39,6 +43,9 @@ fn main() -> Result<()> {
         CommandKind::PerfAnnotateHost => perf_annotate_host(),
         CommandKind::SoakDispatch => soak_dispatch(),
         CommandKind::CleanMergeConflicts { file } => clean_merge_conflicts(file),
+        CommandKind::AdaptReviewAgents => adapt_review_agents(),
+        CommandKind::FixAgentIssues => fix_agent_issues(),
+        CommandKind::FinalCleanupAgents => final_cleanup_agents(),
     }
 }
 
@@ -335,4 +342,300 @@ fn clean_merge_conflicts(file: PathBuf) -> Result<()> {
 
     fs::write(&target, out).with_context(|| format!("failed to write {}", target.display()))?;
     Ok(())
+}
+
+const AGENTS_REVIEW_DIR: &str = ".claude/agents4/review";
+
+#[derive(Clone, Copy)]
+enum TextRule {
+    Literal(&'static str, &'static str),
+    Regex(&'static str, &'static str),
+    BitnetCrate,
+}
+
+fn bitnet_crate_replacement(hit: &str) -> &str {
+    match hit {
+        "bitnet-quantization" => "copybook-core",
+        "bitnet-kernels" => "copybook-codec",
+        "bitnet-inference" => "copybook-cli",
+        "bitnet-wasm" => "copybook-gen",
+        "bitnet-tokenizers" => "copybook-bench",
+        _ => "copybook-core",
+    }
+}
+
+fn replace_bitnet_crate_names(content: &str) -> String {
+    let mut output = String::with_capacity(content.len());
+    let mut cursor = 0usize;
+
+    while let Some(relative_start) = content[cursor..].find("bitnet-") {
+        let start = cursor + relative_start;
+        output.push_str(&content[cursor..start]);
+
+        let mut end = start + "bitnet-".len();
+        for (offset, ch) in content[end..].char_indices() {
+            if !ch.is_ascii_alphabetic() {
+                break;
+            }
+            end = start + "bitnet-".len() + offset + ch.len_utf8();
+        }
+
+        output.push_str(bitnet_crate_replacement(&content[start..end]));
+        cursor = end;
+    }
+
+    output.push_str(&content[cursor..]);
+    output
+}
+
+fn apply_text_rules(mut content: String, rules: &[TextRule]) -> Result<String> {
+    for rule in rules {
+        match rule {
+            TextRule::Literal(from, to) => {
+                content = content.replace(from, to);
+            }
+            TextRule::Regex(pattern, replacement) => {
+                let re = Regex::new(pattern)
+                    .with_context(|| format!("invalid cleanup regex: {pattern}"))?;
+                content = re.replace_all(&content, *replacement).into_owned();
+            }
+            TextRule::BitnetCrate => {
+                content = replace_bitnet_crate_names(&content);
+            }
+        }
+    }
+
+    Ok(content)
+}
+
+fn agent_markdown_files(root: &Path) -> Result<Vec<PathBuf>> {
+    if !root.exists() {
+        bail!("Error: Directory {} does not exist", root.display());
+    }
+
+    let mut paths = Vec::new();
+    for item in fs::read_dir(root).with_context(|| format!("failed to read {}", root.display()))? {
+        let entry = item?;
+        let path = entry.path();
+        if entry.file_type()?.is_file() && path.extension().and_then(OsStr::to_str) == Some("md") {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+
+    if paths.is_empty() {
+        bail!("No .md files found in {}", root.display());
+    }
+
+    Ok(paths)
+}
+
+fn process_agent_files(action: &str, intro: &str, rules: &[TextRule]) -> Result<()> {
+    let root = workspace_root()?.join(AGENTS_REVIEW_DIR);
+    let agent_files = agent_markdown_files(&root)?;
+    println!("Found {} agent files {}", agent_files.len(), intro);
+
+    let mut changed_count = 0usize;
+    for path in agent_files {
+        let name = path
+            .file_name()
+            .and_then(OsStr::to_str)
+            .unwrap_or("<unknown>");
+        println!("{action} {name}...");
+
+        let original = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        let updated = apply_text_rules(original.clone(), rules)?;
+
+        if updated == original {
+            println!("  - No changes needed for {name}");
+            continue;
+        }
+
+        fs::write(&path, updated).with_context(|| format!("failed to write {}", path.display()))?;
+        changed_count += 1;
+        println!("  ✓ Updated {name}");
+    }
+
+    println!("\nCompleted! Updated {changed_count} agent files.");
+    Ok(())
+}
+
+const ADAPT_REVIEW_AGENT_RULES: &[TextRule] = &[
+    TextRule::Literal(
+        "BitNet.rs neural network inference",
+        "copybook-rs enterprise mainframe data processing",
+    ),
+    TextRule::Literal("BitNet neural network", "copybook-rs enterprise mainframe"),
+    TextRule::Literal("BitNet.rs", "copybook-rs"),
+    TextRule::Literal("neural network", "COBOL parsing"),
+    TextRule::Literal("quantization", "COBOL parsing"),
+    TextRule::Literal("inference", "data conversion"),
+    TextRule::Literal("GPU", "enterprise performance"),
+    TextRule::Literal("I2S, TL1, TL2", "DISPLAY, COMP, COMP-3"),
+    TextRule::Literal("quantization accuracy", "COBOL parsing accuracy"),
+    TextRule::Literal("cross-validation", "mainframe compatibility"),
+    TextRule::Literal("GGUF", "EBCDIC"),
+    TextRule::Literal("tensor", "field"),
+    TextRule::Literal("model", "copybook"),
+    TextRule::Literal("CUDA", "SIMD"),
+    TextRule::Literal(
+        ">99% accuracy",
+        "enterprise performance targets (DISPLAY ≥ 4.1 GiB/s, COMP-3 ≥ 560 MiB/s)",
+    ),
+    TextRule::Literal("99.8%", "4.1 GiB/s"),
+    TextRule::Literal("99.6%", "560 MiB/s"),
+    TextRule::Literal("bitnet-quantization", "copybook-core"),
+    TextRule::Literal("bitnet-kernels", "copybook-codec"),
+    TextRule::Literal("bitnet-inference", "copybook-cli"),
+    TextRule::Literal("bitnet-wasm", "copybook-gen"),
+    TextRule::Literal("bitnet-tokenizers", "copybook-bench"),
+    TextRule::Literal("--no-default-features --features cpu", "--workspace"),
+    TextRule::Literal(
+        "--no-default-features --features gpu",
+        "--workspace --release",
+    ),
+    TextRule::Literal("cargo run -p xtask -- crossval", "cargo xtask ci"),
+    TextRule::Literal(
+        "cargo run -p xtask -- benchmark",
+        "cargo bench --package copybook-bench",
+    ),
+    TextRule::Literal("./scripts/verify-tests.sh", "cargo xtask ci --quick"),
+    TextRule::Literal("CUDA unavailable", "xtask unavailable"),
+    TextRule::Literal("GPU memory", "parsing memory"),
+    TextRule::Literal("C++ reference", "mainframe compatibility"),
+    TextRule::Literal("CPU: ok, GPU: ok", "workspace release ok"),
+    TextRule::Literal("tokens/sec", "records/sec"),
+    TextRule::Literal("I2S: 99.X%", "DISPLAY: X.Y GiB/s"),
+    TextRule::Literal("quantization kernels", "COBOL parsing kernels"),
+    TextRule::Literal("inference pipeline", "data processing pipeline"),
+    TextRule::Literal(
+        "1-bit neural networks",
+        "enterprise mainframe data processing",
+    ),
+    TextRule::BitnetCrate,
+    TextRule::Regex(
+        r"cargo test --workspace --no-default-features --features \w+",
+        "cargo test --workspace",
+    ),
+    TextRule::Regex(
+        r"cargo build --release --no-default-features --features \w+",
+        "cargo build --workspace --release",
+    ),
+    TextRule::Regex(
+        r"tests: cargo test: (\d+)/(\d+) pass; CPU: (\d+)/(\d+), GPU: (\d+)/(\d+); quarantined: (\d+) \(linked\)",
+        "tests: nextest: $1/$2 pass; enterprise validation: $3/$4; quarantined: $7 (linked)",
+    ),
+];
+
+const FIX_AGENT_ISSUE_RULES: &[TextRule] = &[
+    TextRule::Regex(r"(?m)^copybook: sonnet$", "model: sonnet"),
+    TextRule::Literal("--workspace --workspace", "--workspace"),
+    TextRule::Literal("--workspace --release --workspace", "--workspace --release"),
+    TextRule::Literal("copybook-core parsing", "copybook-core"),
+    TextRule::Literal("copybook-codec parsing", "copybook-codec"),
+    TextRule::Literal("deCOBOL parsing", "data conversion"),
+    TextRule::Literal(
+        "I2S: 4.1 GiB/s, TL1: 560 MiB/s, TL2: 99.7%",
+        "DISPLAY: ≥4.1 GiB/s, COMP-3: ≥560 MiB/s",
+    ),
+    TextRule::Literal("copybook.gguf", "copybook.cpy"),
+    TextRule::Literal("copybooks/bitnet/", "examples/"),
+    TextRule::Literal("weight deCOBOL parsing", "field layout computation"),
+    TextRule::Literal(
+        "COBOL parsing/deCOBOL parsing",
+        "COBOL parsing/data conversion",
+    ),
+    TextRule::Literal(
+        "COBOL parsing kernels (DISPLAY, COMP, COMP-3)",
+        "COBOL parsing engines (lexer, parser, AST)",
+    ),
+    TextRule::Literal("records/sec", "GiB/s for DISPLAY, MiB/s for COMP-3"),
+    TextRule::Literal("BITNET_DETERMINISTIC=1", "deterministic parsing"),
+    TextRule::Literal("BITNET_EBCDIC", "COPYBOOK_DATA"),
+    TextRule::Regex(r"bitnet-\*", "copybook-*"),
+];
+
+const FINAL_CLEANUP_AGENT_RULES: &[TextRule] = &[
+    TextRule::Literal(
+        "1-bit quantized COBOL parsings",
+        "enterprise mainframe data processing",
+    ),
+    TextRule::Literal(
+        "Neural Network Security Testing (NNST)",
+        "COBOL Parsing Security Testing",
+    ),
+    TextRule::Literal("HuggingFace tokens", "mainframe authentication tokens"),
+    TextRule::Literal("copybook poisoning attacks", "malicious copybook attacks"),
+    TextRule::Literal(
+        "copybook-rs workspace crates",
+        "copybook-rs 5-crate workspace (core, codec, cli, gen, bench)",
+    ),
+    TextRule::Literal(
+        "cargo clippy --workspace --all-targets --workspace",
+        "cargo clippy --workspace --all-targets",
+    ),
+    TextRule::Literal(
+        "--workspace -- -D warnings",
+        "-- -D warnings -W clippy::pedantic",
+    ),
+    TextRule::Literal("COBOL parsing COBOL parsing", "COBOL parsing"),
+    TextRule::Literal("enterprise performance/CPU", "high-performance"),
+    TextRule::Literal("enterprise performance memory", "memory"),
+    TextRule::Literal("SIMD enterprise performance", "SIMD CPU"),
+    TextRule::Literal("GiB/s for DISPLAY, MiB/s for COMP-3ond", "records/second"),
+    TextRule::Literal(
+        "GiB/s for DISPLAY, MiB/s for COMP-3",
+        "GiB/s (DISPLAY), MiB/s (COMP-3)",
+    ),
+    TextRule::Literal(
+        "cargo bench --workspace --workspace",
+        "cargo bench --package copybook-bench",
+    ),
+    TextRule::Literal(
+        "cargo test --workspace --workspace",
+        "cargo test --workspace",
+    ),
+    TextRule::Literal(
+        "I2S ≥4.1 GiB/s, TL1 ≥560 MiB/s, TL2 ≥99.7%",
+        "DISPLAY ≥4.1 GiB/s, COMP-3 ≥560 MiB/s",
+    ),
+    TextRule::Literal("I2S: 4.1 GiB/s", "DISPLAY: 4.1+ GiB/s"),
+    TextRule::Literal("TL1: 560 MiB/s", "COMP-3: 560+ MiB/s"),
+    TextRule::Literal("copybook weight handling", "copybook field handling"),
+    TextRule::Literal("weight data conversion", "field layout computation"),
+    TextRule::Literal("Tensor Core acceleration", "SIMD acceleration"),
+    TextRule::Literal("mixed precision", "high-precision"),
+    TextRule::Literal("--tokens 128", "--batch-size 128"),
+    TextRule::Literal(
+        "--copybook examples/copybook.cpy --tokens",
+        "--input examples/data.bin --copybook examples/schema.cpy --records",
+    ),
+    TextRule::Literal("Neural Network Validation", "COBOL Parsing Validation"),
+    TextRule::Literal("attention computation", "field processing"),
+    TextRule::Literal("KV cache", "field cache"),
+    TextRule::Regex(
+        r"test_dequantize_cpu_and_gpu_paths",
+        "enterprise_performance_validation",
+    ),
+    TextRule::Regex(
+        r#"COPYBOOK_DATA="[^"]*""#,
+        "COPYBOOK_TEST_DATA=\"examples/test.cpy\"",
+    ),
+];
+
+fn adapt_review_agents() -> Result<()> {
+    process_agent_files("Processing", "to process", ADAPT_REVIEW_AGENT_RULES)
+}
+
+fn fix_agent_issues() -> Result<()> {
+    process_agent_files("Fixing", "to fix", FIX_AGENT_ISSUE_RULES)
+}
+
+fn final_cleanup_agents() -> Result<()> {
+    process_agent_files(
+        "Final cleanup of",
+        "for final cleanup",
+        FINAL_CLEANUP_AGENT_RULES,
+    )
 }

--- a/tools/copybook-scripts/src/main.rs
+++ b/tools/copybook-scripts/src/main.rs
@@ -355,7 +355,6 @@ enum TextRule {
 
 fn bitnet_crate_replacement(hit: &str) -> &str {
     match hit {
-        "bitnet-quantization" => "copybook-core",
         "bitnet-kernels" => "copybook-codec",
         "bitnet-inference" => "copybook-cli",
         "bitnet-wasm" => "copybook-gen",
@@ -466,6 +465,18 @@ const ADAPT_REVIEW_AGENT_RULES: &[TextRule] = &[
         "BitNet.rs neural network inference",
         "copybook-rs enterprise mainframe data processing",
     ),
+    TextRule::Regex(
+        r"cargo test --workspace --no-default-features --features \w+",
+        "cargo test --workspace",
+    ),
+    TextRule::Regex(
+        r"cargo build --release --no-default-features --features \w+",
+        "cargo build --workspace --release",
+    ),
+    TextRule::Regex(
+        r"tests: cargo test: (\d+)/(\d+) pass; CPU: (\d+)/(\d+), GPU: (\d+)/(\d+); quarantined: (\d+) \(linked\)",
+        "tests: nextest: $1/$2 pass; enterprise validation: $3/$4; quarantined: $7 (linked)",
+    ),
     TextRule::Literal("BitNet neural network", "copybook-rs enterprise mainframe"),
     TextRule::Literal("BitNet.rs", "copybook-rs"),
     TextRule::Literal("neural network", "COBOL parsing"),
@@ -514,18 +525,6 @@ const ADAPT_REVIEW_AGENT_RULES: &[TextRule] = &[
         "enterprise mainframe data processing",
     ),
     TextRule::BitnetCrate,
-    TextRule::Regex(
-        r"cargo test --workspace --no-default-features --features \w+",
-        "cargo test --workspace",
-    ),
-    TextRule::Regex(
-        r"cargo build --release --no-default-features --features \w+",
-        "cargo build --workspace --release",
-    ),
-    TextRule::Regex(
-        r"tests: cargo test: (\d+)/(\d+) pass; CPU: (\d+)/(\d+), GPU: (\d+)/(\d+); quarantined: (\d+) \(linked\)",
-        "tests: nextest: $1/$2 pass; enterprise validation: $3/$4; quarantined: $7 (linked)",
-    ),
 ];
 
 const FIX_AGENT_ISSUE_RULES: &[TextRule] = &[
@@ -593,6 +592,10 @@ const FINAL_CLEANUP_AGENT_RULES: &[TextRule] = &[
         "cargo bench --package copybook-bench",
     ),
     TextRule::Literal(
+        "cargo bench --workspace",
+        "cargo bench --package copybook-bench",
+    ),
+    TextRule::Literal(
         "cargo test --workspace --workspace",
         "cargo test --workspace",
     ),
@@ -638,4 +641,86 @@ fn final_cleanup_agents() -> Result<()> {
         "for final cleanup",
         FINAL_CLEANUP_AGENT_RULES,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ADAPT_REVIEW_AGENT_RULES, FINAL_CLEANUP_AGENT_RULES, FIX_AGENT_ISSUE_RULES,
+        apply_text_rules, replace_bitnet_crate_names,
+    };
+
+    fn apply_rules(input: &str, rules: &[super::TextRule]) -> String {
+        match apply_text_rules(input.to_string(), rules) {
+            Ok(output) => output,
+            Err(error) => panic!("{error}"),
+        }
+    }
+
+    #[test]
+    fn bitnet_crate_mapper_handles_known_and_default_crates() {
+        let input =
+            "bitnet-kernels bitnet-inference bitnet-quantization bitnet-tokenizers bitnet-extra";
+
+        assert_eq!(
+            replace_bitnet_crate_names(input),
+            "copybook-codec copybook-cli copybook-core copybook-bench copybook-core"
+        );
+    }
+
+    #[test]
+    fn adapt_review_rules_rewrite_commands_and_evidence() {
+        let input = concat!(
+            "BitNet.rs neural network inference\n",
+            "cargo test --workspace --no-default-features --features gpu\n",
+            "tests: cargo test: 9/10 pass; CPU: 4/5, GPU: 6/7; quarantined: 1 (linked)\n",
+        );
+
+        let output = apply_rules(input, ADAPT_REVIEW_AGENT_RULES);
+
+        assert!(output.contains("copybook-rs enterprise mainframe data processing"));
+        assert!(output.contains("cargo test --workspace"));
+        assert!(output.contains(
+            "tests: nextest: 9/10 pass; enterprise validation: 4/5; quarantined: 1 (linked)"
+        ));
+    }
+
+    #[test]
+    fn fix_agent_issue_rules_repair_frontmatter_and_workspace_terms() {
+        let input = concat!(
+            "---\n",
+            "copybook: sonnet\n",
+            "---\n",
+            "cargo test --workspace --workspace\n",
+            "bitnet-* copybook.gguf BITNET_EBCDIC\n",
+        );
+
+        let output = apply_rules(input, FIX_AGENT_ISSUE_RULES);
+
+        assert!(output.contains("model: sonnet"));
+        assert!(output.contains("cargo test --workspace"));
+        assert!(output.contains("copybook-* copybook.cpy COPYBOOK_DATA"));
+    }
+
+    #[test]
+    fn final_cleanup_rules_rewrite_remaining_agent_terms() {
+        let input = concat!(
+            "Neural Network Validation uses COPYBOOK_DATA=\"fixtures/demo.cpy\"\n",
+            "attention computation and KV cache\n",
+            "cargo bench --workspace --workspace\n",
+            "cargo bench --workspace\n",
+        );
+
+        let output = apply_rules(input, FINAL_CLEANUP_AGENT_RULES);
+
+        assert!(output.contains("COBOL Parsing Validation"));
+        assert!(output.contains("COPYBOOK_TEST_DATA=\"examples/test.cpy\""));
+        assert!(output.contains("field processing and field cache"));
+        assert_eq!(
+            output
+                .matches("cargo bench --package copybook-bench")
+                .count(),
+            2
+        );
+    }
 }


### PR DESCRIPTION
### Motivation
- Consolidate ad-hoc agent cleanup scripts into the native Rust maintenance tool.
- Keep the Python script entry points available while moving the real cleanup logic into typed, testable Rust code.
- Refresh the PR on current `main` without carrying stale shared CI/security churn.

### Description
- Add `copybook-scripts` subcommands for `adapt-review-agents`, `fix-agent-issues`, and `final-cleanup-agents`.
- Port the agent text cleanup rules to a Rust rule engine supporting literal, regex, and BitNet crate-name replacements.
- Keep the Python scripts as compatibility wrappers that delegate to the Rust subcommands, now resolving the repository root from the wrapper path so they can be launched from any working directory.
- Fix rule ordering so specific command/evidence regexes run before broad text replacements, and make final bench-command cleanup work after earlier duplicate-flag normalization.
- Add unit coverage for the crate mapper and each migrated rule set.

### Testing
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 test -p copybook-scripts`
- `cargo +1.95.0 clippy -p copybook-scripts --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `python3 -m py_compile scripts/adapt-review-agents.py scripts/fix-agent-issues.py scripts/final-cleanup-agents.py`
- Temp-workspace smoke test for `adapt-review-agents`, `fix-agent-issues`, and `final-cleanup-agents`
- `git diff --check`