### PR TITLE
refactor(cli): share encode/decode workflow helpers

### DIFF
--- a/crates/copybook-cli/src/commands/decode.rs
+++ b/crates/copybook-cli/src/commands/decode.rs
@@ -4,17 +4,14 @@
 use crate::exit_codes::ExitCode;
 use crate::subcode;
 use crate::utils::{
-    ParseOptionsConfig, apply_field_projection, atomic_write, build_parse_options,
-    determine_exit_code, read_file_or_stdin,
+    ParseOptionsConfig, SummaryIssueCountStyle, append_processing_summary, determine_exit_code,
+    effective_error_policy, log_strict_comments, parse_projected_schema, run_with_output,
 };
 use crate::{ExitDiagnostics, Stage, emit_exit_diagnostics_stage, write_stdout_all};
 use copybook_codec::{
     Codepage, DecodeOptions, FloatFormat, JsonNumberMode, RawMode, RecordFormat, UnmappablePolicy,
 };
-use copybook_core::parse_copybook_with_options;
-use std::fmt::Write as _;
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use tracing::{Level, info};
 
 #[allow(clippy::struct_excessive_bools)]
@@ -46,9 +43,7 @@ pub struct DecodeArgs<'a> {
 pub fn run(args: &DecodeArgs) -> anyhow::Result<ExitCode> {
     info!("Decoding data file: {:?}", args.input);
 
-    if args.strict_comments {
-        info!("Inline comments (*>) disabled (COBOL-85 compatibility)");
-    }
+    log_strict_comments(args.strict_comments);
 
     if args.preferred_zoned_encoding != copybook_codec::ZonedEncodingFormat::Auto
         && !args.preserve_zoned_encoding
@@ -89,29 +84,20 @@ pub fn run(args: &DecodeArgs) -> anyhow::Result<ExitCode> {
         );
     }
 
-    // Read copybook file or stdin
-    let copybook_text = read_file_or_stdin(args.copybook)?;
+    let codepage = args.codepage.to_string();
+    let working_schema = parse_projected_schema(
+        args.copybook,
+        &ParseOptionsConfig {
+            strict: args.strict,
+            strict_comments: args.strict_comments,
+            codepage: &codepage,
+            emit_filler: args.emit_filler,
+            dialect: args.dialect,
+        },
+        args.select,
+    )?;
 
-    // Parse copybook with options
-    let parse_options = build_parse_options(&ParseOptionsConfig {
-        strict: args.strict,
-        strict_comments: args.strict_comments,
-        codepage: &args.codepage.to_string(),
-        emit_filler: args.emit_filler,
-        dialect: args.dialect,
-    });
-    let schema = parse_copybook_with_options(&copybook_text, &parse_options)?;
-
-    // Apply field projection if --select is provided
-    let working_schema = apply_field_projection(schema, args.select)?;
-
-    // Configure decode options - use strict mode when fail_fast is enabled
-    let effective_strict_mode = args.strict || args.fail_fast;
-    let effective_max_errors = if args.fail_fast {
-        Some(1)
-    } else {
-        args.max_errors
-    };
+    let error_policy = effective_error_policy(args.strict, args.fail_fast, args.max_errors);
 
     let options = DecodeOptions::new()
         .with_format(args.format)
@@ -120,88 +106,36 @@ pub fn run(args: &DecodeArgs) -> anyhow::Result<ExitCode> {
         .with_emit_filler(args.emit_filler)
         .with_emit_meta(args.emit_meta)
         .with_emit_raw(args.emit_raw)
-        .with_strict_mode(effective_strict_mode)
-        .with_max_errors(effective_max_errors)
+        .with_strict_mode(error_policy.strict_mode)
+        .with_max_errors(error_policy.max_errors)
         .with_unmappable_policy(args.on_decode_unmappable)
         .with_threads(args.threads)
         .with_preserve_zoned_encoding(args.preserve_zoned_encoding)
         .with_preferred_zoned_encoding(args.preferred_zoned_encoding)
         .with_float_format(args.float_format);
 
-    // Check if output is stdout
-    let write_to_stdout = args.output.as_path() == Path::new("-");
-
-    // Decode file
-    let summary = if write_to_stdout {
-        // Write directly to stdout (no atomic write, no summary)
-        let input_file = fs::File::open(args.input)?;
-        let mut stdout = std::io::stdout().lock();
-        copybook_codec::decode_file_to_jsonl(&working_schema, input_file, &mut stdout, &options)?
-    } else {
-        // Use atomic write for file output
-        let mut result_summary = None;
-        atomic_write(args.output, |output_writer| {
-            let input_file = fs::File::open(args.input).map_err(std::io::Error::other)?;
-            let summary = copybook_codec::decode_file_to_jsonl(
+    let (summary, write_to_stdout) =
+        run_with_output(args.input, args.output, |input_file, output_writer| {
+            Ok(copybook_codec::decode_file_to_jsonl(
                 &working_schema,
                 input_file,
                 output_writer,
                 &options,
-            )
-            .map_err(std::io::Error::other)?;
-            result_summary = Some(summary);
-            Ok(())
+            )?)
         })?;
-        result_summary.ok_or_else(|| {
-            std::io::Error::other(
-                "Internal error: summary not populated after successful processing",
-            )
-        })?
-    };
 
     // Print comprehensive summary (only when not writing to stdout)
     if !write_to_stdout {
         let mut summary_output = String::new();
-        writeln!(&mut summary_output, "=== Decode Summary ===")?;
-        writeln!(
+        append_processing_summary(
             &mut summary_output,
-            "Records processed: {}",
-            summary.records_processed
+            "Decode",
+            &summary,
+            SummaryIssueCountStyle {
+                show_zero_counts: true,
+                repeat_nonzero_counts: true,
+            },
         )?;
-        writeln!(
-            &mut summary_output,
-            "Records with errors: {}",
-            summary.records_with_errors
-        )?;
-        writeln!(&mut summary_output, "Warnings: {}", summary.warnings)?;
-        writeln!(
-            &mut summary_output,
-            "Processing time: {}ms",
-            summary.processing_time_ms
-        )?;
-        writeln!(
-            &mut summary_output,
-            "Bytes processed: {}",
-            summary.bytes_processed
-        )?;
-        writeln!(
-            &mut summary_output,
-            "Throughput: {:.2} MB/s",
-            summary.throughput_mbps
-        )?;
-
-        if summary.has_warnings() {
-            writeln!(&mut summary_output, "Warnings: {}", summary.warnings)?;
-        }
-
-        // Print error summary if available
-        if summary.has_errors() {
-            writeln!(
-                &mut summary_output,
-                "Records with errors: {}",
-                summary.records_with_errors
-            )?;
-        }
 
         write_stdout_all(summary_output.as_bytes())?;
     }

--- a/crates/copybook-cli/src/commands/encode.rs
+++ b/crates/copybook-cli/src/commands/encode.rs
@@ -3,15 +3,13 @@
 
 use crate::exit_codes::ExitCode;
 use crate::utils::{
-    ParseOptionsConfig, apply_field_projection, atomic_write, build_parse_options,
-    determine_exit_code, read_file_or_stdin,
+    ParseOptionsConfig, SummaryIssueCountStyle, append_processing_summary, determine_exit_code,
+    effective_error_policy, log_strict_comments, parse_projected_schema, run_with_output,
 };
 use crate::{write_stderr_all, write_stdout_all};
-use anyhow::{anyhow, bail};
+use anyhow::bail;
 use copybook_codec::{Codepage, EncodeOptions, FloatFormat, RecordFormat};
-use copybook_core::parse_copybook_with_options;
 use std::fmt::Write as _;
-use std::fs;
 use std::path::Path;
 use tracing::info;
 
@@ -43,113 +41,57 @@ pub fn run(
 ) -> anyhow::Result<ExitCode> {
     info!("Encoding JSONL file: {:?}", input);
 
-    if options.strict_comments {
-        info!("Inline comments (*>) disabled (COBOL-85 compatibility)");
-    }
+    log_strict_comments(options.strict_comments);
 
-    // Read copybook file or stdin
-    let copybook_text = read_file_or_stdin(copybook)?;
+    let codepage = options.codepage.to_string();
+    let working_schema = parse_projected_schema(
+        copybook,
+        &ParseOptionsConfig {
+            strict: options.strict,
+            strict_comments: options.strict_comments,
+            codepage: &codepage,
+            emit_filler: false,
+            dialect: options.dialect,
+        },
+        options.select,
+    )?;
 
-    // Parse copybook with options
-    let parse_options = build_parse_options(&ParseOptionsConfig {
-        strict: options.strict,
-        strict_comments: options.strict_comments,
-        codepage: &options.codepage.to_string(),
-        emit_filler: false,
-        dialect: options.dialect,
-    });
-    let schema = parse_copybook_with_options(&copybook_text, &parse_options)?;
-
-    // Apply field projection if --select is provided
-    let working_schema = apply_field_projection(schema, options.select)?;
-
-    // Configure encode options - use strict mode when fail_fast is enabled
-    let effective_strict_mode = options.strict || options.fail_fast;
-    let effective_max_errors = if options.fail_fast {
-        Some(1)
-    } else {
-        options.max_errors
-    };
+    let error_policy =
+        effective_error_policy(options.strict, options.fail_fast, options.max_errors);
 
     let encode_options = EncodeOptions::new()
         .with_format(options.format)
         .with_codepage(options.codepage)
         .with_use_raw(options.use_raw)
         .with_bwz_encode(options.bwz_encode)
-        .with_strict_mode(effective_strict_mode)
-        .with_max_errors(effective_max_errors)
+        .with_strict_mode(error_policy.strict_mode)
+        .with_max_errors(error_policy.max_errors)
         .with_threads(options.threads)
         .with_coerce_numbers(options.coerce_numbers)
         .with_zoned_encoding_override(options.zoned_encoding_override)
         .with_float_format(options.float_format);
 
-    // Check if output is stdout
-    let write_to_stdout = output == Path::new("-");
-
-    // Encode file
-    let summary = if write_to_stdout {
-        // Write directly to stdout (no atomic write, no summary)
-        let input_file = fs::File::open(input)?;
-        let mut stdout = std::io::stdout().lock();
-        copybook_codec::encode_jsonl_to_file(
-            &working_schema,
-            input_file,
-            &mut stdout,
-            &encode_options,
-        )?
-    } else {
-        // Use atomic write for file output
-        let mut summary = None;
-        atomic_write(output, |output_writer| {
-            let input_file = fs::File::open(input).map_err(std::io::Error::other)?;
-            let run_summary = copybook_codec::encode_jsonl_to_file(
+    let (summary, write_to_stdout) =
+        run_with_output(input, output, |input_file, output_writer| {
+            Ok(copybook_codec::encode_jsonl_to_file(
                 &working_schema,
                 input_file,
                 output_writer,
                 &encode_options,
-            )
-            .map_err(std::io::Error::other)?;
-            summary = Some(run_summary);
-            Ok(())
+            )?)
         })?;
-        summary.ok_or_else(|| {
-            anyhow!("Internal error: summary not populated after successful processing")
-        })?
-    };
 
     // Print comprehensive summary (only when not writing to stdout)
     if !write_to_stdout {
         let mut summary_output = String::new();
-        writeln!(&mut summary_output, "=== Encode Summary ===")?;
-        writeln!(
+        append_processing_summary(
             &mut summary_output,
-            "Records processed: {}",
-            summary.records_processed
-        )?;
-        if summary.records_with_errors > 0 {
-            writeln!(
-                &mut summary_output,
-                "Records with errors: {}",
-                summary.records_with_errors
-            )?;
-        }
-        if summary.warnings > 0 {
-            writeln!(&mut summary_output, "Warnings: {}", summary.warnings)?;
-        }
-        writeln!(
-            &mut summary_output,
-            "Processing time: {}ms",
-            summary.processing_time_ms
-        )?;
-        writeln!(
-            &mut summary_output,
-            "Bytes processed: {}",
-            summary.bytes_processed
-        )?;
-        writeln!(
-            &mut summary_output,
-            "Throughput: {:.2} MB/s",
-            summary.throughput_mbps
+            "Encode",
+            &summary,
+            SummaryIssueCountStyle {
+                show_zero_counts: false,
+                repeat_nonzero_counts: false,
+            },
         )?;
         write_stdout_all(summary_output.as_bytes())?;
     }

--- a/crates/copybook-cli/src/utils.rs
+++ b/crates/copybook-cli/src/utils.rs
@@ -2,13 +2,61 @@
 //! Utility functions for CLI operations
 
 use crate::exit_codes::ExitCode;
-use copybook_core::{ParseOptions, Schema};
+use copybook_codec::RunSummary;
+use copybook_core::{ParseOptions, Schema, parse_copybook_with_options};
+use std::fmt::Write as FmtWrite;
+use std::fs;
 use std::io::{self, Read, Write};
 use std::path::Path;
 #[cfg(test)]
 use std::path::PathBuf;
 use tempfile::NamedTempFile;
 use tracing::{debug, info};
+
+/// Effective error handling derived from CLI `strict`, `max_errors`, and `fail_fast` flags.
+pub struct ErrorPolicy {
+    pub strict_mode: bool,
+    pub max_errors: Option<u64>,
+}
+
+/// Normalize strict/error-limit flags shared by encode and decode commands.
+#[must_use]
+pub const fn effective_error_policy(
+    strict: bool,
+    fail_fast: bool,
+    max_errors: Option<u64>,
+) -> ErrorPolicy {
+    ErrorPolicy {
+        strict_mode: strict || fail_fast,
+        max_errors: if fail_fast { Some(1) } else { max_errors },
+    }
+}
+
+/// Emit the common strict-comments informational trace used by CLI commands.
+pub fn log_strict_comments(strict_comments: bool) {
+    if strict_comments {
+        info!("Inline comments (*>) disabled (COBOL-85 compatibility)");
+    }
+}
+
+/// Read, parse, and optionally project a copybook schema.
+///
+/// This consolidates the parse/projection pipeline shared by commands that
+/// transform data using a copybook.
+///
+/// # Errors
+///
+/// Returns an error when the copybook cannot be read, parsed, or projected.
+pub fn parse_projected_schema(
+    copybook: &Path,
+    config: &ParseOptionsConfig,
+    select_args: &[String],
+) -> anyhow::Result<Schema> {
+    let copybook_text = read_file_or_stdin(copybook)?;
+    let parse_options = build_parse_options(config);
+    let schema = parse_copybook_with_options(&copybook_text, &parse_options)?;
+    apply_field_projection(schema, select_args)
+}
 
 /// Parse --select arguments (supports comma-separated and multiple flags)
 ///
@@ -85,6 +133,91 @@ pub fn build_parse_options(config: &ParseOptionsConfig) -> ParseOptions {
         allow_inline_comments: !config.strict_comments,
         dialect: config.dialect,
     }
+}
+
+/// Run a streaming transformation, writing either to stdout (`-`) or atomically to a file.
+///
+/// # Errors
+///
+/// Returns an error when input cannot be opened, the transformation fails, or the
+/// output cannot be written atomically.
+pub fn run_with_output<T, F>(
+    input: &Path,
+    output: &Path,
+    mut process: F,
+) -> anyhow::Result<(T, bool)>
+where
+    F: FnMut(fs::File, &mut dyn Write) -> anyhow::Result<T>,
+{
+    let write_to_stdout = output == Path::new("-");
+
+    if write_to_stdout {
+        let input_file = fs::File::open(input)?;
+        let mut stdout = std::io::stdout().lock();
+        return Ok((process(input_file, &mut stdout)?, true));
+    }
+
+    let mut summary = None;
+    atomic_write(output, |output_writer| {
+        let input_file = fs::File::open(input).map_err(std::io::Error::other)?;
+        let run_summary = process(input_file, output_writer).map_err(std::io::Error::other)?;
+        summary = Some(run_summary);
+        Ok(())
+    })?;
+
+    let summary = summary.ok_or_else(|| {
+        anyhow::anyhow!("Internal error: summary not populated after successful processing")
+    })?;
+    Ok((summary, false))
+}
+
+/// Controls how issue counts are printed in a processing summary.
+pub struct SummaryIssueCountStyle {
+    pub show_zero_counts: bool,
+    pub repeat_nonzero_counts: bool,
+}
+
+/// Append the standard encode/decode processing summary to `output`.
+///
+/// # Errors
+///
+/// Returns a formatting error if writing to the provided string fails.
+pub fn append_processing_summary(
+    output: &mut String,
+    title: &str,
+    summary: &RunSummary,
+    issue_style: SummaryIssueCountStyle,
+) -> std::fmt::Result {
+    writeln!(output, "=== {title} Summary ===")?;
+    writeln!(output, "Records processed: {}", summary.records_processed)?;
+    if issue_style.show_zero_counts || summary.records_with_errors > 0 {
+        writeln!(
+            output,
+            "Records with errors: {}",
+            summary.records_with_errors
+        )?;
+    }
+    if issue_style.show_zero_counts || summary.warnings > 0 {
+        writeln!(output, "Warnings: {}", summary.warnings)?;
+    }
+    writeln!(output, "Processing time: {}ms", summary.processing_time_ms)?;
+    writeln!(output, "Bytes processed: {}", summary.bytes_processed)?;
+    writeln!(output, "Throughput: {:.2} MB/s", summary.throughput_mbps)?;
+
+    if issue_style.repeat_nonzero_counts {
+        if summary.has_warnings() {
+            writeln!(output, "Warnings: {}", summary.warnings)?;
+        }
+        if summary.has_errors() {
+            writeln!(
+                output,
+                "Records with errors: {}",
+                summary.records_with_errors
+            )?;
+        }
+    }
+
+    Ok(())
 }
 
 /// Atomically write data to a file using temporary file + rename
@@ -238,6 +371,63 @@ mod tests {
             determine_exit_code(true, true, ExitCode::Encode),
             ExitCode::Encode
         ); // Both warnings and errors adopt failure variant
+    }
+
+    #[test]
+    fn test_effective_error_policy() {
+        let lenient = effective_error_policy(false, false, Some(25));
+        assert!(!lenient.strict_mode);
+        assert_eq!(lenient.max_errors, Some(25));
+
+        let fail_fast = effective_error_policy(false, true, Some(25));
+        assert!(fail_fast.strict_mode);
+        assert_eq!(fail_fast.max_errors, Some(1));
+
+        let strict = effective_error_policy(true, false, None);
+        assert!(strict.strict_mode);
+        assert_eq!(strict.max_errors, None);
+    }
+
+    #[test]
+    fn test_append_processing_summary_styles() -> Result<()> {
+        let summary = RunSummary {
+            records_processed: 3,
+            records_with_errors: 1,
+            warnings: 2,
+            processing_time_ms: 42,
+            bytes_processed: 2048,
+            throughput_mbps: 1.5,
+            ..RunSummary::default()
+        };
+
+        let mut encode_summary = String::new();
+        append_processing_summary(
+            &mut encode_summary,
+            "Encode",
+            &summary,
+            SummaryIssueCountStyle {
+                show_zero_counts: false,
+                repeat_nonzero_counts: false,
+            },
+        )?;
+        assert!(encode_summary.contains("=== Encode Summary ==="));
+        assert_eq!(encode_summary.matches("Warnings: 2").count(), 1);
+        assert_eq!(encode_summary.matches("Records with errors: 1").count(), 1);
+
+        let mut decode_summary = String::new();
+        append_processing_summary(
+            &mut decode_summary,
+            "Decode",
+            &summary,
+            SummaryIssueCountStyle {
+                show_zero_counts: true,
+                repeat_nonzero_counts: true,
+            },
+        )?;
+        assert!(decode_summary.contains("=== Decode Summary ==="));
+        assert_eq!(decode_summary.matches("Warnings: 2").count(), 2);
+        assert_eq!(decode_summary.matches("Records with errors: 1").count(), 2);
+        Ok(())
     }
 
     #[test]

--- a/crates/copybook-cli/src/utils.rs
+++ b/crates/copybook-cli/src/utils.rs
@@ -432,6 +432,44 @@ mod tests {
     }
 
     #[test]
+    fn test_append_processing_summary_zero_counts() -> Result<()> {
+        let summary = RunSummary {
+            records_processed: 3,
+            processing_time_ms: 42,
+            bytes_processed: 2048,
+            throughput_mbps: 1.5,
+            ..RunSummary::default()
+        };
+
+        let mut encode_summary = String::new();
+        append_processing_summary(
+            &mut encode_summary,
+            "Encode",
+            &summary,
+            SummaryIssueCountStyle {
+                show_zero_counts: false,
+                repeat_nonzero_counts: false,
+            },
+        )?;
+        assert!(!encode_summary.contains("Warnings: 0"));
+        assert!(!encode_summary.contains("Records with errors: 0"));
+
+        let mut decode_summary = String::new();
+        append_processing_summary(
+            &mut decode_summary,
+            "Decode",
+            &summary,
+            SummaryIssueCountStyle {
+                show_zero_counts: true,
+                repeat_nonzero_counts: true,
+            },
+        )?;
+        assert_eq!(decode_summary.matches("Warnings: 0").count(), 1);
+        assert_eq!(decode_summary.matches("Records with errors: 0").count(), 1);
+        Ok(())
+    }
+
+    #[test]
     fn test_temp_path_for() {
         let target = Path::new("/path/to/output.jsonl");
         let temp = temp_path_for(target);

--- a/crates/copybook-cli/src/utils.rs
+++ b/crates/copybook-cli/src/utils.rs
@@ -172,6 +172,7 @@ where
 }
 
 /// Controls how issue counts are printed in a processing summary.
+#[derive(Clone, Copy)]
 pub struct SummaryIssueCountStyle {
     pub show_zero_counts: bool,
     pub repeat_nonzero_counts: bool,


### PR DESCRIPTION
### Motivation
- Reduce duplication in CLI encode/decode commands by consolidating shared workflow plumbing.
- Preserve existing stdout/file-output, summary, diagnostics, and exit-code behavior while sharing the setup path.

### Description
- Add shared helpers in `crates/copybook-cli/src/utils.rs` for strict-comments logging, copybook parse/projection, fail-fast/error-policy normalization, stdout vs atomic file output, and summary rendering.
- Update `encode` and `decode` commands to use the shared helpers while preserving command-specific options and summaries.
- Keep `SummaryIssueCountStyle` copyable and add summary tests for both nonzero and zero issue-count compatibility.
- This is the survivor for the overlapping #497/#498 CLI-helper pair; #497 is superseded once this merges.

### Testing
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 check -p copybook-cli`
- `cargo +1.95.0 test -p copybook-cli --bin copybook`
- `cargo +1.95.0 clippy -p copybook-cli --all-targets --all-features -- -D warnings`
- `git diff --check`

### Notes
- `cargo +1.95.0 clippy -p copybook-cli --all-targets --all-features -- -D warnings -W clippy::pedantic` currently fails on pre-existing test-suite lints outside this refactor, so the scoped gate above is the relevant local clippy check.