### PR TITLE
refactor(codepage): centralize metadata handling

### DIFF
--- a/crates/copybook-codepage/src/lib.rs
+++ b/crates/copybook-codepage/src/lib.rs
@@ -159,10 +159,14 @@ impl FromStr for Codepage {
 
     #[inline]
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        let s = s.to_lowercase();
         Ok(Self::METADATA
             .iter()
-            .find_map(|(codepage, metadata)| (metadata.display_name == s).then_some(*codepage))
+            .find_map(|(codepage, metadata)| {
+                metadata
+                    .display_name
+                    .eq_ignore_ascii_case(s)
+                    .then_some(*codepage)
+            })
             // Default to CP037 for backward compatibility
             .unwrap_or(Self::CP037))
     }
@@ -223,10 +227,9 @@ impl FromStr for UnmappablePolicy {
 
     #[inline]
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        let s = s.to_lowercase();
         Ok(Self::NAMES
             .iter()
-            .find_map(|(policy, name)| (*name == s).then_some(*policy))
+            .find_map(|(policy, name)| name.eq_ignore_ascii_case(s).then_some(*policy))
             // Default to Error for backward compatibility
             .unwrap_or(Self::Error))
     }

--- a/crates/copybook-codepage/src/lib.rs
+++ b/crates/copybook-codepage/src/lib.rs
@@ -44,12 +44,78 @@ pub enum Codepage {
     CP1140,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct CodepageMetadata {
+    display_name: &'static str,
+    description: &'static str,
+    code_page_number: Option<u16>,
+}
+
+impl CodepageMetadata {
+    const ASCII: Self = Self {
+        display_name: "ascii",
+        description: "ASCII encoding",
+        code_page_number: None,
+    };
+
+    const fn ebcdic(
+        display_name: &'static str,
+        description: &'static str,
+        code_page_number: u16,
+    ) -> Self {
+        Self {
+            display_name,
+            description,
+            code_page_number: Some(code_page_number),
+        }
+    }
+}
+
 impl Codepage {
+    const METADATA: [(Self, CodepageMetadata); 6] = [
+        (Self::ASCII, CodepageMetadata::ASCII),
+        (
+            Self::CP037,
+            CodepageMetadata::ebcdic("cp037", "EBCDIC Code Page 037 (US/Canada)", 37),
+        ),
+        (
+            Self::CP273,
+            CodepageMetadata::ebcdic("cp273", "EBCDIC Code Page 273 (Germany/Austria)", 273),
+        ),
+        (
+            Self::CP500,
+            CodepageMetadata::ebcdic("cp500", "EBCDIC Code Page 500 (International)", 500),
+        ),
+        (
+            Self::CP1047,
+            CodepageMetadata::ebcdic("cp1047", "EBCDIC Code Page 1047 (Open Systems)", 1047),
+        ),
+        (
+            Self::CP1140,
+            CodepageMetadata::ebcdic(
+                "cp1140",
+                "EBCDIC Code Page 1140 (US/Canada with Euro)",
+                1140,
+            ),
+        ),
+    ];
+
+    const fn metadata(self) -> CodepageMetadata {
+        match self {
+            Self::ASCII => Self::METADATA[0].1,
+            Self::CP037 => Self::METADATA[1].1,
+            Self::CP273 => Self::METADATA[2].1,
+            Self::CP500 => Self::METADATA[3].1,
+            Self::CP1047 => Self::METADATA[4].1,
+            Self::CP1140 => Self::METADATA[5].1,
+        }
+    }
+
     /// Check if this is an ASCII codepage
     #[must_use]
     #[inline]
     pub const fn is_ascii(self) -> bool {
-        matches!(self, Self::ASCII)
+        self.metadata().code_page_number.is_none()
     }
 
     /// Check if this is an EBCDIC codepage
@@ -63,42 +129,28 @@ impl Codepage {
     #[must_use]
     #[inline]
     pub const fn code_page_number(self) -> Option<u16> {
-        match self {
-            Self::ASCII => None,
-            Self::CP037 => Some(37),
-            Self::CP273 => Some(273),
-            Self::CP500 => Some(500),
-            Self::CP1047 => Some(1047),
-            Self::CP1140 => Some(1140),
-        }
+        self.metadata().code_page_number
     }
 
     /// Get a human-readable description of the codepage
     #[must_use]
     #[inline]
     pub const fn description(self) -> &'static str {
-        match self {
-            Self::ASCII => "ASCII encoding",
-            Self::CP037 => "EBCDIC Code Page 037 (US/Canada)",
-            Self::CP273 => "EBCDIC Code Page 273 (Germany/Austria)",
-            Self::CP500 => "EBCDIC Code Page 500 (International)",
-            Self::CP1047 => "EBCDIC Code Page 1047 (Open Systems)",
-            Self::CP1140 => "EBCDIC Code Page 1140 (US/Canada with Euro)",
-        }
+        self.metadata().description
+    }
+
+    /// Get the canonical lower-case command-line/display spelling.
+    #[must_use]
+    #[inline]
+    pub const fn as_str(self) -> &'static str {
+        self.metadata().display_name
     }
 }
 
 impl std::fmt::Display for Codepage {
     #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::ASCII => write!(f, "ascii"),
-            Self::CP037 => write!(f, "cp037"),
-            Self::CP273 => write!(f, "cp273"),
-            Self::CP500 => write!(f, "cp500"),
-            Self::CP1047 => write!(f, "cp1047"),
-            Self::CP1140 => write!(f, "cp1140"),
-        }
+        f.write_str(self.as_str())
     }
 }
 
@@ -107,15 +159,12 @@ impl FromStr for Codepage {
 
     #[inline]
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        Ok(match s.to_lowercase().as_str() {
-            "ascii" => Self::ASCII,
-            "cp273" => Self::CP273,
-            "cp500" => Self::CP500,
-            "cp1047" => Self::CP1047,
-            "cp1140" => Self::CP1140,
+        let s = s.to_lowercase();
+        Ok(Self::METADATA
+            .iter()
+            .find_map(|(codepage, metadata)| (metadata.display_name == s).then_some(*codepage))
             // Default to CP037 for backward compatibility
-            _ => Self::CP037,
-        })
+            .unwrap_or(Self::CP037))
     }
 }
 
@@ -143,14 +192,29 @@ pub enum UnmappablePolicy {
     Skip,
 }
 
+impl UnmappablePolicy {
+    const NAMES: [(Self, &'static str); 3] = [
+        (Self::Error, "error"),
+        (Self::Replace, "replace"),
+        (Self::Skip, "skip"),
+    ];
+
+    /// Get the canonical lower-case command-line/display spelling.
+    #[must_use]
+    #[inline]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Error => Self::NAMES[0].1,
+            Self::Replace => Self::NAMES[1].1,
+            Self::Skip => Self::NAMES[2].1,
+        }
+    }
+}
+
 impl std::fmt::Display for UnmappablePolicy {
     #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Error => write!(f, "error"),
-            Self::Replace => write!(f, "replace"),
-            Self::Skip => write!(f, "skip"),
-        }
+        f.write_str(self.as_str())
     }
 }
 
@@ -159,11 +223,12 @@ impl FromStr for UnmappablePolicy {
 
     #[inline]
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        Ok(match s.to_lowercase().as_str() {
-            "replace" => Self::Replace,
-            "skip" => Self::Skip,
-            _ => Self::Error, // Default to Error for backward compatibility
-        })
+        let s = s.to_lowercase();
+        Ok(Self::NAMES
+            .iter()
+            .find_map(|(policy, name)| (*name == s).then_some(*policy))
+            // Default to Error for backward compatibility
+            .unwrap_or(Self::Error))
     }
 }
 

--- a/crates/copybook-codepage/tests/codepage_comprehensive.rs
+++ b/crates/copybook-codepage/tests/codepage_comprehensive.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-//! Comprehensive tests for copybook-codepage: all variants, Display, FromStr,
-//! description, code_page_number, space_byte, zoned sign tables, serde, and
-//! UnmappablePolicy semantics.
+//! Comprehensive tests for copybook-codepage: all variants, `Display`, `FromStr`,
+//! description, `code_page_number`, `space_byte`, zoned sign tables, serde, and
+//! `UnmappablePolicy` semantics.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use copybook_codepage::{Codepage, UnmappablePolicy, get_zoned_sign_table, space_byte};


### PR DESCRIPTION
### Motivation
- Reduce repeated codepage and unmappable-policy metadata mapping while keeping existing fallback parsing behavior.

### Description
- Centralize `Codepage` display names, descriptions, and numeric IDs behind shared metadata.
- Route `Codepage` and `UnmappablePolicy` display/parsing through shared tables.
- Avoid lowercase `String` allocations during parsing by using ASCII-insensitive table lookups.
- Tighten codepage comprehensive test docs so package pedantic clippy passes.

### Testing
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 test -p copybook-codepage`
- `cargo +1.95.0 clippy -p copybook-codepage --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `git diff --check`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b8ad2ea883338d00290bc87804d0)