### PR TITLE
refactor(cli): share encode/decode processing helpers

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -14,6 +14,7 @@ on:
       - 'tests/**'
       - 'Cargo.*'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches: [ main, develop ]
     paths:
       - 'crates/**'
@@ -30,9 +31,13 @@ env:
 
 jobs:
   coverage:
-    name: Code Coverage
+    name: Tarpaulin Coverage
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'coverage') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     steps:
     - name: Checkout code

--- a/.github/workflows/leak-detection.yml
+++ b/.github/workflows/leak-detection.yml
@@ -6,6 +6,7 @@ on:
   schedule:
     - cron: "0 4 * * 0"  # Weekly on Sunday at 04:00 UTC
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - "crates/copybook-codec/**"
       - "crates/copybook-core/**"
@@ -24,6 +25,10 @@ jobs:
     name: Memory Leak Detection (LSAN)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'leak-check') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     steps:
       - uses: actions/checkout@v6
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
  "hex",
  "logos",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "serde_plain",
@@ -1049,7 +1049,7 @@ dependencies = [
  "copybook-codec",
  "copybook-core",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "sha2",
@@ -1156,7 +1156,7 @@ dependencies = [
  "copybook-support-matrix",
  "crossbeam-channel",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
 ]
@@ -3069,9 +3069,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -3364,9 +3364,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3780,7 +3780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/crates/copybook-cli/src/commands/audit.rs
+++ b/crates/copybook-cli/src/commands/audit.rs
@@ -2701,12 +2701,11 @@ fn run_audit_health_check_impl(
         );
     }
 
-    let overall_health_score = if checks_executed == 0 {
-        0
-    } else {
-        let failed_penalty = (checks_failed * 100) / checks_executed;
-        (100u32.saturating_sub(failed_penalty)).min(100)
-    };
+    let overall_health_score = (checks_failed * 100)
+        .checked_div(checks_executed)
+        .map_or(0, |failed_penalty| {
+            (100u32.saturating_sub(failed_penalty)).min(100)
+        });
 
     let status_code = if checks_failed > 0 || !parse_issues.is_empty() {
         ExitCode::Data

--- a/crates/copybook-cli/src/commands/decode.rs
+++ b/crates/copybook-cli/src/commands/decode.rs
@@ -4,16 +4,13 @@
 use crate::exit_codes::ExitCode;
 use crate::subcode;
 use crate::utils::{
-    ParseOptionsConfig, apply_field_projection, atomic_write, build_parse_options,
-    determine_exit_code, read_file_or_stdin,
+    ParseOptionsConfig, determine_exit_code, effective_error_options, parse_projected_schema,
+    process_input_to_output, write_processing_summary,
 };
-use crate::{ExitDiagnostics, Stage, emit_exit_diagnostics_stage, write_stdout_all};
+use crate::{ExitDiagnostics, Stage, emit_exit_diagnostics_stage};
 use copybook_codec::{
     Codepage, DecodeOptions, FloatFormat, JsonNumberMode, RawMode, RecordFormat, UnmappablePolicy,
 };
-use copybook_core::parse_copybook_with_options;
-use std::fmt::Write as _;
-use std::fs;
 use std::path::{Path, PathBuf};
 use tracing::{Level, info};
 
@@ -89,29 +86,20 @@ pub fn run(args: &DecodeArgs) -> anyhow::Result<ExitCode> {
         );
     }
 
-    // Read copybook file or stdin
-    let copybook_text = read_file_or_stdin(args.copybook)?;
+    let working_schema = parse_projected_schema(
+        args.copybook,
+        &ParseOptionsConfig {
+            strict: args.strict,
+            strict_comments: args.strict_comments,
+            codepage: &args.codepage.to_string(),
+            emit_filler: args.emit_filler,
+            dialect: args.dialect,
+        },
+        args.select,
+    )?;
 
-    // Parse copybook with options
-    let parse_options = build_parse_options(&ParseOptionsConfig {
-        strict: args.strict,
-        strict_comments: args.strict_comments,
-        codepage: &args.codepage.to_string(),
-        emit_filler: args.emit_filler,
-        dialect: args.dialect,
-    });
-    let schema = parse_copybook_with_options(&copybook_text, &parse_options)?;
-
-    // Apply field projection if --select is provided
-    let working_schema = apply_field_projection(schema, args.select)?;
-
-    // Configure decode options - use strict mode when fail_fast is enabled
-    let effective_strict_mode = args.strict || args.fail_fast;
-    let effective_max_errors = if args.fail_fast {
-        Some(1)
-    } else {
-        args.max_errors
-    };
+    let (effective_strict_mode, effective_max_errors) =
+        effective_error_options(args.strict, args.max_errors, args.fail_fast);
 
     let options = DecodeOptions::new()
         .with_format(args.format)
@@ -128,82 +116,14 @@ pub fn run(args: &DecodeArgs) -> anyhow::Result<ExitCode> {
         .with_preferred_zoned_encoding(args.preferred_zoned_encoding)
         .with_float_format(args.float_format);
 
-    // Check if output is stdout
     let write_to_stdout = args.output.as_path() == Path::new("-");
+    let summary = process_input_to_output(args.input, args.output, |input_file, output_writer| {
+        copybook_codec::decode_file_to_jsonl(&working_schema, input_file, output_writer, &options)
+            .map_err(Into::into)
+    })?;
 
-    // Decode file
-    let summary = if write_to_stdout {
-        // Write directly to stdout (no atomic write, no summary)
-        let input_file = fs::File::open(args.input)?;
-        let mut stdout = std::io::stdout().lock();
-        copybook_codec::decode_file_to_jsonl(&working_schema, input_file, &mut stdout, &options)?
-    } else {
-        // Use atomic write for file output
-        let mut result_summary = None;
-        atomic_write(args.output, |output_writer| {
-            let input_file = fs::File::open(args.input).map_err(std::io::Error::other)?;
-            let summary = copybook_codec::decode_file_to_jsonl(
-                &working_schema,
-                input_file,
-                output_writer,
-                &options,
-            )
-            .map_err(std::io::Error::other)?;
-            result_summary = Some(summary);
-            Ok(())
-        })?;
-        result_summary.ok_or_else(|| {
-            std::io::Error::other(
-                "Internal error: summary not populated after successful processing",
-            )
-        })?
-    };
-
-    // Print comprehensive summary (only when not writing to stdout)
     if !write_to_stdout {
-        let mut summary_output = String::new();
-        writeln!(&mut summary_output, "=== Decode Summary ===")?;
-        writeln!(
-            &mut summary_output,
-            "Records processed: {}",
-            summary.records_processed
-        )?;
-        writeln!(
-            &mut summary_output,
-            "Records with errors: {}",
-            summary.records_with_errors
-        )?;
-        writeln!(&mut summary_output, "Warnings: {}", summary.warnings)?;
-        writeln!(
-            &mut summary_output,
-            "Processing time: {}ms",
-            summary.processing_time_ms
-        )?;
-        writeln!(
-            &mut summary_output,
-            "Bytes processed: {}",
-            summary.bytes_processed
-        )?;
-        writeln!(
-            &mut summary_output,
-            "Throughput: {:.2} MB/s",
-            summary.throughput_mbps
-        )?;
-
-        if summary.has_warnings() {
-            writeln!(&mut summary_output, "Warnings: {}", summary.warnings)?;
-        }
-
-        // Print error summary if available
-        if summary.has_errors() {
-            writeln!(
-                &mut summary_output,
-                "Records with errors: {}",
-                summary.records_with_errors
-            )?;
-        }
-
-        write_stdout_all(summary_output.as_bytes())?;
+        write_processing_summary("Decode", &summary, true)?;
     }
 
     info!("Decode completed successfully");

--- a/crates/copybook-cli/src/commands/decode.rs
+++ b/crates/copybook-cli/src/commands/decode.rs
@@ -4,8 +4,8 @@
 use crate::exit_codes::ExitCode;
 use crate::subcode;
 use crate::utils::{
-    ParseOptionsConfig, determine_exit_code, effective_error_options, parse_projected_schema,
-    process_input_to_output, write_processing_summary,
+    ParseOptionsConfig, ProcessingSummaryStyle, determine_exit_code, effective_error_options,
+    parse_projected_schema, process_input_to_output, write_processing_summary,
 };
 use crate::{ExitDiagnostics, Stage, emit_exit_diagnostics_stage};
 use copybook_codec::{
@@ -123,7 +123,14 @@ pub fn run(args: &DecodeArgs) -> anyhow::Result<ExitCode> {
     })?;
 
     if !write_to_stdout {
-        write_processing_summary("Decode", &summary, true)?;
+        write_processing_summary(
+            "Decode",
+            &summary,
+            ProcessingSummaryStyle {
+                show_zero_counts: true,
+                repeat_nonzero_counts: true,
+            },
+        )?;
     }
 
     info!("Decode completed successfully");

--- a/crates/copybook-cli/src/commands/encode.rs
+++ b/crates/copybook-cli/src/commands/encode.rs
@@ -3,8 +3,8 @@
 
 use crate::exit_codes::ExitCode;
 use crate::utils::{
-    ParseOptionsConfig, determine_exit_code, effective_error_options, parse_projected_schema,
-    process_input_to_output, write_processing_summary,
+    ParseOptionsConfig, ProcessingSummaryStyle, determine_exit_code, effective_error_options,
+    parse_projected_schema, process_input_to_output, write_processing_summary,
 };
 use crate::write_stderr_all;
 use anyhow::bail;
@@ -84,7 +84,14 @@ pub fn run(
     })?;
 
     if !write_to_stdout {
-        write_processing_summary("Encode", &summary, false)?;
+        write_processing_summary(
+            "Encode",
+            &summary,
+            ProcessingSummaryStyle {
+                show_zero_counts: false,
+                repeat_nonzero_counts: false,
+            },
+        )?;
     }
 
     // Provide detailed feedback about encode status

--- a/crates/copybook-cli/src/commands/encode.rs
+++ b/crates/copybook-cli/src/commands/encode.rs
@@ -3,15 +3,13 @@
 
 use crate::exit_codes::ExitCode;
 use crate::utils::{
-    ParseOptionsConfig, apply_field_projection, atomic_write, build_parse_options,
-    determine_exit_code, read_file_or_stdin,
+    ParseOptionsConfig, determine_exit_code, effective_error_options, parse_projected_schema,
+    process_input_to_output, write_processing_summary,
 };
-use crate::{write_stderr_all, write_stdout_all};
-use anyhow::{anyhow, bail};
+use crate::write_stderr_all;
+use anyhow::bail;
 use copybook_codec::{Codepage, EncodeOptions, FloatFormat, RecordFormat};
-use copybook_core::parse_copybook_with_options;
 use std::fmt::Write as _;
-use std::fs;
 use std::path::Path;
 use tracing::info;
 
@@ -47,29 +45,20 @@ pub fn run(
         info!("Inline comments (*>) disabled (COBOL-85 compatibility)");
     }
 
-    // Read copybook file or stdin
-    let copybook_text = read_file_or_stdin(copybook)?;
+    let working_schema = parse_projected_schema(
+        copybook,
+        &ParseOptionsConfig {
+            strict: options.strict,
+            strict_comments: options.strict_comments,
+            codepage: &options.codepage.to_string(),
+            emit_filler: false,
+            dialect: options.dialect,
+        },
+        options.select,
+    )?;
 
-    // Parse copybook with options
-    let parse_options = build_parse_options(&ParseOptionsConfig {
-        strict: options.strict,
-        strict_comments: options.strict_comments,
-        codepage: &options.codepage.to_string(),
-        emit_filler: false,
-        dialect: options.dialect,
-    });
-    let schema = parse_copybook_with_options(&copybook_text, &parse_options)?;
-
-    // Apply field projection if --select is provided
-    let working_schema = apply_field_projection(schema, options.select)?;
-
-    // Configure encode options - use strict mode when fail_fast is enabled
-    let effective_strict_mode = options.strict || options.fail_fast;
-    let effective_max_errors = if options.fail_fast {
-        Some(1)
-    } else {
-        options.max_errors
-    };
+    let (effective_strict_mode, effective_max_errors) =
+        effective_error_options(options.strict, options.max_errors, options.fail_fast);
 
     let encode_options = EncodeOptions::new()
         .with_format(options.format)
@@ -83,75 +72,19 @@ pub fn run(
         .with_zoned_encoding_override(options.zoned_encoding_override)
         .with_float_format(options.float_format);
 
-    // Check if output is stdout
     let write_to_stdout = output == Path::new("-");
-
-    // Encode file
-    let summary = if write_to_stdout {
-        // Write directly to stdout (no atomic write, no summary)
-        let input_file = fs::File::open(input)?;
-        let mut stdout = std::io::stdout().lock();
+    let summary = process_input_to_output(input, output, |input_file, output_writer| {
         copybook_codec::encode_jsonl_to_file(
             &working_schema,
             input_file,
-            &mut stdout,
+            output_writer,
             &encode_options,
-        )?
-    } else {
-        // Use atomic write for file output
-        let mut summary = None;
-        atomic_write(output, |output_writer| {
-            let input_file = fs::File::open(input).map_err(std::io::Error::other)?;
-            let run_summary = copybook_codec::encode_jsonl_to_file(
-                &working_schema,
-                input_file,
-                output_writer,
-                &encode_options,
-            )
-            .map_err(std::io::Error::other)?;
-            summary = Some(run_summary);
-            Ok(())
-        })?;
-        summary.ok_or_else(|| {
-            anyhow!("Internal error: summary not populated after successful processing")
-        })?
-    };
+        )
+        .map_err(Into::into)
+    })?;
 
-    // Print comprehensive summary (only when not writing to stdout)
     if !write_to_stdout {
-        let mut summary_output = String::new();
-        writeln!(&mut summary_output, "=== Encode Summary ===")?;
-        writeln!(
-            &mut summary_output,
-            "Records processed: {}",
-            summary.records_processed
-        )?;
-        if summary.records_with_errors > 0 {
-            writeln!(
-                &mut summary_output,
-                "Records with errors: {}",
-                summary.records_with_errors
-            )?;
-        }
-        if summary.warnings > 0 {
-            writeln!(&mut summary_output, "Warnings: {}", summary.warnings)?;
-        }
-        writeln!(
-            &mut summary_output,
-            "Processing time: {}ms",
-            summary.processing_time_ms
-        )?;
-        writeln!(
-            &mut summary_output,
-            "Bytes processed: {}",
-            summary.bytes_processed
-        )?;
-        writeln!(
-            &mut summary_output,
-            "Throughput: {:.2} MB/s",
-            summary.throughput_mbps
-        )?;
-        write_stdout_all(summary_output.as_bytes())?;
+        write_processing_summary("Encode", &summary, false)?;
     }
 
     // Provide detailed feedback about encode status

--- a/crates/copybook-cli/src/main.rs
+++ b/crates/copybook-cli/src/main.rs
@@ -554,13 +554,10 @@ fn main() -> ProcessExitCode {
 
 #[allow(clippy::too_many_lines)]
 fn run() -> anyhow::Result<ExitCode> {
-    #[allow(clippy::panic)]
-    if std::env::var("COPYBOOK_TEST_PANIC")
-        .map(|v| v == "1")
-        .unwrap_or(false)
-    {
-        panic!("COPYBOOK_TEST_PANIC triggered");
-    }
+    assert!(
+        !std::env::var("COPYBOOK_TEST_PANIC").is_ok_and(|v| v == "1"),
+        "COPYBOOK_TEST_PANIC triggered"
+    );
 
     let cli = match Cli::try_parse() {
         Ok(cli) => cli,

--- a/crates/copybook-cli/src/utils.rs
+++ b/crates/copybook-cli/src/utils.rs
@@ -163,19 +163,25 @@ where
     })
 }
 
-/// Render and write a standard CLI processing summary.
-///
-/// Set `always_show_counts` for commands that historically print zero-valued error
-/// and warning counts. Encode omits those rows when the counts are zero.
+/// Controls issue-count rows in a standard CLI processing summary.
+#[derive(Clone, Copy)]
+pub struct ProcessingSummaryStyle {
+    /// Print warning and error rows even when the count is zero.
+    pub show_zero_counts: bool,
+    /// Repeat nonzero warning and error rows for compatibility with legacy output.
+    pub repeat_nonzero_counts: bool,
+}
+
+/// Render a standard CLI processing summary.
 ///
 /// # Errors
 ///
-/// Returns an error if formatting or writing to stdout fails.
-pub fn write_processing_summary(
+/// Returns an error if formatting the summary fails.
+pub fn render_processing_summary(
     title: &str,
     summary: &RunSummary,
-    always_show_counts: bool,
-) -> anyhow::Result<()> {
+    style: ProcessingSummaryStyle,
+) -> Result<String, std::fmt::Error> {
     let mut summary_output = String::new();
     writeln!(&mut summary_output, "=== {title} Summary ===")?;
     writeln!(
@@ -183,14 +189,14 @@ pub fn write_processing_summary(
         "Records processed: {}",
         summary.records_processed
     )?;
-    if always_show_counts || summary.records_with_errors > 0 {
+    if style.show_zero_counts || summary.records_with_errors > 0 {
         writeln!(
             &mut summary_output,
             "Records with errors: {}",
             summary.records_with_errors
         )?;
     }
-    if always_show_counts || summary.warnings > 0 {
+    if style.show_zero_counts || summary.warnings > 0 {
         writeln!(&mut summary_output, "Warnings: {}", summary.warnings)?;
     }
     writeln!(
@@ -208,6 +214,32 @@ pub fn write_processing_summary(
         "Throughput: {:.2} MB/s",
         summary.throughput_mbps
     )?;
+    if style.repeat_nonzero_counts {
+        if summary.has_warnings() {
+            writeln!(&mut summary_output, "Warnings: {}", summary.warnings)?;
+        }
+        if summary.has_errors() {
+            writeln!(
+                &mut summary_output,
+                "Records with errors: {}",
+                summary.records_with_errors
+            )?;
+        }
+    }
+    Ok(summary_output)
+}
+
+/// Render and write a standard CLI processing summary.
+///
+/// # Errors
+///
+/// Returns an error if formatting or writing to stdout fails.
+pub fn write_processing_summary(
+    title: &str,
+    summary: &RunSummary,
+    style: ProcessingSummaryStyle,
+) -> anyhow::Result<()> {
+    let summary_output = render_processing_summary(title, summary, style)?;
     crate::write_stdout_all(summary_output.as_bytes())?;
     Ok(())
 }
@@ -363,6 +395,93 @@ mod tests {
             determine_exit_code(true, true, ExitCode::Encode),
             ExitCode::Encode
         ); // Both warnings and errors adopt failure variant
+    }
+
+    #[test]
+    fn test_effective_error_options() {
+        assert_eq!(effective_error_options(false, None, false), (false, None));
+        assert_eq!(
+            effective_error_options(true, Some(10), false),
+            (true, Some(10))
+        );
+        assert_eq!(
+            effective_error_options(false, Some(10), true),
+            (true, Some(1))
+        );
+    }
+
+    #[test]
+    fn test_render_processing_summary_styles() -> Result<()> {
+        let summary = RunSummary {
+            records_processed: 3,
+            records_with_errors: 1,
+            warnings: 2,
+            processing_time_ms: 42,
+            bytes_processed: 2048,
+            throughput_mbps: 1.5,
+            ..RunSummary::default()
+        };
+
+        let encode = render_processing_summary(
+            "Encode",
+            &summary,
+            ProcessingSummaryStyle {
+                show_zero_counts: false,
+                repeat_nonzero_counts: false,
+            },
+        )?;
+        assert!(encode.contains("=== Encode Summary ==="));
+        assert_eq!(encode.matches("Warnings: 2").count(), 1);
+        assert_eq!(encode.matches("Records with errors: 1").count(), 1);
+
+        let decode = render_processing_summary(
+            "Decode",
+            &summary,
+            ProcessingSummaryStyle {
+                show_zero_counts: true,
+                repeat_nonzero_counts: true,
+            },
+        )?;
+        assert!(decode.contains("=== Decode Summary ==="));
+        assert_eq!(decode.matches("Warnings: 2").count(), 2);
+        assert_eq!(decode.matches("Records with errors: 1").count(), 2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_render_processing_summary_zero_counts() -> Result<()> {
+        let summary = RunSummary {
+            records_processed: 3,
+            processing_time_ms: 42,
+            bytes_processed: 2048,
+            throughput_mbps: 1.5,
+            ..RunSummary::default()
+        };
+
+        let encode = render_processing_summary(
+            "Encode",
+            &summary,
+            ProcessingSummaryStyle {
+                show_zero_counts: false,
+                repeat_nonzero_counts: false,
+            },
+        )?;
+        assert!(!encode.contains("Warnings: 0"));
+        assert!(!encode.contains("Records with errors: 0"));
+
+        let decode = render_processing_summary(
+            "Decode",
+            &summary,
+            ProcessingSummaryStyle {
+                show_zero_counts: true,
+                repeat_nonzero_counts: true,
+            },
+        )?;
+        assert_eq!(decode.matches("Warnings: 0").count(), 1);
+        assert_eq!(decode.matches("Records with errors: 0").count(), 1);
+
+        Ok(())
     }
 
     #[test]

--- a/crates/copybook-cli/src/utils.rs
+++ b/crates/copybook-cli/src/utils.rs
@@ -2,7 +2,10 @@
 //! Utility functions for CLI operations
 
 use crate::exit_codes::ExitCode;
-use copybook_core::{ParseOptions, Schema};
+use copybook_codec::RunSummary;
+use copybook_core::{ParseOptions, Schema, parse_copybook_with_options};
+use std::fmt::Write as FmtWrite;
+use std::fs;
 use std::io::{self, Read, Write};
 use std::path::Path;
 #[cfg(test)]
@@ -85,6 +88,128 @@ pub fn build_parse_options(config: &ParseOptionsConfig) -> ParseOptions {
         allow_inline_comments: !config.strict_comments,
         dialect: config.dialect,
     }
+}
+
+/// Build parse options, read a copybook, parse it, and apply optional field projection.
+///
+/// This consolidates the common decode/encode command setup path so both commands
+/// parse copybooks and selectors consistently.
+///
+/// # Errors
+///
+/// Returns an error when reading the copybook, parsing it, or applying field
+/// projection fails.
+pub fn parse_projected_schema(
+    copybook: &Path,
+    config: &ParseOptionsConfig<'_>,
+    select_args: &[String],
+) -> anyhow::Result<Schema> {
+    let copybook_text = read_file_or_stdin(copybook)?;
+    let parse_options = build_parse_options(config);
+    let schema = parse_copybook_with_options(&copybook_text, &parse_options)?;
+    apply_field_projection(schema, select_args)
+}
+
+/// Return the strictness/max-error pair implied by common processing flags.
+///
+/// `--fail-fast` forces strict mode and limits processing to the first error for
+/// both encode and decode operations.
+#[must_use]
+pub const fn effective_error_options(
+    strict: bool,
+    max_errors: Option<u64>,
+    fail_fast: bool,
+) -> (bool, Option<u64>) {
+    if fail_fast {
+        (true, Some(1))
+    } else {
+        (strict, max_errors)
+    }
+}
+
+/// Run a streaming processor, using stdout directly for `-` and atomic writes for files.
+///
+/// The processor receives an opened input file and the destination writer, and must
+/// return the resulting [`RunSummary`].
+///
+/// # Errors
+///
+/// Returns an error if opening the input, writing the output, or running the
+/// processor fails.
+pub fn process_input_to_output<F>(
+    input: &Path,
+    output: &Path,
+    mut processor: F,
+) -> anyhow::Result<RunSummary>
+where
+    F: FnMut(fs::File, &mut dyn Write) -> anyhow::Result<RunSummary>,
+{
+    if output == Path::new("-") {
+        let input_file = fs::File::open(input)?;
+        let mut stdout = std::io::stdout().lock();
+        return processor(input_file, &mut stdout);
+    }
+
+    let mut summary = None;
+    atomic_write(output, |output_writer| {
+        let input_file = fs::File::open(input).map_err(io::Error::other)?;
+        let run_summary = processor(input_file, output_writer).map_err(io::Error::other)?;
+        summary = Some(run_summary);
+        Ok(())
+    })?;
+
+    summary.ok_or_else(|| {
+        anyhow::anyhow!("Internal error: summary not populated after successful processing")
+    })
+}
+
+/// Render and write a standard CLI processing summary.
+///
+/// Set `always_show_counts` for commands that historically print zero-valued error
+/// and warning counts. Encode omits those rows when the counts are zero.
+///
+/// # Errors
+///
+/// Returns an error if formatting or writing to stdout fails.
+pub fn write_processing_summary(
+    title: &str,
+    summary: &RunSummary,
+    always_show_counts: bool,
+) -> anyhow::Result<()> {
+    let mut summary_output = String::new();
+    writeln!(&mut summary_output, "=== {title} Summary ===")?;
+    writeln!(
+        &mut summary_output,
+        "Records processed: {}",
+        summary.records_processed
+    )?;
+    if always_show_counts || summary.records_with_errors > 0 {
+        writeln!(
+            &mut summary_output,
+            "Records with errors: {}",
+            summary.records_with_errors
+        )?;
+    }
+    if always_show_counts || summary.warnings > 0 {
+        writeln!(&mut summary_output, "Warnings: {}", summary.warnings)?;
+    }
+    writeln!(
+        &mut summary_output,
+        "Processing time: {}ms",
+        summary.processing_time_ms
+    )?;
+    writeln!(
+        &mut summary_output,
+        "Bytes processed: {}",
+        summary.bytes_processed
+    )?;
+    writeln!(
+        &mut summary_output,
+        "Throughput: {:.2} MB/s",
+        summary.throughput_mbps
+    )?;
+    crate::write_stdout_all(summary_output.as_bytes())?;
+    Ok(())
 }
 
 /// Atomically write data to a file using temporary file + rename

--- a/crates/copybook-codec/src/fidelity.rs
+++ b/crates/copybook-codec/src/fidelity.rs
@@ -948,11 +948,9 @@ pub mod utils {
             .map(|p| p.validation_time_ms)
             .sum();
         let total_records_u64 = u64::try_from(total_records).unwrap_or(u64::MAX);
-        let average_validation_time = if total_records_u64 == 0 {
-            0
-        } else {
-            total_validation_time / total_records_u64
-        };
+        let average_validation_time = total_validation_time
+            .checked_div(total_records_u64)
+            .unwrap_or(0);
 
         BatchFidelityMetrics {
             total_records,

--- a/crates/copybook-contracts/src/feature_flags.rs
+++ b/crates/copybook-contracts/src/feature_flags.rs
@@ -530,8 +530,7 @@ impl FeatureFlagsHandle {
     pub fn is_enabled(&self, feature: Feature) -> bool {
         self.flags
             .read()
-            .map(|flags| flags.is_enabled(feature))
-            .unwrap_or(false)
+            .is_ok_and(|flags| flags.is_enabled(feature))
     }
 
     /// Enable a feature flag through the handle.

--- a/crates/copybook-core/src/audit/security.rs
+++ b/crates/copybook-core/src/audit/security.rs
@@ -421,8 +421,7 @@ impl SecurityMonitor {
         let priority = 16 * 8 + 4; // 132
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_secs());
         format!(
             "<{}>1 {} copybook-rs SecurityMonitor - {} - {}",
             priority, timestamp, violation.violation_id, violation.description


### PR DESCRIPTION
## Motivation

Reduce duplicated CLI encode/decode setup while keeping the existing command behavior stable.

## Description

- Shares copybook parsing, selector projection, fail-fast error option handling, and input/output processing helpers between encode and decode.
- Adds explicit processing-summary styling so encode keeps omitting zero issue counts while decode keeps showing zero counts and repeating nonzero issue counts for compatibility.
- Adds focused unit coverage for error option derivation and summary rendering styles.
- Carries the shared CI/security baseline maintenance commits already used on the neighboring cleanup PRs.

## Testing

- `cargo +1.95.0 fmt --all --check`
- `cargo +1.95.0 check -p copybook-cli`
- `cargo +1.95.0 test -p copybook-cli --bin copybook`
- `cargo +1.95.0 clippy -p copybook-cli --all-targets --all-features -- -D warnings`
- `cargo +1.95.0 clippy --workspace --lib --bins --examples --all-features -- -D warnings -W clippy::pedantic`
- `cargo +1.95.0 clippy --workspace --tests --all-features -- -D warnings -A clippy::unwrap_used -A clippy::expect_used -A clippy::panic -A clippy::dbg_macro -A clippy::print_stdout -A clippy::print_stderr -A clippy::missing_inline_in_public_items -A clippy::duplicated_attributes -A deprecated`
- `cargo deny --workspace --all-features check`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `COPYBOOK_FF_SIGN_SEPARATE=1 cargo +1.95.0 test --workspace --lib --features audit`
- `COPYBOOK_FF_SIGN_SEPARATE=1 cargo +1.95.0 clippy --workspace --lib --bins --examples -- -D warnings -W clippy::pedantic`
- `COPYBOOK_FF_SIGN_SEPARATE=1 cargo +1.95.0 build --release -p copybook-cli --features audit`
