### PR TITLE
docs: fill out claude.md navigation files across workspace

### DIFF
--- a/crates/claude.md
+++ b/crates/claude.md
@@ -1,0 +1,30 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Holds the 36 publishable crates of the copybook-rs workspace (plus 2 facade/alias crates).
+- Organized by layer; see the "Workspace Layout" table in `../CLAUDE.md`.
+
+## Layers at a glance
+| Layer | Crates |
+|---|---|
+| Facade | `copybook`, `copybook-rs` |
+| Parser | `copybook-core`, `copybook-lexer` |
+| Codec | `copybook-codec`, `copybook-codec-memory`, `copybook-codepage`, `copybook-charset`, `copybook-overpunch`, `copybook-zoned-format` |
+| CLI | `copybook-cli`, `copybook-cli-determinism`, `copybook-options` |
+| Framing | `copybook-fixed`, `copybook-rdw`, `copybook-rdw-predicates`, `copybook-record-io` |
+| Schema | `copybook-dialect`, `copybook-determinism`, `copybook-support-matrix` |
+| Governance | `copybook-contracts`, `copybook-governance`, `copybook-governance-contracts`, `copybook-governance-grid`, `copybook-governance-runtime` |
+| Safety | `copybook-error`, `copybook-error-reporter`, `copybook-overflow`, `copybook-safe-index`, `copybook-safe-ops`, `copybook-safe-text`, `copybook-utils` |
+| Quality | `copybook-corruption`, `copybook-corruption-detectors`, `copybook-corruption-predicates`, `copybook-corruption-rdw` |
+| Other | `copybook-arrow`, `copybook-sequence-ring` |
+
+## Navigation
+- Repository root + invariants: `../CLAUDE.md`
+- Per-crate guidance: each `<crate>/claude.md`
+- Canonical feature/error docs: `../docs/`
+
+## Build
+- `cargo build --workspace` (everything) or `cargo build -p <crate>` (one)
+- `cargo test --workspace`
+- `cargo clippy --workspace -- -D warnings -W clippy::pedantic`

--- a/crates/copybook-arrow/claude.md
+++ b/crates/copybook-arrow/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- COBOL schema conversion to Apache Arrow and Parquet formats.
+- Layer: **Other**.
+- Workspace package `copybook-arrow` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-arrow`
+- Test: `cargo test -p copybook-arrow`
+- Lint: `cargo clippy -p copybook-arrow -- -D warnings`

--- a/crates/copybook-arrow/examples/claude.md
+++ b/crates/copybook-arrow/examples/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Runnable examples demonstrating `copybook-arrow` usage.
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo run -p copybook-arrow --example <name>`

--- a/crates/copybook-arrow/src/claude.md
+++ b/crates/copybook-arrow/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-arrow` (Other layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-arrow`

--- a/crates/copybook-arrow/tests/claude.md
+++ b/crates/copybook-arrow/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-arrow` (Other layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-arrow`

--- a/crates/copybook-charset/claude.md
+++ b/crates/copybook-charset/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Character set conversion utilities for EBCDIC/ASCII encoding.
+- Layer: **Codec**.
+- Workspace package `copybook-charset` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-charset`
+- Test: `cargo test -p copybook-charset`
+- Lint: `cargo clippy -p copybook-charset -- -D warnings`

--- a/crates/copybook-charset/src/claude.md
+++ b/crates/copybook-charset/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-charset` (Codec layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-charset`

--- a/crates/copybook-charset/tests/claude.md
+++ b/crates/copybook-charset/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-charset` (Codec layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-charset`

--- a/crates/copybook-cli-determinism/claude.md
+++ b/crates/copybook-cli-determinism/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Determinism command execution and output rendering for the copybook CLI.
+- Layer: **CLI**.
+- Workspace package `copybook-cli-determinism` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-cli-determinism`
+- Test: `cargo test -p copybook-cli-determinism`
+- Lint: `cargo clippy -p copybook-cli-determinism -- -D warnings`

--- a/crates/copybook-cli-determinism/src/claude.md
+++ b/crates/copybook-cli-determinism/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-cli-determinism` (CLI layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-cli-determinism`

--- a/crates/copybook-cli-determinism/tests/claude.md
+++ b/crates/copybook-cli-determinism/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-cli-determinism` (CLI layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-cli-determinism`

--- a/crates/copybook-cli/claude.md
+++ b/crates/copybook-cli/claude.md
@@ -1,0 +1,17 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- CLI for parsing, decoding, encoding, and verifying COBOL copybook data (clap).
+- Layer: **CLI**.
+- Workspace package `copybook-cli` (see `Cargo.toml`).
+- Subcommands: `src/commands/`
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-cli`
+- Test: `cargo test -p copybook-cli`
+- Lint: `cargo clippy -p copybook-cli -- -D warnings`

--- a/crates/copybook-cli/src/claude.md
+++ b/crates/copybook-cli/src/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-cli` (CLI layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Subcommand modules: `commands/`
+
+## Build
+- `cargo build -p copybook-cli`

--- a/crates/copybook-cli/src/commands/claude.md
+++ b/crates/copybook-cli/src/commands/claude.md
@@ -2,7 +2,7 @@
 # claude.md
 
 ## Scope
-- CLI subcommand implementations for `copybook-cli`: `parse`, `decode`, `encode`, `verify`, `inspect`, `support`, `determinism`, `audit`.
+- CLI subcommand implementations for `copybook-cli`: `parse`, `decode`, `encode`, `verify`, `verify_report`, `inspect`, `support`, `determinism`, `audit`.
 
 ## Navigation
 - CLI crate root: `../../claude.md`

--- a/crates/copybook-cli/src/commands/claude.md
+++ b/crates/copybook-cli/src/commands/claude.md
@@ -1,0 +1,14 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- CLI subcommand implementations for `copybook-cli`: `parse`, `decode`, `encode`, `verify`, `inspect`, `support`, `determinism`, `audit`.
+
+## Navigation
+- CLI crate root: `../../claude.md`
+- CLI sources: `../claude.md`
+- Repository root: `../../../../CLAUDE.md`
+- CLI flags/examples: `../../../../docs/CLI_REFERENCE.md`
+
+## Build
+- `cargo build -p copybook-cli`

--- a/crates/copybook-cli/tests/claude.md
+++ b/crates/copybook-cli/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-cli` (CLI layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-cli`

--- a/crates/copybook-codec-memory/claude.md
+++ b/crates/copybook-codec-memory/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Reusable memory utilities (scratch buffers) for codec streaming and parallelism.
+- Layer: **Codec**.
+- Workspace package `copybook-codec-memory` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-codec-memory`
+- Test: `cargo test -p copybook-codec-memory`
+- Lint: `cargo clippy -p copybook-codec-memory -- -D warnings`

--- a/crates/copybook-codec-memory/src/claude.md
+++ b/crates/copybook-codec-memory/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-codec-memory` (Codec layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-codec-memory`

--- a/crates/copybook-codec-memory/tests/claude.md
+++ b/crates/copybook-codec-memory/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-codec-memory` (Codec layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-codec-memory`

--- a/crates/copybook-codec/claude.md
+++ b/crates/copybook-codec/claude.md
@@ -1,0 +1,17 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Deterministic COBOL copybook codec for EBCDIC/ASCII fixed and RDW records. Schema -> encode/decode binary <-> JSON.
+- Layer: **Codec**.
+- Workspace package `copybook-codec` (see `Cargo.toml`).
+- Raw data capture (`__raw_b64`) convention: see root `CLAUDE.md`
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-codec`
+- Test: `cargo test -p copybook-codec`
+- Lint: `cargo clippy -p copybook-codec -- -D warnings`

--- a/crates/copybook-codec/examples/claude.md
+++ b/crates/copybook-codec/examples/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Runnable examples demonstrating `copybook-codec` usage.
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo run -p copybook-codec --example <name>`

--- a/crates/copybook-codec/src/claude.md
+++ b/crates/copybook-codec/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-codec` (Codec layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-codec`

--- a/crates/copybook-codec/tests/claude.md
+++ b/crates/copybook-codec/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-codec` (Codec layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-codec`

--- a/crates/copybook-codepage/claude.md
+++ b/crates/copybook-codepage/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Codepage and unmappable-character policy types (CP037/CP273/CP500/CP1047/CP1140).
+- Layer: **Codec**.
+- Workspace package `copybook-codepage` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-codepage`
+- Test: `cargo test -p copybook-codepage`
+- Lint: `cargo clippy -p copybook-codepage -- -D warnings`

--- a/crates/copybook-codepage/src/claude.md
+++ b/crates/copybook-codepage/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-codepage` (Codec layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-codepage`

--- a/crates/copybook-codepage/tests/claude.md
+++ b/crates/copybook-codepage/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-codepage` (Codec layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-codepage`

--- a/crates/copybook-contracts/claude.md
+++ b/crates/copybook-contracts/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Shared contracts for feature-flag governance and runtime control.
+- Layer: **Governance**.
+- Workspace package `copybook-contracts` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-contracts`
+- Test: `cargo test -p copybook-contracts`
+- Lint: `cargo clippy -p copybook-contracts -- -D warnings`

--- a/crates/copybook-contracts/src/claude.md
+++ b/crates/copybook-contracts/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-contracts` (Governance layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-contracts`

--- a/crates/copybook-contracts/tests/claude.md
+++ b/crates/copybook-contracts/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-contracts` (Governance layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-contracts`

--- a/crates/copybook-core/claude.md
+++ b/crates/copybook-core/claude.md
@@ -1,0 +1,17 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Core COBOL copybook parser, schema, and validation primitives. Produces the Schema AST consumed by the codec.
+- Layer: **Parser**.
+- Workspace package `copybook-core` (see `Cargo.toml`).
+- Audit module: `src/audit/`
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-core`
+- Test: `cargo test -p copybook-core`
+- Lint: `cargo clippy -p copybook-core -- -D warnings`

--- a/crates/copybook-core/src/audit/claude.md
+++ b/crates/copybook-core/src/audit/claude.md
@@ -1,0 +1,14 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Enterprise audit submodules for `copybook-core`: compliance, context, events, lineage, logging, performance, reporting, security.
+
+## Navigation
+- Core crate root: `../../claude.md`
+- Core sources: `../claude.md`
+- Repository root: `../../../../CLAUDE.md`
+- Performance/audit policy: `../../../../docs/PERFORMANCE_GOVERNANCE.md`
+
+## Build
+- `cargo build -p copybook-core`

--- a/crates/copybook-core/src/audit/claude.md
+++ b/crates/copybook-core/src/audit/claude.md
@@ -2,7 +2,7 @@
 # claude.md
 
 ## Scope
-- Enterprise audit submodules for `copybook-core`: compliance, context, events, lineage, logging, performance, reporting, security.
+- Enterprise audit submodules for `copybook-core`: compliance, context, event, lineage, logger, performance, report, security.
 
 ## Navigation
 - Core crate root: `../../claude.md`

--- a/crates/copybook-core/src/claude.md
+++ b/crates/copybook-core/src/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-core` (Parser layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Audit submodules: `audit/`
+
+## Build
+- `cargo build -p copybook-core`

--- a/crates/copybook-core/tests/claude.md
+++ b/crates/copybook-core/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-core` (Parser layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-core`

--- a/crates/copybook-corruption-detectors/claude.md
+++ b/crates/copybook-corruption-detectors/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Focused corruption detectors for transfer-corruption heuristics.
+- Layer: **Quality**.
+- Workspace package `copybook-corruption-detectors` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-corruption-detectors`
+- Test: `cargo test -p copybook-corruption-detectors`
+- Lint: `cargo clippy -p copybook-corruption-detectors -- -D warnings`

--- a/crates/copybook-corruption-detectors/src/claude.md
+++ b/crates/copybook-corruption-detectors/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-corruption-detectors` (Quality layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-corruption-detectors`

--- a/crates/copybook-corruption-detectors/tests/claude.md
+++ b/crates/copybook-corruption-detectors/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-corruption-detectors` (Quality layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-corruption-detectors`

--- a/crates/copybook-corruption-predicates/claude.md
+++ b/crates/copybook-corruption-predicates/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Pure byte predicate helpers for transfer-corruption detection.
+- Layer: **Quality**.
+- Workspace package `copybook-corruption-predicates` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-corruption-predicates`
+- Test: `cargo test -p copybook-corruption-predicates`
+- Lint: `cargo clippy -p copybook-corruption-predicates -- -D warnings`

--- a/crates/copybook-corruption-predicates/src/claude.md
+++ b/crates/copybook-corruption-predicates/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-corruption-predicates` (Quality layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-corruption-predicates`

--- a/crates/copybook-corruption-predicates/tests/claude.md
+++ b/crates/copybook-corruption-predicates/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-corruption-predicates` (Quality layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-corruption-predicates`

--- a/crates/copybook-corruption-rdw/claude.md
+++ b/crates/copybook-corruption-rdw/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Single-purpose RDW ASCII-heuristic corruption detection.
+- Layer: **Quality**.
+- Workspace package `copybook-corruption-rdw` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-corruption-rdw`
+- Test: `cargo test -p copybook-corruption-rdw`
+- Lint: `cargo clippy -p copybook-corruption-rdw -- -D warnings`

--- a/crates/copybook-corruption-rdw/src/claude.md
+++ b/crates/copybook-corruption-rdw/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-corruption-rdw` (Quality layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-corruption-rdw`

--- a/crates/copybook-corruption-rdw/tests/claude.md
+++ b/crates/copybook-corruption-rdw/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-corruption-rdw` (Quality layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-corruption-rdw`

--- a/crates/copybook-corruption/claude.md
+++ b/crates/copybook-corruption/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Transfer-corruption detection microcrate for codec heuristics.
+- Layer: **Quality**.
+- Workspace package `copybook-corruption` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-corruption`
+- Test: `cargo test -p copybook-corruption`
+- Lint: `cargo clippy -p copybook-corruption -- -D warnings`

--- a/crates/copybook-corruption/src/claude.md
+++ b/crates/copybook-corruption/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-corruption` (Quality layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-corruption`

--- a/crates/copybook-corruption/tests/claude.md
+++ b/crates/copybook-corruption/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-corruption` (Quality layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-corruption`

--- a/crates/copybook-determinism/claude.md
+++ b/crates/copybook-determinism/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Determinism primitives for stable hash/diff comparison.
+- Layer: **Schema**.
+- Workspace package `copybook-determinism` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-determinism`
+- Test: `cargo test -p copybook-determinism`
+- Lint: `cargo clippy -p copybook-determinism -- -D warnings`

--- a/crates/copybook-determinism/src/claude.md
+++ b/crates/copybook-determinism/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-determinism` (Schema layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-determinism`

--- a/crates/copybook-determinism/tests/claude.md
+++ b/crates/copybook-determinism/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-determinism` (Schema layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-determinism`

--- a/crates/copybook-dialect/claude.md
+++ b/crates/copybook-dialect/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Dialect contract for ODO min_count semantics.
+- Layer: **Schema**.
+- Workspace package `copybook-dialect` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-dialect`
+- Test: `cargo test -p copybook-dialect`
+- Lint: `cargo clippy -p copybook-dialect -- -D warnings`

--- a/crates/copybook-dialect/src/claude.md
+++ b/crates/copybook-dialect/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-dialect` (Schema layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-dialect`

--- a/crates/copybook-dialect/tests/claude.md
+++ b/crates/copybook-dialect/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-dialect` (Schema layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-dialect`

--- a/crates/copybook-error-reporter/claude.md
+++ b/crates/copybook-error-reporter/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Structured error reporting policies and summaries.
+- Layer: **Safety**.
+- Workspace package `copybook-error-reporter` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-error-reporter`
+- Test: `cargo test -p copybook-error-reporter`
+- Lint: `cargo clippy -p copybook-error-reporter -- -D warnings`

--- a/crates/copybook-error-reporter/src/claude.md
+++ b/crates/copybook-error-reporter/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-error-reporter` (Safety layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-error-reporter`

--- a/crates/copybook-error-reporter/tests/claude.md
+++ b/crates/copybook-error-reporter/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-error-reporter` (Safety layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-error-reporter`

--- a/crates/copybook-error/claude.md
+++ b/crates/copybook-error/claude.md
@@ -1,0 +1,17 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Error types and taxonomy (10 families, 61 stable codes) for copybook-rs.
+- Layer: **Safety**.
+- Workspace package `copybook-error` (see `Cargo.toml`).
+- Error code catalog: `../../docs/reference/ERROR_CODES.md`
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-error`
+- Test: `cargo test -p copybook-error`
+- Lint: `cargo clippy -p copybook-error -- -D warnings`

--- a/crates/copybook-error/src/claude.md
+++ b/crates/copybook-error/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-error` (Safety layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-error`

--- a/crates/copybook-error/tests/claude.md
+++ b/crates/copybook-error/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-error` (Safety layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-error`

--- a/crates/copybook-fixed/claude.md
+++ b/crates/copybook-fixed/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Fixed-length (LRECL) record framing reader/writer primitives.
+- Layer: **Framing**.
+- Workspace package `copybook-fixed` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-fixed`
+- Test: `cargo test -p copybook-fixed`
+- Lint: `cargo clippy -p copybook-fixed -- -D warnings`

--- a/crates/copybook-fixed/src/claude.md
+++ b/crates/copybook-fixed/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-fixed` (Framing layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-fixed`

--- a/crates/copybook-fixed/tests/claude.md
+++ b/crates/copybook-fixed/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-fixed` (Framing layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-fixed`

--- a/crates/copybook-governance-contracts/claude.md
+++ b/crates/copybook-governance-contracts/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Contracts facade for feature flags and support matrix interoperability.
+- Layer: **Governance**.
+- Workspace package `copybook-governance-contracts` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-governance-contracts`
+- Test: `cargo test -p copybook-governance-contracts`
+- Lint: `cargo clippy -p copybook-governance-contracts -- -D warnings`

--- a/crates/copybook-governance-contracts/src/claude.md
+++ b/crates/copybook-governance-contracts/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-governance-contracts` (Governance layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-governance-contracts`

--- a/crates/copybook-governance-contracts/tests/claude.md
+++ b/crates/copybook-governance-contracts/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-governance-contracts` (Governance layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-governance-contracts`

--- a/crates/copybook-governance-grid/claude.md
+++ b/crates/copybook-governance-grid/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Governance grid mapping between support matrix entries and runtime feature flags.
+- Layer: **Governance**.
+- Workspace package `copybook-governance-grid` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-governance-grid`
+- Test: `cargo test -p copybook-governance-grid`
+- Lint: `cargo clippy -p copybook-governance-grid -- -D warnings`

--- a/crates/copybook-governance-grid/src/claude.md
+++ b/crates/copybook-governance-grid/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-governance-grid` (Governance layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-governance-grid`

--- a/crates/copybook-governance-grid/tests/claude.md
+++ b/crates/copybook-governance-grid/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-governance-grid` (Governance layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-governance-grid`

--- a/crates/copybook-governance-runtime/claude.md
+++ b/crates/copybook-governance-runtime/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Runtime governance state evaluation for support-matrix and feature-flag interoperability.
+- Layer: **Governance**.
+- Workspace package `copybook-governance-runtime` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-governance-runtime`
+- Test: `cargo test -p copybook-governance-runtime`
+- Lint: `cargo clippy -p copybook-governance-runtime -- -D warnings`

--- a/crates/copybook-governance-runtime/src/claude.md
+++ b/crates/copybook-governance-runtime/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-governance-runtime` (Governance layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-governance-runtime`

--- a/crates/copybook-governance-runtime/tests/claude.md
+++ b/crates/copybook-governance-runtime/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-governance-runtime` (Governance layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-governance-runtime`

--- a/crates/copybook-governance/claude.md
+++ b/crates/copybook-governance/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Governance contracts and interoperability map for feature flags and support matrix.
+- Layer: **Governance**.
+- Workspace package `copybook-governance` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-governance`
+- Test: `cargo test -p copybook-governance`
+- Lint: `cargo clippy -p copybook-governance -- -D warnings`

--- a/crates/copybook-governance/src/claude.md
+++ b/crates/copybook-governance/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-governance` (Governance layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-governance`

--- a/crates/copybook-governance/tests/claude.md
+++ b/crates/copybook-governance/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-governance` (Governance layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-governance`

--- a/crates/copybook-lexer/claude.md
+++ b/crates/copybook-lexer/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- COBOL copybook lexical analysis and tokenization primitives (logos-based).
+- Layer: **Parser**.
+- Workspace package `copybook-lexer` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-lexer`
+- Test: `cargo test -p copybook-lexer`
+- Lint: `cargo clippy -p copybook-lexer -- -D warnings`

--- a/crates/copybook-lexer/src/claude.md
+++ b/crates/copybook-lexer/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-lexer` (Parser layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-lexer`

--- a/crates/copybook-lexer/tests/claude.md
+++ b/crates/copybook-lexer/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-lexer` (Parser layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-lexer`

--- a/crates/copybook-options/claude.md
+++ b/crates/copybook-options/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Configuration option contracts (DecodeOptions/EncodeOptions) shared across codec workflows.
+- Layer: **CLI**.
+- Workspace package `copybook-options` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-options`
+- Test: `cargo test -p copybook-options`
+- Lint: `cargo clippy -p copybook-options -- -D warnings`

--- a/crates/copybook-options/src/claude.md
+++ b/crates/copybook-options/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-options` (CLI layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-options`

--- a/crates/copybook-options/tests/claude.md
+++ b/crates/copybook-options/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-options` (CLI layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-options`

--- a/crates/copybook-overflow/claude.md
+++ b/crates/copybook-overflow/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Overflow-safe integer narrowing and bounds arithmetic.
+- Layer: **Safety**.
+- Workspace package `copybook-overflow` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-overflow`
+- Test: `cargo test -p copybook-overflow`
+- Lint: `cargo clippy -p copybook-overflow -- -D warnings`

--- a/crates/copybook-overflow/src/claude.md
+++ b/crates/copybook-overflow/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-overflow` (Safety layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-overflow`

--- a/crates/copybook-overflow/tests/claude.md
+++ b/crates/copybook-overflow/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-overflow` (Safety layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-overflow`

--- a/crates/copybook-overpunch/claude.md
+++ b/crates/copybook-overpunch/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Zoned decimal overpunch encode/decode primitives.
+- Layer: **Codec**.
+- Workspace package `copybook-overpunch` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-overpunch`
+- Test: `cargo test -p copybook-overpunch`
+- Lint: `cargo clippy -p copybook-overpunch -- -D warnings`

--- a/crates/copybook-overpunch/src/claude.md
+++ b/crates/copybook-overpunch/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-overpunch` (Codec layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-overpunch`

--- a/crates/copybook-overpunch/tests/claude.md
+++ b/crates/copybook-overpunch/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-overpunch` (Codec layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-overpunch`

--- a/crates/copybook-rdw-predicates/claude.md
+++ b/crates/copybook-rdw-predicates/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Single-purpose RDW header ASCII-heuristic predicate.
+- Layer: **Framing**.
+- Workspace package `copybook-rdw-predicates` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-rdw-predicates`
+- Test: `cargo test -p copybook-rdw-predicates`
+- Lint: `cargo clippy -p copybook-rdw-predicates -- -D warnings`

--- a/crates/copybook-rdw-predicates/src/claude.md
+++ b/crates/copybook-rdw-predicates/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-rdw-predicates` (Framing layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-rdw-predicates`

--- a/crates/copybook-rdw-predicates/tests/claude.md
+++ b/crates/copybook-rdw-predicates/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-rdw-predicates` (Framing layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-rdw-predicates`

--- a/crates/copybook-rdw/claude.md
+++ b/crates/copybook-rdw/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- RDW framing microcrate: header primitives, reader/writer, buffered helpers.
+- Layer: **Framing**.
+- Workspace package `copybook-rdw` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-rdw`
+- Test: `cargo test -p copybook-rdw`
+- Lint: `cargo clippy -p copybook-rdw -- -D warnings`

--- a/crates/copybook-rdw/src/claude.md
+++ b/crates/copybook-rdw/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-rdw` (Framing layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-rdw`

--- a/crates/copybook-rdw/tests/claude.md
+++ b/crates/copybook-rdw/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-rdw` (Framing layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-rdw`

--- a/crates/copybook-record-io/claude.md
+++ b/crates/copybook-record-io/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Record-format dispatch microcrate bridging fixed and RDW framing primitives.
+- Layer: **Framing**.
+- Workspace package `copybook-record-io` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-record-io`
+- Test: `cargo test -p copybook-record-io`
+- Lint: `cargo clippy -p copybook-record-io -- -D warnings`

--- a/crates/copybook-record-io/src/claude.md
+++ b/crates/copybook-record-io/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-record-io` (Framing layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-record-io`

--- a/crates/copybook-record-io/tests/claude.md
+++ b/crates/copybook-record-io/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-record-io` (Framing layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-record-io`

--- a/crates/copybook-rs/claude.md
+++ b/crates/copybook-rs/claude.md
@@ -1,0 +1,17 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Search alias for the canonical copybook crate (pub use copybook::*).
+- Layer: **Facade**.
+- Workspace package `copybook-rs` (see `Cargo.toml`).
+- Canonical crate this aliases: `../copybook/`
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-rs`
+- Test: `cargo test -p copybook-rs`
+- Lint: `cargo clippy -p copybook-rs -- -D warnings`

--- a/crates/copybook-rs/src/claude.md
+++ b/crates/copybook-rs/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-rs` (Facade layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-rs`

--- a/crates/copybook-rs/tests/claude.md
+++ b/crates/copybook-rs/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-rs` (Facade layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-rs`

--- a/crates/copybook-safe-index/claude.md
+++ b/crates/copybook-safe-index/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Panic-safe division and slice indexing helpers.
+- Layer: **Safety**.
+- Workspace package `copybook-safe-index` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-safe-index`
+- Test: `cargo test -p copybook-safe-index`
+- Lint: `cargo clippy -p copybook-safe-index -- -D warnings`

--- a/crates/copybook-safe-index/src/claude.md
+++ b/crates/copybook-safe-index/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-safe-index` (Safety layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-safe-index`

--- a/crates/copybook-safe-index/tests/claude.md
+++ b/crates/copybook-safe-index/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-safe-index` (Safety layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-safe-index`

--- a/crates/copybook-safe-ops/claude.md
+++ b/crates/copybook-safe-ops/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Panic-safe conversion and numeric helper operations.
+- Layer: **Safety**.
+- Workspace package `copybook-safe-ops` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-safe-ops`
+- Test: `cargo test -p copybook-safe-ops`
+- Lint: `cargo clippy -p copybook-safe-ops -- -D warnings`

--- a/crates/copybook-safe-ops/src/claude.md
+++ b/crates/copybook-safe-ops/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-safe-ops` (Safety layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-safe-ops`

--- a/crates/copybook-safe-ops/tests/claude.md
+++ b/crates/copybook-safe-ops/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-safe-ops` (Safety layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-safe-ops`

--- a/crates/copybook-safe-text/claude.md
+++ b/crates/copybook-safe-text/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Panic-safe text parsing and string helper functions.
+- Layer: **Safety**.
+- Workspace package `copybook-safe-text` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-safe-text`
+- Test: `cargo test -p copybook-safe-text`
+- Lint: `cargo clippy -p copybook-safe-text -- -D warnings`

--- a/crates/copybook-safe-text/src/claude.md
+++ b/crates/copybook-safe-text/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-safe-text` (Safety layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-safe-text`

--- a/crates/copybook-safe-text/tests/claude.md
+++ b/crates/copybook-safe-text/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-safe-text` (Safety layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-safe-text`

--- a/crates/copybook-sequence-ring/claude.md
+++ b/crates/copybook-sequence-ring/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Deterministic sequence reordering primitive for parallel pipelines.
+- Layer: **Other**.
+- Workspace package `copybook-sequence-ring` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-sequence-ring`
+- Test: `cargo test -p copybook-sequence-ring`
+- Lint: `cargo clippy -p copybook-sequence-ring -- -D warnings`

--- a/crates/copybook-sequence-ring/src/claude.md
+++ b/crates/copybook-sequence-ring/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-sequence-ring` (Other layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-sequence-ring`

--- a/crates/copybook-sequence-ring/tests/claude.md
+++ b/crates/copybook-sequence-ring/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-sequence-ring` (Other layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-sequence-ring`

--- a/crates/copybook-support-matrix/claude.md
+++ b/crates/copybook-support-matrix/claude.md
@@ -1,0 +1,17 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- COBOL feature support matrix contract and status registry.
+- Layer: **Schema**.
+- Workspace package `copybook-support-matrix` (see `Cargo.toml`).
+- Feature support matrix: `../../docs/reference/COBOL_SUPPORT_MATRIX.md`
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-support-matrix`
+- Test: `cargo test -p copybook-support-matrix`
+- Lint: `cargo clippy -p copybook-support-matrix -- -D warnings`

--- a/crates/copybook-support-matrix/src/claude.md
+++ b/crates/copybook-support-matrix/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-support-matrix` (Schema layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-support-matrix`

--- a/crates/copybook-support-matrix/tests/claude.md
+++ b/crates/copybook-support-matrix/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-support-matrix` (Schema layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-support-matrix`

--- a/crates/copybook-utils/claude.md
+++ b/crates/copybook-utils/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Panic-safe utility functions and extension traits.
+- Layer: **Safety**.
+- Workspace package `copybook-utils` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-utils`
+- Test: `cargo test -p copybook-utils`
+- Lint: `cargo clippy -p copybook-utils -- -D warnings`

--- a/crates/copybook-utils/src/claude.md
+++ b/crates/copybook-utils/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-utils` (Safety layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-utils`

--- a/crates/copybook-utils/tests/claude.md
+++ b/crates/copybook-utils/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-utils` (Safety layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-utils`

--- a/crates/copybook-zoned-format/claude.md
+++ b/crates/copybook-zoned-format/claude.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Zoned decimal format detection and representation microcrate.
+- Layer: **Codec**.
+- Workspace package `copybook-zoned-format` (see `Cargo.toml`).
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-zoned-format`
+- Test: `cargo test -p copybook-zoned-format`
+- Lint: `cargo clippy -p copybook-zoned-format -- -D warnings`

--- a/crates/copybook-zoned-format/src/claude.md
+++ b/crates/copybook-zoned-format/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook-zoned-format` (Codec layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook-zoned-format`

--- a/crates/copybook-zoned-format/tests/claude.md
+++ b/crates/copybook-zoned-format/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook-zoned-format` (Codec layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-zoned-format`

--- a/crates/copybook/claude.md
+++ b/crates/copybook/claude.md
@@ -1,0 +1,17 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Root facade re-exporting the canonical API for the copybook-rs crate family.
+- Layer: **Facade**.
+- Workspace package `copybook` (see `Cargo.toml`).
+- Canonical crate this facade re-exports: `../copybook/`
+
+## Navigation
+- Crates index + layer map: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook`
+- Test: `cargo test -p copybook`
+- Lint: `cargo clippy -p copybook -- -D warnings`

--- a/crates/copybook/src/claude.md
+++ b/crates/copybook/src/claude.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library sources for `copybook` (Facade layer).
+
+## Navigation
+- Crate root: `../claude.md`
+
+## Build
+- `cargo build -p copybook`

--- a/crates/copybook/tests/claude.md
+++ b/crates/copybook/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for `copybook` (Facade layer).
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook`

--- a/examples/basic/claude.md
+++ b/examples/basic/claude.md
@@ -1,0 +1,14 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Minimal example: parse a copybook, decode a record to JSON, and re-encode.
+- The starting point for new users.
+
+## Navigation
+- Examples index: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+- Library API reference: `../../docs/reference/LIBRARY_API.md`
+
+## Run
+- `cargo run --example basic` (from repo root)

--- a/examples/claude.md
+++ b/examples/claude.md
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Standalone example projects demonstrating how to consume copybook-rs crates as a user would.
+- `kafka_pipeline` is excluded from the workspace (see root `Cargo.toml` `exclude`); build it standalone.
+
+## Examples
+| Example | Focus |
+|---|---|
+| `basic` | Minimal decode/encode usage |
+| `enterprise` | Audit/governance/governance-runtime features |
+| `integration` | Multi-crate composition |
+| `kafka_pipeline` | Streaming pipeline (standalone crate, not a workspace member) |
+
+## Navigation
+- Repository root + invariants: `../CLAUDE.md`
+- Library API reference: `../docs/reference/LIBRARY_API.md`
+
+## Run
+- `cargo run --example <name>` (for workspace examples)
+- `kafka_pipeline`: `cd kafka_pipeline && cargo run`

--- a/examples/enterprise/claude.md
+++ b/examples/enterprise/claude.md
@@ -1,0 +1,15 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Enterprise example: demonstrates audit lineage, governance, and governance-runtime features.
+- Exercises the governance layer crates (`copybook-governance*`) and `copybook-core` audit module.
+
+## Navigation
+- Examples index: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+- Performance/audit policy: `../../docs/PERFORMANCE_GOVERNANCE.md`
+- Audit module: `../../crates/copybook-core/src/audit/`
+
+## Run
+- `cargo run --example enterprise` (from repo root)

--- a/examples/integration/claude.md
+++ b/examples/integration/claude.md
@@ -1,0 +1,13 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration example: composes multiple copybook-rs crates (parser + codec + framing) in a realistic workflow.
+
+## Navigation
+- Examples index: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+- Library API reference: `../../docs/reference/LIBRARY_API.md`
+
+## Run
+- `cargo run --example integration` (from repo root)

--- a/examples/kafka_pipeline/claude.md
+++ b/examples/kafka_pipeline/claude.md
@@ -1,0 +1,14 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Streaming pipeline example (crate `kafka-pipeline`).
+- Excluded from the workspace (see root `Cargo.toml` `exclude`); build/run it standalone.
+
+## Navigation
+- Examples index: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+- Source: `src/`
+
+## Run
+- `cd kafka_pipeline && cargo run`

--- a/examples/kafka_pipeline/src/claude.md
+++ b/examples/kafka_pipeline/src/claude.md
@@ -1,0 +1,13 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Source for the `kafka-pipeline` streaming example (`main.rs` entry point).
+
+## Navigation
+- Example crate root: `../claude.md`
+- Examples index: `../../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- From `../`: `cargo run`

--- a/fuzz/claude.md
+++ b/fuzz/claude.md
@@ -1,0 +1,13 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- LibFuzzer / `cargo-fuzz` targets for fuzzing codec and parser surfaces.
+- Standalone; not a workspace member.
+
+## Navigation
+- Repository root + invariants: `../CLAUDE.md`
+- Fuzz targets: `fuzz_targets/`
+
+## Run
+- `cargo +nightly fuzz run <target>` (requires nightly toolchain + `cargo-fuzz`)

--- a/fuzz/fuzz_targets/claude.md
+++ b/fuzz/fuzz_targets/claude.md
@@ -1,0 +1,13 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Individual libFuzzer fuzz target binaries (one `.rs` per target).
+- Belongs to the standalone `copybook-fuzz` crate at `../../fuzz`.
+
+## Navigation
+- Crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run a target
+- `cargo +nightly fuzz run <target_name>` from `../../fuzz`

--- a/tests/bdd/claude.md
+++ b/tests/bdd/claude.md
@@ -1,0 +1,14 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Behavior-driven tests for copybook-rs using Cucumber/Gherkin (crate `copybook-bdd`).
+- `.feature` scenarios in Gherkin; Rust step bindings in `steps/`.
+
+## Navigation
+- Repository root + invariants: `../../CLAUDE.md`
+- Step definitions: `steps/`
+- Shared test helpers: `../common/`
+
+## Run
+- `cargo test -p copybook-bdd`

--- a/tests/bdd/steps/claude.md
+++ b/tests/bdd/steps/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Rust step-definition bindings for the Gherkin `.feature` files in the parent BDD crate.
+
+## Navigation
+- BDD crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-bdd`

--- a/tests/claude.md
+++ b/tests/claude.md
@@ -1,0 +1,23 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Workspace test-only members (`publish = false`) that exercise the published crates end-to-end.
+- Separated from per-crate unit/integration tests so they can consume crates exactly as external users do.
+
+## Members
+| Suite | Framework | Focus |
+|---|---|---|
+| `bdd` | Cucumber/Gherkin (`copybook-bdd`) | Behavior scenarios |
+| `e2e` | integration (`copybook-e2e`) | End-to-end decode/encode/CLI flows |
+| `proptest` | proptest (`copybook-proptest`) | Property-based round-trip and invariants |
+
+## Navigation
+- Repository root + invariants: `../CLAUDE.md`
+- Shared test helpers: `common/`
+
+## Run
+- `cargo test -p copybook-bdd`
+- `cargo test -p copybook-e2e`
+- `cargo test -p copybook-proptest`
+- All together: `cargo test --workspace`

--- a/tests/common/claude.md
+++ b/tests/common/claude.md
@@ -1,0 +1,10 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Shared test helpers used across the `tests/` suites (bdd, e2e, proptest).
+- Not a workspace member on its own; consumed via path dependency.
+
+## Navigation
+- Repository root + invariants: `../CLAUDE.md`
+- Test suites: `../bdd/`, `../e2e/`, `../proptest/`

--- a/tests/e2e/claude.md
+++ b/tests/e2e/claude.md
@@ -1,0 +1,14 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- End-to-end integration tests (crate `copybook-e2e`, `publish = false`).
+- Exercises decode/encode round-trips, CLI subcommands, error taxonomy, determinism, and projection/dialect flags as an external user would.
+
+## Navigation
+- Repository root + invariants: `../../CLAUDE.md`
+- Shared test helpers: `../common/`
+- Error codes: `../../docs/reference/ERROR_CODES.md`
+
+## Run
+- `cargo test -p copybook-e2e`

--- a/tests/proptest/claude.md
+++ b/tests/proptest/claude.md
@@ -1,0 +1,14 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Property-based tests (crate `copybook-proptest`, `publish = false`) using `proptest`.
+- Targets round-trip determinism and codec invariants.
+
+## Navigation
+- Repository root + invariants: `../../CLAUDE.md`
+- Shared test helpers: `../common/`
+- Determinism policy: `../../docs/PERFORMANCE_GOVERNANCE.md`
+
+## Run
+- `cargo test -p copybook-proptest`

--- a/tools/claude.md
+++ b/tools/claude.md
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Dev-only crates (`publish = false`): benchmarks, fixture generation, maintenance scripts, and project automation.
+- Not shipped to crates.io.
+
+## Members
+| Crate | Purpose |
+|---|---|
+| `copybook-bench` | Benchmark harness and baseline tooling (criterion) |
+| `copybook-gen` | Test fixture and synthetic dataset generation |
+| `copybook-scripts` | Native Rust replacements for small repo maintenance scripts |
+| `xtask` | Project automation xtasks (CI/release helpers) |
+
+## Navigation
+- Repository root + invariants: `../CLAUDE.md`
+- Perf receipts (bench output): `../scripts/bench/perf.json`
+
+## Build
+- `cargo build -p copybook-bench` etc.
+- Run benchmarks: `cargo bench -p copybook-bench`

--- a/tools/copybook-bench/benches/claude.md
+++ b/tools/copybook-bench/benches/claude.md
@@ -1,0 +1,13 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Criterion benchmark targets for copybook-rs performance measurement.
+
+## Navigation
+- Bench crate root: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+- Perf receipts (output): `../../scripts/bench/perf.json`
+
+## Run
+- `cargo bench -p copybook-bench`

--- a/tools/copybook-bench/claude.md
+++ b/tools/copybook-bench/claude.md
@@ -1,0 +1,17 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Benchmark harness and baseline tooling for copybook-rs (crate `copybook-bench`, `publish = false`).
+- Uses `criterion`. Baselines feed the canonical perf receipts in `../../scripts/bench/perf.json`.
+
+## Navigation
+- Tools index: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+- Performance policy: `../../docs/PERFORMANCE_GOVERNANCE.md`
+- Perf receipts: `../../scripts/bench/perf.json`
+- Sources: `src/`, binaries: `src/bin/`, benchmarks: `benches/`
+
+## Run
+- `cargo bench -p copybook-bench`
+- Build only: `cargo build -p copybook-bench --all-features`

--- a/tools/copybook-bench/src/bin/claude.md
+++ b/tools/copybook-bench/src/bin/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Executable binaries for the bench harness (e.g. `bench-report.rs`).
+
+## Navigation
+- Bench crate root: `../../claude.md`
+- Repository root: `../../../CLAUDE.md`
+
+## Run
+- `cargo run -p copybook-bench --bin bench-report`

--- a/tools/copybook-bench/src/claude.md
+++ b/tools/copybook-bench/src/claude.md
@@ -1,0 +1,13 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Library + module sources for the `copybook-bench` harness: baselines, health checks, memory tests, regression tracking, reporting.
+
+## Navigation
+- Bench crate root: `../claude.md`
+- Tools index: `../../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-bench`

--- a/tools/copybook-bench/tests/claude.md
+++ b/tools/copybook-bench/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Integration tests for the bench harness (baseline validity, regression harness sanity).
+
+## Navigation
+- Bench crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-bench`

--- a/tools/copybook-gen/claude.md
+++ b/tools/copybook-gen/claude.md
@@ -1,0 +1,15 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Test fixture and synthetic dataset generation for copybook-rs (crate `copybook-gen`, `publish = false`).
+- Produces copybooks, data files, golden fixtures, and enterprise-scale datasets used across the test suites.
+
+## Navigation
+- Tools index: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+- Sources: `src/`, tests: `tests/`, runnable examples: `examples/`
+
+## Run
+- `cargo run -p copybook-gen`
+- Build: `cargo build -p copybook-gen`

--- a/tools/copybook-gen/examples/claude.md
+++ b/tools/copybook-gen/examples/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Runnable examples showing how to invoke `copybook-gen` to produce fixtures.
+
+## Navigation
+- Gen crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo run -p copybook-gen --example <name>`

--- a/tools/copybook-gen/src/claude.md
+++ b/tools/copybook-gen/src/claude.md
@@ -1,0 +1,13 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Sources for `copybook-gen`: copybook synthesis, data generation, enterprise dataset builders, golden fixture generation.
+
+## Navigation
+- Gen crate root: `../claude.md`
+- Tools index: `../../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Build
+- `cargo build -p copybook-gen`

--- a/tools/copybook-gen/tests/claude.md
+++ b/tools/copybook-gen/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Tests for the fixture generator (output validity, determinism of generated data).
+
+## Navigation
+- Gen crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p copybook-gen`

--- a/tools/copybook-scripts/claude.md
+++ b/tools/copybook-scripts/claude.md
@@ -1,0 +1,14 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Native Rust replacements for small repository maintenance scripts (crate `copybook-scripts`, `publish = false`).
+- Binary crate (`src/main.rs`) — a CLI for one-off maintenance tasks.
+
+## Navigation
+- Tools index: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+- Python maintenance scripts (predecessors): `../../scripts/`
+
+## Run
+- `cargo run -p copybook-scripts`

--- a/tools/copybook-scripts/src/claude.md
+++ b/tools/copybook-scripts/src/claude.md
@@ -1,0 +1,13 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Sources for the `copybook-scripts` maintenance CLI (`main.rs`).
+
+## Navigation
+- Scripts crate root: `../claude.md`
+- Tools index: `../../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo run -p copybook-scripts`

--- a/tools/xtask/claude.md
+++ b/tools/xtask/claude.md
@@ -1,0 +1,15 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Project automation xtasks for copybook-rs (crate `xtask`, `publish = false`).
+- CI/release helpers invoked via `cargo xtask <command>` (e.g. perf, PR insights, debug-88 analysis).
+
+## Navigation
+- Tools index: `../claude.md`
+- Repository root + invariants: `../../CLAUDE.md`
+- Release process: `../../docs/RELEASE_PROCESS.md`
+- Sources: `src/`
+
+## Run
+- `cargo xtask <command>` (install alias) or `cargo run -p xtask -- <command>`

--- a/tools/xtask/src/claude.md
+++ b/tools/xtask/src/claude.md
@@ -1,0 +1,13 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Sources for `xtask`: `main.rs` dispatch + subcommands (`perf`, `pr_insights`, `debug_88`).
+
+## Navigation
+- Xtask crate root: `../claude.md`
+- Tools index: `../../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo run -p xtask -- <command>`

--- a/tools/xtask/tests/claude.md
+++ b/tools/xtask/tests/claude.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# claude.md
+
+## Scope
+- Tests for the xtask automation commands.
+
+## Navigation
+- Xtask crate root: `../claude.md`
+- Repository root: `../../CLAUDE.md`
+
+## Run
+- `cargo test -p xtask`


### PR DESCRIPTION
## Summary

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions with no changes to library or CLI behavior.
> 
> **Overview**
> Adds a **layered `claude.md` navigation tree** so agents and contributors can orient in the repo without reading every crate blindly.
> 
> **`crates/claude.md`** is the crates index: workspace scope, a **layer table** (Facade, Parser, Codec, CLI, Framing, Schema, Governance, Safety, Quality, Other), links to root `CLAUDE.md` and `docs/`, and standard workspace build/test/clippy commands.
> 
> Under **`crates/`**, each publishable crate gets a root **`claude.md`** (purpose, layer, `cargo build/test/clippy -p …`). Deeper stubs follow the same pattern in **`src/`**, **`tests/`**, and **`examples/`** where they exist, with extra entries for notable subtrees (e.g. **`copybook-cli/src/commands/`**, **`copybook-core/src/audit/`**) pointing at **`CLI_REFERENCE.md`** or governance docs when relevant.
> 
> The same pattern extends to **`examples/`** (including standalone **`kafka_pipeline`**), **`tests/`** (bdd/e2e/proptest + **`common/`**), **`fuzz/`**, and **`tools/`** (bench, gen, scripts, xtask). Files are AGPL-licensed headers plus Scope / Navigation / Build or Run sections—**no runtime or API changes**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5d06599cbb065338b9b540069216027bddf9bcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->