### PR TITLE
docs: define source-of-truth stack

### DIFF
--- a/.copybook/goals/README.md
+++ b/.copybook/goals/README.md
@@ -1,0 +1,59 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# Active goals
+
+The active goal manifest is the source of truth for **what agents should do
+now**.
+
+Use `.copybook/goals/active.toml` when a lane is selected. Archive superseded
+active manifests under `.copybook/goals/archive/`.
+
+## Manifest shape
+
+```toml
+id = "copybook-lane-id"
+title = "Human readable lane title"
+status = "active"
+owner = "codex-claude"
+created = "YYYY-MM-DD"
+
+proposal = "docs/proposals/COPYBOOK-PROP-0001-lane.md"
+plan = "plans/lane/implementation-plan.md"
+
+specs = [
+  "docs/specs/COPYBOOK-SPEC-0001-contract.md",
+]
+
+adrs = []
+
+objective = """
+State the current lane objective in one paragraph.
+"""
+
+end_state = [
+  "Checkable end-state outcome.",
+]
+
+claim_boundaries = [
+  "Do not broaden behavior beyond the linked spec.",
+]
+
+status_docs = [
+  "docs/reference/COBOL_SUPPORT_MATRIX.md",
+  "docs/ROADMAP.md",
+]
+
+[[work_item]]
+id = "work-item-id"
+status = "ready"
+spec = "docs/specs/COPYBOOK-SPEC-0001-contract.md"
+adr = "n/a"
+plan = "plans/lane/implementation-plan.md#work-item-work-item-id"
+current_pointer = "docs/ROADMAP.md"
+claim_boundary = "What this work item may and may not claim."
+commands = [
+  "git diff --check",
+]
+```
+
+Agents should not invent work when `active.toml` is absent, paused, stale, or
+missing linked files. They should stop and report the missing source of truth.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,42 @@
 
 <!-- Provide a brief description of what this PR does and why -->
 
+## Source-of-Truth Links
+
+Proposal: n/a
+Spec: n/a
+ADR: n/a
+Plan item: n/a
+Active goal: n/a
+
+## Scope
+
+- [ ] Proposal / why
+- [ ] Spec / behavior contract
+- [ ] ADR / durable decision
+- [ ] Plan / sequencing
+- [ ] Active goal / current execution state
+- [ ] Runtime / implementation
+- [ ] Policy ledger
+- [ ] Support-tier update
+- [ ] Generated status / receipt
+
+## Non-goals
+
+<!-- What this PR explicitly does not do -->
+
+## Proof
+
+```bash
+# commands run
+```
+
+Results:
+
+Claim boundary:
+
+Rollback:
+
 ## Type of Change
 
 <!-- Mark the relevant option with an 'x' -->

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -14,6 +14,7 @@ on:
       - 'tests/**'
       - 'Cargo.*'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches: [ main, develop ]
     paths:
       - 'crates/**'
@@ -30,9 +31,13 @@ env:
 
 jobs:
   coverage:
-    name: Code Coverage
+    name: Tarpaulin Coverage
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'coverage') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     steps:
     - name: Checkout code

--- a/.github/workflows/leak-detection.yml
+++ b/.github/workflows/leak-detection.yml
@@ -6,6 +6,7 @@ on:
   schedule:
     - cron: "0 4 * * 0"  # Weekly on Sunday at 04:00 UTC
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - "crates/copybook-codec/**"
       - "crates/copybook-core/**"
@@ -24,6 +25,10 @@ jobs:
     name: Memory Leak Detection (LSAN)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'leak-check') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     steps:
       - uses: actions/checkout@v6
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# AGENTS.md
+
+## Repo source-of-truth stack
+
+This repo uses a linked source-of-truth stack:
+
+```text
+Roadmap -> Proposal -> Spec -> ADR -> Plan -> Active goal -> PR -> Proof
+```
+
+Read these before changing files:
+
+1. `docs/reference/SPEC_SYSTEM.md`
+2. `.copybook/goals/active.toml` when it exists
+3. the linked implementation plan
+4. the linked spec for the selected work item
+5. linked ADRs
+
+## Scope rule
+
+Implement one work item per PR.
+
+Docs-only artifacts are separate PRs:
+
+- proposal PRs explain why;
+- spec PRs define behavior;
+- ADR PRs record durable decisions;
+- plan PRs define sequencing;
+- active goal PRs define current execution.
+
+Runtime/code PRs must link to the spec and plan item they implement.
+
+## Proof rule
+
+Run the proof commands listed in the plan item.
+
+If a proof command cannot run, record:
+
+- command;
+- reason unavailable;
+- substitute evidence if any;
+- whether this blocks merge.
+
+Always run `git diff --check` before completion.
+
+## Generated status rule
+
+Do not hand-edit generated status. Run the generator or checker named in the
+plan.
+
+## Policy rule
+
+If you add an exception, add or update the relevant `policy/*.toml` ledger with:
+
+- owner;
+- reason;
+- `covered_by`;
+- created;
+- `review_after`;
+- expiry if temporary.
+
+## Stop conditions
+
+Stop and report instead of guessing when:
+
+- the active goal is missing or stale and the request expects implementation;
+- linked specs or plans are missing;
+- proof commands cannot run;
+- unrelated staged changes exist;
+- generated status is dirty;
+- requested behavior contradicts an ADR;
+- the requested task would require a new proposal, spec, or ADR that was not
+  requested.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,28 @@
 
 Maintainer and operator guidance for Claude Code working in this repository.
 
+## Source-of-Truth Workflow
+
+Before changing files for a lane or work item, read:
+
+1. `docs/reference/SPEC_SYSTEM.md`
+2. `.copybook/goals/active.toml` when it exists
+3. the linked implementation plan
+4. the linked spec for the selected work item
+5. any linked ADRs
+
+Work on exactly one work item at a time. Do not create a new lane, mix semantic
+artifact types, broaden support claims, or hand-edit generated status unless the
+selected plan item explicitly requires it. A PR is ready only when the intended
+artifact or code change exists, linked docs are updated, proof commands have run
+or are explicitly marked unavailable, claim boundaries are respected, and
+`git diff --check` passes.
+
+Stop and report instead of guessing when the active goal is missing or stale,
+linked specs are missing, proof commands cannot run, generated status differs
+from committed status, requested work conflicts with an ADR, or the branch
+contains unrelated staged changes.
+
 ## Project Identity
 
 - Rust workspace, Edition 2024, MSRV 1.92

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
  "hex",
  "logos",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "serde_plain",
@@ -1049,7 +1049,7 @@ dependencies = [
  "copybook-codec",
  "copybook-core",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "sha2",
@@ -1156,7 +1156,7 @@ dependencies = [
  "copybook-support-matrix",
  "crossbeam-channel",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
 ]
@@ -3069,9 +3069,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -3364,9 +3364,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3780,7 +3780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/crates/copybook-cli/src/commands/audit.rs
+++ b/crates/copybook-cli/src/commands/audit.rs
@@ -2701,12 +2701,11 @@ fn run_audit_health_check_impl(
         );
     }
 
-    let overall_health_score = if checks_executed == 0 {
-        0
-    } else {
-        let failed_penalty = (checks_failed * 100) / checks_executed;
-        (100u32.saturating_sub(failed_penalty)).min(100)
-    };
+    let overall_health_score = (checks_failed * 100)
+        .checked_div(checks_executed)
+        .map_or(0, |failed_penalty| {
+            (100u32.saturating_sub(failed_penalty)).min(100)
+        });
 
     let status_code = if checks_failed > 0 || !parse_issues.is_empty() {
         ExitCode::Data

--- a/crates/copybook-cli/src/main.rs
+++ b/crates/copybook-cli/src/main.rs
@@ -554,13 +554,10 @@ fn main() -> ProcessExitCode {
 
 #[allow(clippy::too_many_lines)]
 fn run() -> anyhow::Result<ExitCode> {
-    #[allow(clippy::panic)]
-    if std::env::var("COPYBOOK_TEST_PANIC")
-        .map(|v| v == "1")
-        .unwrap_or(false)
-    {
-        panic!("COPYBOOK_TEST_PANIC triggered");
-    }
+    assert!(
+        !std::env::var("COPYBOOK_TEST_PANIC").is_ok_and(|v| v == "1"),
+        "COPYBOOK_TEST_PANIC triggered"
+    );
 
     let cli = match Cli::try_parse() {
         Ok(cli) => cli,

--- a/crates/copybook-codec/src/fidelity.rs
+++ b/crates/copybook-codec/src/fidelity.rs
@@ -948,11 +948,9 @@ pub mod utils {
             .map(|p| p.validation_time_ms)
             .sum();
         let total_records_u64 = u64::try_from(total_records).unwrap_or(u64::MAX);
-        let average_validation_time = if total_records_u64 == 0 {
-            0
-        } else {
-            total_validation_time / total_records_u64
-        };
+        let average_validation_time = total_validation_time
+            .checked_div(total_records_u64)
+            .unwrap_or(0);
 
         BatchFidelityMetrics {
             total_records,

--- a/crates/copybook-contracts/src/feature_flags.rs
+++ b/crates/copybook-contracts/src/feature_flags.rs
@@ -530,8 +530,7 @@ impl FeatureFlagsHandle {
     pub fn is_enabled(&self, feature: Feature) -> bool {
         self.flags
             .read()
-            .map(|flags| flags.is_enabled(feature))
-            .unwrap_or(false)
+            .is_ok_and(|flags| flags.is_enabled(feature))
     }
 
     /// Enable a feature flag through the handle.

--- a/crates/copybook-core/src/audit/security.rs
+++ b/crates/copybook-core/src/audit/security.rs
@@ -421,8 +421,7 @@ impl SecurityMonitor {
         let priority = 16 * 8 + 4; // 132
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_secs());
         format!(
             "<{}>1 {} copybook-rs SecurityMonitor - {} - {}",
             priority, timestamp, violation.violation_id, violation.description

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ Start with **[START_HERE.md](START_HERE.md)** for the hand-maintained navigation
 - [COBOL Support Matrix](reference/COBOL_SUPPORT_MATRIX.md) -- feature coverage
 - [Error Codes](reference/ERROR_CODES.md) -- 10 families, 61 stable codes
 - [CLI Examples](reference/CLI_EXAMPLES.md) -- copy-paste command recipes
+- [Source-of-Truth System](reference/SPEC_SYSTEM.md) -- repo control plane for proposals, specs, ADRs, plans, active goals, and proof
 
 ### Project
 - [Roadmap](ROADMAP.md) -- project status, next/later plan
@@ -25,6 +26,8 @@ Start with **[START_HERE.md](START_HERE.md)** for the hand-maintained navigation
 - [Release Process](RELEASE_PROCESS.md) -- release workflow
 
 ### Architecture
+- [Proposals](proposals/) -- lane motivation, users, risks, and success criteria
+- [Specs](specs/) -- behavior contracts, acceptance examples, and proof requirements
 - [Architecture Decision Records](adr/) -- ADRs for significant decisions
 - [Design docs](design/) -- ODO, RENAMES, feature contracts
 - [Internal feature specs](internal/features/) -- dialect lever, edited PIC

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,41 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# Architecture Decision Records
+
+ADRs are the source of truth for **durable decisions**.
+
+Use ADRs sparingly. A good ADR should still matter six months after it lands.
+ADRs own context, the selected decision, consequences, rejected alternatives, and
+follow-up specs or plans. They do not own PR task lists, current metric state, or
+implementation queues.
+
+## Naming
+
+Existing historical ADRs use `ADR-*` names. New source-of-truth ADRs should use
+stable copybook-rs IDs:
+
+```text
+COPYBOOK-ADR-0001-<durable-decision>.md
+```
+
+## Required shape
+
+```md
+# COPYBOOK-ADR-0001: Decision title
+
+Status: accepted
+Date: YYYY-MM-DD
+Owner: n/a
+Linked proposal: n/a
+Linked specs: n/a
+Linked plan: n/a
+
+## Decision
+
+## Context
+
+## Consequences
+
+## Alternatives considered
+
+## Follow-up specs / plans
+```

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -1,0 +1,61 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# Proposals
+
+Proposals are the source of truth for **why** a lane exists.
+
+A proposal owns user pain, affected surfaces, success criteria, rejected alternatives,
+risks, non-goals, and the specs or ADRs a lane needs. It does not own exact PR
+sequencing, implementation details, generated status, or proof receipts.
+
+## Naming
+
+Use stable, boring IDs:
+
+```text
+COPYBOOK-PROP-0001-<lane>.md
+```
+
+## Required shape
+
+```md
+# COPYBOOK-PROP-0001: Lane title
+
+Status: proposed
+Owner: n/a
+Created: YYYY-MM-DD
+Target milestone: n/a
+Linked specs: n/a
+Linked ADRs: n/a
+Linked plan: n/a
+Support/status impact: n/a
+Policy impact: n/a
+
+## Problem
+
+## Users and surfaces
+
+## Success criteria
+
+## Proposed shape
+
+## Alternatives considered
+
+## Specs to create or update
+
+## ADRs needed
+
+## Implementation campaign shape
+
+## Evidence plan
+
+## Risks
+
+## Non-goals
+
+## Exit criteria
+
+## Claim boundary
+```
+
+Keep PR order and task details in `plans/<lane>/implementation-plan.md`, not in
+proposal documents.

--- a/docs/reference/SPEC_SYSTEM.md
+++ b/docs/reference/SPEC_SYSTEM.md
@@ -1,0 +1,190 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# Repo source-of-truth system
+
+copybook-rs uses a linked source-of-truth stack so humans and agents can tell
+which artifact owns each kind of truth.
+
+## Stack
+
+```text
+Roadmap
+  -> Proposal
+    -> Spec
+      -> ADR
+        -> Implementation plan
+          -> Active goal
+            -> PR
+              -> Proof
+```
+
+## Artifact roles
+
+| Artifact | Owns | Does not own |
+|---|---|---|
+| Roadmap | release direction and milestone framing | detailed PR queue |
+| Proposal | why, users, alternatives, risks | behavior contract or exact PR order |
+| Spec | behavior, acceptance, examples, proof | product rationale or PR sequence |
+| ADR | durable decision and consequences | task list or current status |
+| Plan | PR order, proof commands, rollback | product rationale or architecture decision |
+| Active goal | current machine-readable work | generated status or long prose |
+| Support tiers | public claim proof | feature design |
+| Policy ledgers | exceptions and CI or policy receipts | broad architecture |
+
+## Rules
+
+1. One kind of truth per artifact.
+2. One semantic artifact per PR unless the linked plan says otherwise.
+3. Specs define behavior; plans define sequencing.
+4. Proposals explain why; ADRs record durable decisions.
+5. Active goals tell agents what to do now.
+6. Generated status is updated by tools, not by hand.
+7. Public claims require a support-tier row or equivalent proof pointer.
+8. Policy exceptions require owner, reason, coverage, and review date.
+
+## Required headers
+
+Every new proposal, spec, ADR, and plan should include the applicable headers
+below. Use `n/a` when a header does not apply.
+
+```text
+Status:
+Owner:
+Created:
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Linked issues:
+Linked PRs:
+Support-tier impact:
+Policy impact:
+```
+
+## Agent workflow
+
+Agents must:
+
+1. read repo instructions such as `AGENTS.md` or `CLAUDE.md`;
+2. read this source-of-truth system;
+3. read `.copybook/goals/active.toml` when it exists;
+4. choose exactly one ready work item from the active goal and linked plan;
+5. read the linked spec for acceptance and linked ADRs for constraints;
+6. implement only that item;
+7. run the listed proof commands;
+8. update receipts, status, or policy ledgers only when the work item requires
+   it;
+9. stop on missing or contradictory source-of-truth artifacts.
+
+## Stop conditions
+
+Stop and report instead of guessing when:
+
+- the active goal is missing, paused, stale, or references missing files;
+- linked specs or plans do not exist;
+- proof commands cannot run;
+- generated status differs from committed status;
+- unrelated staged files exist;
+- requested work conflicts with an ADR;
+- a public claim lacks support-tier proof.
+
+## Active goal lifecycle
+
+Activate one lane at a time with:
+
+```text
+.copybook/goals/active.toml
+```
+
+Set `status = "paused"` with a reason when no lane is selected. Archive old
+manifests under:
+
+```text
+.copybook/goals/archive/YYYY-MM-DD-<lane>.toml
+```
+
+Do not leave multiple active goals.
+
+## Closeout format
+
+At the end of a lane, write `plans/<lane>/closeout.md`:
+
+```md
+# Lane closeout: <lane>
+
+Status: completed
+Date: YYYY-MM-DD
+Owner: n/a
+Linked proposal: n/a
+Linked specs: n/a
+Linked ADRs: n/a
+Linked plan: plans/<lane>/implementation-plan.md
+Active goal archive: .copybook/goals/archive/YYYY-MM-DD-<lane>.toml
+
+## What shipped
+
+## Proof
+
+## Receipts
+
+## What did not ship
+
+## Deferred work
+
+## Claim boundary
+
+## Next lane recommendation
+```
+
+## Common failure modes
+
+### Spec becomes a task list
+
+Move PR order to `plans/<lane>/implementation-plan.md`; keep the spec focused on
+behavior, examples, and proof.
+
+### Plan becomes product rationale
+
+Move user pain, alternatives, and lane motivation to `docs/proposals/`; keep the
+plan focused on work items.
+
+### Active goal becomes prose
+
+Keep `.copybook/goals/active.toml` machine-readable and link out to documents.
+Do not add long generated tables.
+
+### Agent hand-edits generated status
+
+Add a generated-status rule, make the generator command explicit, and run the
+checker instead of hand-editing generated outputs.
+
+### Support claims drift
+
+Require a support-tier impact header and proof pointer before broadening public
+README claims.
+
+### Policy exceptions become silent debt
+
+Every exception must have owner, reason, `covered_by`, `review_after`, and an
+expiry when temporary.
+
+### Mega PR
+
+Use one semantic artifact per PR and one implementation work item per runtime
+PR.
+
+## What good looks like
+
+A new contributor or agent can arrive cold and answer:
+
+```text
+What are we doing?
+Why?
+What must be true?
+What decision constrains it?
+What PR lands next?
+What command proves it?
+What may we claim?
+What must we not claim?
+```
+
+If the repo answers those questions without chat history, the method is working.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,71 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# Specs
+
+Specs are the source of truth for **what must be true**.
+
+A spec owns required behavior, non-goals, acceptance examples, proof
+requirements, test mapping, implementation mapping, CI proof, and support-tier
+impact. It does not own product rationale, PR sequencing, active queues, or
+durable architecture decisions unless unavoidable.
+
+## Naming
+
+Use stable, boring IDs:
+
+```text
+COPYBOOK-SPEC-0001-<behavior-contract>.md
+```
+
+## Required shape
+
+````md
+# COPYBOOK-SPEC-0001: Behavior contract title
+
+Status: accepted
+Owner: n/a
+Created: YYYY-MM-DD
+Linked proposal: n/a
+Linked ADRs: n/a
+Linked plan: n/a
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: n/a
+Policy impact: n/a
+
+## Problem
+
+## Behavior
+
+## Non-goals
+
+## Required evidence
+
+## Acceptance examples
+
+### Example: accepted
+
+```text
+input / command / fixture
+expected behavior
+```
+
+### Example: rejected
+
+```text
+input / command / fixture
+expected rejection or failure mode
+```
+
+## Test mapping
+
+## Implementation mapping
+
+## CI proof
+
+## Metrics / promotion rule
+
+## Claim boundaries
+````
+
+Specs should answer agent and reviewer questions about behavior without turning
+into task lists.

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,70 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# Plans
+
+Plans are the source of truth for **how work lands**.
+
+A lane plan owns PR sequence, work items, dependencies, proof commands, rollback,
+and status handoff. It does not own product motivation, durable architecture, or
+generated status truth.
+
+## Layout
+
+```text
+plans/
+  <lane>/
+    README.md
+    implementation-plan.md
+    closeout.md
+```
+
+## Implementation plan shape
+
+````md
+# Lane implementation plan
+
+Status: active
+Owner: n/a
+Created: YYYY-MM-DD
+Linked proposal: n/a
+Linked specs: n/a
+Linked ADRs: n/a
+Linked plan: self
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: n/a
+Policy impact: n/a
+Active goal: .copybook/goals/active.toml
+
+## Current state
+
+## Work item: short-id
+
+Status: ready | active | blocked | completed | superseded
+Linked proposal: n/a
+Linked spec: n/a
+Linked ADR: n/a
+Blocks: n/a
+Blocked by: n/a
+
+### Goal
+
+### Production delta
+
+### Non-goals
+
+### Acceptance
+
+### Proof commands
+
+```bash
+git diff --check
+```
+
+### Rollback
+
+### Notes
+````
+
+If a plan starts explaining why a lane exists, move that material to
+`docs/proposals/`. If it starts defining behavior contracts, move that material
+to `docs/specs/`.


### PR DESCRIPTION
### Motivation

- Provide a machine- and human-readable source-of-truth stack so agents and contributors know which artifact owns each kind of truth.
- Prevent agents from improvising by separating `why` (proposals), `what` (specs), `decision` (ADRs), `how` (plans), `what now` (active goals), and `what proves it` (proof/receipts).
- Give a boring, stable scaffold and templates so new lanes and work items follow the same control plane.
- Make agent workflows and stop conditions explicit to avoid drift and accidental behavior changes.

### Description

- Add `docs/reference/SPEC_SYSTEM.md` that defines the stack, artifact roles, required headers, agent workflow, stop conditions, active-goal lifecycle, and closeout format.
- Add scaffolding and templates under `docs/` and `plans/` including `docs/proposals/README.md`, `docs/specs/README.md`, `docs/adr/README.md`, `plans/README.md`, and `.copybook/goals/README.md` to standardize proposals, specs, ADRs, plans, and active goal manifests.
- Add `AGENTS.md` with Codex/agent-facing rules and update `CLAUDE.md` to include a matching source-of-truth workflow and stop rules.
- Extend the PR template in `.github/PULL_REQUEST_TEMPLATE.md` and the docs index `docs/README.md` to reference the source-of-truth system and require source-of-truth links, scope, proof, claim boundary, and rollback fields.
- Refresh the shared CI/security baseline for this branch by applying Rust 1.95 Clippy cleanups and updating vulnerable lockfile entries: `rustls-webpki` `0.103.10 -> 0.103.13` and `rand` `0.10.0 -> 0.10.1`.
- Label-gate heavyweight advisory CI so tarpaulin coverage and LSAN leak detection run on PRs only when `coverage`, `leak-check`, or `full-ci` is requested.

### Testing

- `git diff --check`
- `cargo +1.95.0 fmt --all --check`
- `cargo +1.95.0 clippy --workspace --lib --bins --examples --all-features -- -D warnings -W clippy::pedantic`
- `cargo +1.95.0 clippy --workspace --tests --all-features -- -D warnings -A clippy::unwrap_used -A clippy::expect_used -A clippy::panic -A clippy::dbg_macro -A clippy::print_stdout -A clippy::print_stderr -A clippy::missing_inline_in_public_items -A clippy::duplicated_attributes -A deprecated`
- `cargo deny --workspace --all-features check`
- `COPYBOOK_FF_SIGN_SEPARATE=1 cargo +1.95.0 test --workspace --lib --features audit`
- `COPYBOOK_FF_SIGN_SEPARATE=1 cargo +1.95.0 clippy --workspace --lib --bins --examples -- -D warnings -W clippy::pedantic`
- `COPYBOOK_FF_SIGN_SEPARATE=1 cargo +1.95.0 build --release -p copybook-cli --features audit`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a180871c08333aafd344e430e57a3)