### PR TITLE
ci(perf): add blocking performance regression gate

### DIFF
--- a/.github/workflows/perf-gate.yml
+++ b/.github/workflows/perf-gate.yml
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+name: Perf Gate
+# Blocking performance regression gate. Fails PRs that regress DISPLAY
+# throughput below 80 MiB/s or that regress either metric more than 5% versus
+# the committed baseline at scripts/bench/baseline.json.
+#
+# This is the *blocking* companion to the advisory perf.yml workflow. It runs
+# the canonical SLO benchmarks on ubuntu-latest and enforces floors/regression
+# via `bench-report gate` (non-zero exit on breach). Docs-only and non-perf PRs
+# are skipped via the path filter (mirrors perf.yml).
+on:
+  pull_request:
+    paths:
+      - "tools/copybook-bench/**"
+      - "crates/copybook-codec/**"
+      - "scripts/bench.sh"
+      - "scripts/bench.bat"
+      - "Cargo.lock"
+      - "Cargo.toml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    name: Performance gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Run benches (canonical SLO workloads)
+        run: bash scripts/bench.sh
+        # Produces scripts/bench/perf.json on the canonical ubuntu-latest runner.
+
+      - name: Build gate tool
+        run: cargo build --release -p copybook-bench
+
+      - name: Enforce perf gate (blocking)
+        run: |
+          ./target/release/bench-report gate scripts/bench/perf.json \
+            --baseline scripts/bench/baseline.json \
+            --regression-threshold 5.0
+        # Exits non-zero on DISPLAY floor breach or >5% regression vs baseline.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **ci**: Add blocking performance regression gate (`perf-gate.yml`) enforcing DISPLAY ≥80 MiB/s and >5% relative regression vs committed baseline; ships `bench-report gate` subcommand, `scripts/bench/baseline.json`, and canonical SLO constants in `copybook-bench::slo`
 - **audit**: Implement `Display` for `AuditEventType` and `AuditSeverity` enums
 - **audit**: Add additional Clippy lint enforcement to audit module
 - **feature-flags**: Promote COMP-1/COMP-2 and SIGN SEPARATE features to stable

--- a/docs/PERFORMANCE_GOVERNANCE.md
+++ b/docs/PERFORMANCE_GOVERNANCE.md
@@ -90,6 +90,26 @@ jq -r '.commit' scripts/bench/perf.json
 3. **Reference Validation**: Ensure all performance references point to actual receipts
 4. **Historical Quarantine**: Flag any historical target references as errors
 
+### Blocking Performance Gate (`perf-gate.yml`)
+
+A blocking CI workflow enforces performance regressions on PRs touching perf-
+sensitive paths (`crates/copybook-codec/**`, `tools/copybook-bench/**`, bench
+scripts):
+
+- **DISPLAY absolute floor**: ≥ 80 MiB/s (fails the build on breach).
+- **Relative regression gate**: > 5% slowdown versus the committed baseline at
+  [`scripts/bench/baseline.json`](../scripts/bench/baseline.json), applied to
+  both DISPLAY and COMP-3.
+- **COMP-3 absolute floor**: *deferred*. The current 600 KB SLO fixture is
+  dominated by per-call overhead and measures ~12 MiB/s on CI runners, so only
+  the relative gate protects COMP-3 until the fixture is enlarged.
+
+The gate runs `bench-report gate` (see `tools/copybook-bench/src/slo.rs` for
+the canonical floor/threshold constants). To update the baseline after an
+intentional algorithmic or dependency-driven change, edit
+`scripts/bench/baseline.json` via a PR. Re-baseline triggers follow
+[`BASELINE_METHODOLOGY.md`](../tools/copybook-bench/BASELINE_METHODOLOGY.md).
+
 ### Manual Review Process
 1. **Receipt Verification**: Check SHA-256 hash matches content
 2. **Reference Tracing**: Verify all performance numbers trace to receipts

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -32,7 +32,7 @@ These items must ship before v1.0.0 can be tagged.
 | Item | Est. Effort | Why it blocks |
 |------|-------------|---------------|
 | Enterprise audit/compliance | 8-12 weeks | SOX, HIPAA, GDPR, PCI DSS stubs are experimental; need production-grade outputs |
-| Performance regression gates | 2-4 weeks | Currently advisory-only; must become blocking CI gates |
+| Performance regression gates (COMP-3 floor) | 1-2 weeks | DISPLAY floor + relative regression are now blocking (`perf-gate.yml`); COMP-3 absolute floor deferred until its 600KB SLO fixture is enlarged (per-call overhead artifact currently caps it at ~12 MiB/s) |
 | Iterator module examples | 1-2 weeks | Public API lacks usage docs, slows onboarding |
 | Enterprise deployment guide | 1-2 weeks | No production operations documentation |
 | API freeze window | 4 weeks | Only doc/bench/test changes; stabilizes public surface |
@@ -56,7 +56,7 @@ These items must ship before v1.0.0 can be tagged.
 ## What Blocks Wider Adoption
 
 1. Enterprise audit system outputs are experimental stubs, not compliance evidence.
-2. Performance regression gates are advisory-only; no blocking CI enforcement yet.
+2. Performance regression gates: DISPLAY floor (≥80 MiB/s) and relative regression (>5% vs baseline, both metrics) are now enforced by a blocking CI gate (`perf-gate.yml`); COMP-3 absolute floor deferred pending SLO fixture fix.
 3. Iterator and deployment documentation gaps reduce onboarding velocity.
 
 ## Performance Baseline
@@ -64,9 +64,16 @@ These items must ship before v1.0.0 can be tagged.
 | Workload | Floor (CI) | Baseline (ref hardware) | Commit |
 |----------|-----------|------------------------|--------|
 | DISPLAY-heavy | 80 MiB/s | 205 MiB/s | 1fa63633 |
-| COMP-3-heavy | 40 MiB/s | 58 MiB/s | 1fa63633 |
+| COMP-3-heavy | 40 MiB/s* | 58 MiB/s | 1fa63633 |
+
+\* COMP-3 floor is advisory only; the blocking `perf-gate.yml` enforces COMP-3
+via relative regression (>5% vs committed baseline) rather than the absolute
+floor, because the current 600KB SLO fixture measures ~12 MiB/s on CI runners.
 
 Baseline measured 2025-09-30 on WSL2 / AMD Ryzen 9 9950X3D.
+The committed regression-gate baseline (`scripts/bench/baseline.json`) reflects
+canonical `ubuntu-latest` CI measurements; see
+[PERFORMANCE_GOVERNANCE.md](PERFORMANCE_GOVERNANCE.md).
 See [BASELINE_METHODOLOGY.md](../tools/copybook-bench/BASELINE_METHODOLOGY.md) for procedures.
 
 ## History

--- a/scripts/bench/baseline.json
+++ b/scripts/bench/baseline.json
@@ -1,0 +1,10 @@
+{
+  "branch": "main",
+  "commit": "078767f",
+  "timestamp": "2026-03-07T02:42:48Z",
+  "display_mibps": 1579.31,
+  "comp3_mibps": 12.33,
+  "source_receipt": "scripts/bench/perf.json",
+  "runner": "ubuntu-latest (canonical CI runner)",
+  "note": "Committed regression-gate baseline. Measured on the canonical GitHub-hosted Linux runner. COMP-3 reflects the current 600KB SLO fixture where per-call decode_file_to_jsonl overhead dominates; the COMP-3 absolute floor (40 MiB/s) is therefore deferred and only the relative regression gate is enforced for COMP-3. Update this file via a PR after intentional algorithmic or dependency-driven performance changes, or quarterly per docs/BASELINE_METHODOLOGY.md re-baseline triggers."
+}

--- a/tools/copybook-bench/src/bin/bench-report.rs
+++ b/tools/copybook-bench/src/bin/bench-report.rs
@@ -5,27 +5,31 @@
 //! reporting without requiring full CI/CD infrastructure.
 
 use anyhow::{Context, Result};
-use copybook_bench::{baseline::BaselineStore, reporting::PerformanceReport};
+use copybook_bench::{
+    GateMetric,
+    baseline::BaselineStore,
+    evaluate_metric,
+    reporting::PerformanceReport,
+    slo::{COMP3_FLOOR_MIBPS, DISPLAY_FLOOR_MIBPS, REGRESSION_THRESHOLD_PCT},
+};
 use serde_json::Value;
 use std::env;
 use std::path::PathBuf;
+use std::process::ExitCode;
 
-const DISPLAY_FLOOR_MIBPS: f64 = 80.0;
-const COMP3_FLOOR_MIBPS: f64 = 40.0;
-const DISPLAY_FLOOR_GIBPS: f64 = DISPLAY_FLOOR_MIBPS / 1024.0;
-
-fn main() -> Result<()> {
+fn main() -> Result<ExitCode> {
     let args: Vec<String> = env::args().collect();
 
     if args.len() < 2 {
         print_usage(&args[0]);
-        return Ok(());
+        return Ok(ExitCode::SUCCESS);
     }
 
     match args[1].as_str() {
         "validate" => validate_report(&args)?,
         "baseline" => manage_baseline(&args)?,
         "compare" => compare_performance(&args)?,
+        "gate" => return run_gate(&args),
         "summary" => show_summary(&args),
         "help" | "--help" => print_usage(&args[0]),
         _ => {
@@ -34,7 +38,7 @@ fn main() -> Result<()> {
         }
     }
 
-    Ok(())
+    Ok(ExitCode::SUCCESS)
 }
 
 fn print_usage(program: &str) {
@@ -48,6 +52,7 @@ fn print_usage(program: &str) {
     println!("    baseline promote <perf.json>   Promote report to main baseline");
     println!("    baseline show                  Show current baseline");
     println!("    compare <perf.json>            Compare against baseline");
+    println!("    gate <perf.json> [opts]        Enforce perf gates (non-zero exit on failure)");
     println!("    summary                        Show baseline and SLO status");
     println!("    help                          Show this help message");
     println!();
@@ -55,6 +60,7 @@ fn print_usage(program: &str) {
     println!("    {program} validate perf.json");
     println!("    {program} baseline promote perf.json");
     println!("    {program} compare perf.json");
+    println!("    {program} gate perf.json --baseline baseline.json");
 }
 
 fn validate_report(args: &[String]) -> Result<()> {
@@ -74,7 +80,7 @@ fn validate_report(args: &[String]) -> Result<()> {
         parse_report_from_value(report_path, &value).context("parsing performance report")?;
 
     // Validate against SLOs
-    report.validate_slos(DISPLAY_FLOOR_GIBPS, COMP3_FLOOR_MIBPS);
+    report.validate_slos(DISPLAY_FLOOR_MIBPS / 1024.0, COMP3_FLOOR_MIBPS);
 
     println!("✅ Valid performance report");
     println!("   Status: {}", report.status);
@@ -250,6 +256,171 @@ fn show_summary(args: &[String]) {
         println!("📈 Performance History: 0 entries");
         println!("   Baseline file: {} (not found)", baseline_path.display());
     }
+}
+
+/// Extract a throughput value in MiB/s from a JSON object, looking in common
+/// locations across the receipt (`display_mibps`, `.summary.display_mibps`)
+/// and baseline (`display_mibps`) shapes. Returns `None` if absent.
+fn mibps_from(value: &Value, key: &str) -> Option<f64> {
+    value.get(key).and_then(Value::as_f64).or_else(|| {
+        value
+            .get("summary")
+            .and_then(|s| s.get(key))
+            .and_then(Value::as_f64)
+    })
+}
+
+/// `gate` subcommand: enforce perf floors + relative regression.
+///
+/// Exits non-zero when the DISPLAY absolute floor is breached or when either
+/// metric regresses beyond `--regression-threshold` percent versus the baseline.
+fn run_gate(args: &[String]) -> Result<ExitCode> {
+    if args.len() < 3 {
+        eprintln!(
+            "Usage: {} gate <perf.json> [--baseline <baseline.json>] [--regression-threshold <pct>]",
+            args[0]
+        );
+        return Ok(ExitCode::from(2));
+    }
+
+    let receipt_path = &args[2];
+    let mut baseline_path: Option<String> = None;
+    let mut threshold = REGRESSION_THRESHOLD_PCT;
+    let mut i = 3;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--baseline" => {
+                i += 1;
+                baseline_path = args.get(i).map(String::as_str).map(str::to_owned);
+            }
+            "--regression-threshold" => {
+                i += 1;
+                if let Some(v) = args.get(i) {
+                    threshold = v
+                        .parse::<f64>()
+                        .with_context(|| format!("invalid --regression-threshold value: {v}"))?;
+                }
+            }
+            other => {
+                eprintln!("gate: unknown option '{other}'");
+                return Ok(ExitCode::from(2));
+            }
+        }
+        i += 1;
+    }
+    if threshold < 0.0 {
+        eprintln!("gate: --regression-threshold must be non-negative");
+        return Ok(ExitCode::from(2));
+    }
+
+    // Parse receipt (raw MiB/s — avoids the lossy /1024 GiB/s conversion).
+    let receipt_value: Value = serde_json::from_str(
+        &std::fs::read_to_string(receipt_path)
+            .with_context(|| format!("Failed to read receipt {receipt_path}"))?,
+    )
+    .with_context(|| format!("Failed to parse {receipt_path} as JSON"))?;
+    let receipt_display = mibps_from(&receipt_value, "display_mibps");
+    let receipt_comp3 = mibps_from(&receipt_value, "comp3_mibps");
+
+    let (display_current, comp3_current) = match (receipt_display, receipt_comp3) {
+        (Some(d), Some(c)) => (d, c),
+        (None, _) => {
+            eprintln!("gate: receipt {receipt_path} is missing display_mibps");
+            return Ok(ExitCode::FAILURE);
+        }
+        (_, None) => {
+            eprintln!("gate: receipt {receipt_path} is missing comp3_mibps");
+            return Ok(ExitCode::FAILURE);
+        }
+    };
+
+    // Parse optional baseline.
+    let mut baseline_display = None;
+    let mut baseline_comp3 = None;
+    if let Some(path) = &baseline_path {
+        let base_value: Value = serde_json::from_str(
+            &std::fs::read_to_string(path)
+                .with_context(|| format!("Failed to read baseline {path}"))?,
+        )
+        .with_context(|| format!("Failed to parse baseline {path} as JSON"))?;
+        baseline_display = mibps_from(&base_value, "display_mibps");
+        baseline_comp3 = mibps_from(&base_value, "comp3_mibps");
+    }
+
+    let display = GateMetric {
+        label: "DISPLAY",
+        current: display_current,
+        baseline: baseline_display,
+    };
+    let comp3 = GateMetric {
+        label: "COMP-3",
+        current: comp3_current,
+        baseline: baseline_comp3,
+    };
+
+    // DISPLAY enforces the absolute floor; COMP-3 does not (see slo.rs).
+    let outcomes = [
+        evaluate_metric(&display, true, DISPLAY_FLOOR_MIBPS, threshold),
+        evaluate_metric(&comp3, false, COMP3_FLOOR_MIBPS, threshold),
+    ];
+
+    let any_failed = print_gate_table(&outcomes);
+
+    let summary = if baseline_path.is_some() {
+        format!(
+            "Perf gate: {} (DISPLAY floor ≥{:.0} MiB/s, regression threshold -{:.0}% vs baseline)",
+            if any_failed { "FAILED" } else { "passed" },
+            DISPLAY_FLOOR_MIBPS,
+            threshold
+        )
+    } else {
+        format!(
+            "Perf gate: {} (DISPLAY floor ≥{:.0} MiB/s; no baseline — relative gate skipped)",
+            if any_failed { "FAILED" } else { "passed" },
+            DISPLAY_FLOOR_MIBPS,
+        )
+    };
+    println!("{summary}");
+    if let Ok(s) = env::var("GITHUB_STEP_SUMMARY")
+        && !s.is_empty()
+    {
+        std::fs::write(s, format!("### {summary}\n"))?;
+    }
+
+    if any_failed {
+        Ok(ExitCode::FAILURE)
+    } else {
+        Ok(ExitCode::SUCCESS)
+    }
+}
+
+/// Print the per-metric gate results as a markdown table, emit GitHub Actions
+/// `::error::` annotations for failures, and return whether any metric failed.
+fn print_gate_table(outcomes: &[copybook_bench::GateOutcome]) -> bool {
+    println!();
+    println!("| Metric | Current | Floor | Baseline | Delta | Status |");
+    println!("|--------|---------|-------|----------|-------|--------|");
+    let mut any_failed = false;
+    for o in outcomes {
+        if o.failed {
+            any_failed = true;
+        }
+        let floor = o
+            .floor_enforced
+            .map_or("—".to_string(), |f| format!("{f:.0}"));
+        let base = o.baseline.map_or("—".to_string(), |b| format!("{b:.1}"));
+        let delta = o.delta_pct.map_or("—".to_string(), |d| format!("{d:.2}%"));
+        let status = if o.failed { "❌ FAIL" } else { "✅ pass" };
+        println!(
+            "| {} | {:.1} MiB/s | {} | {} MiB/s | {} | {} |",
+            o.label, o.current, floor, base, delta, status
+        );
+        for reason in &o.reasons {
+            eprintln!("::error::{reason}");
+        }
+    }
+    println!();
+    any_failed
 }
 
 fn parse_report_from_value(report_path: &str, value: &Value) -> Result<PerformanceReport> {

--- a/tools/copybook-bench/src/lib.rs
+++ b/tools/copybook-bench/src/lib.rs
@@ -12,10 +12,16 @@ pub mod health;
 pub mod memory;
 pub mod regression;
 pub mod reporting;
+pub mod slo;
 
 // Re-export key types for Issue #52 machine-readable reporting
 pub use baseline::{BaselineStore, PerformanceBaseline};
 pub use reporting::PerformanceReport;
+// Re-export canonical SLO thresholds (single source of truth for gates)
+pub use slo::{
+    COMP3_FLOOR_MIBPS, DISPLAY_FLOOR_MIBPS, GateMetric, GateOutcome, REGRESSION_THRESHOLD_PCT,
+    evaluate_metric,
+};
 
 // Re-export legacy types for performance regression detection
 pub use regression::{

--- a/tools/copybook-bench/src/slo.rs
+++ b/tools/copybook-bench/src/slo.rs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Performance SLO thresholds — the single canonical source of truth.
+//!
+//! The floor and regression values used across the bench harness, the
+//! `bench-report` CLI, and the `perf-gate` CI workflow all derive from these
+//! constants. Workflow/Python duplications exist historically; this module is
+//! the canonical home and should be consulted when reconciling them.
+
+/// Minimum DISPLAY-heavy decode throughput enforced by the absolute floor gate.
+///
+/// Measured in MiB/s. The CI SLO bench comfortably exceeds this (~1.5 GiB/s on
+/// `ubuntu-latest`), so the floor has wide headroom. The `bench-report gate`
+/// subcommand fails the build when a receipt reports below this value.
+pub const DISPLAY_FLOOR_MIBPS: f64 = 80.0;
+
+/// Minimum COMP-3-heavy decode throughput (MiB/s).
+///
+/// **Not enforced** as an absolute floor by the gate today: the current SLO
+/// fixture processes only 600 KB, where per-call `decode_file_to_jsonl` overhead
+/// dominates and CI measures ~12 MiB/s. COMP-3 is still protected by the
+/// *relative* regression gate against the committed baseline. Making this an
+/// absolute floor requires enlarging the SLO fixture first (tracked follow-up).
+pub const COMP3_FLOOR_MIBPS: f64 = 40.0;
+
+/// Maximum acceptable slowdown (percent) versus the committed baseline before
+/// the relative-regression gate fails the build. Applies to both metrics.
+///
+/// Chosen to absorb normal CI runner variance while catching real regressions;
+/// matches the historical threshold used in `perf.yml`'s comparison step.
+pub const REGRESSION_THRESHOLD_PCT: f64 = 5.0;
+
+/// A single throughput metric (MiB/s) under gate evaluation.
+///
+/// `current` is the measured PR run; `baseline` is the committed reference
+/// (`None` when no baseline is available, e.g. a first run or nightly fallback).
+#[derive(Clone, Copy, Debug)]
+pub struct GateMetric {
+    /// Human-readable label, e.g. `"DISPLAY"` / `"COMP-3"`.
+    pub label: &'static str,
+    /// Measured throughput in MiB/s.
+    pub current: f64,
+    /// Committed baseline throughput in MiB/s, if any.
+    pub baseline: Option<f64>,
+}
+
+/// Outcome of evaluating one metric.
+#[derive(Clone, Debug)]
+pub struct GateOutcome {
+    /// Label of the evaluated metric.
+    pub label: &'static str,
+    /// Measured throughput (MiB/s).
+    pub current: f64,
+    /// Absolute floor enforced, if any (DISPLAY only today).
+    pub floor_enforced: Option<f64>,
+    /// Baseline throughput compared against, if any.
+    pub baseline: Option<f64>,
+    /// Percentage change vs baseline (`None` if no baseline).
+    pub delta_pct: Option<f64>,
+    /// Whether this metric failed any enforced check.
+    pub failed: bool,
+    /// Human-readable failure reasons (empty on pass).
+    pub reasons: Vec<String>,
+}
+
+/// Evaluate one metric against an (optional) absolute floor and an (optional)
+/// committed baseline.
+///
+/// - When `enforce_floor` is `true`, `current < floor` fails the gate. Today
+///   only DISPLAY enforces the floor; COMP-3 defers (see `COMP3_FLOOR_MIBPS`).
+/// - When a baseline value is present and positive, a regression worse than
+///   `threshold` percent fails the gate. A missing/zero baseline is skipped
+///   (graceful for first runs) and never fails on its own.
+#[must_use]
+pub fn evaluate_metric(
+    metric: &GateMetric,
+    enforce_floor: bool,
+    floor: f64,
+    threshold: f64,
+) -> GateOutcome {
+    let mut outcome = GateOutcome {
+        label: metric.label,
+        current: metric.current,
+        floor_enforced: enforce_floor.then_some(floor),
+        baseline: metric.baseline,
+        delta_pct: None,
+        failed: false,
+        reasons: Vec::new(),
+    };
+
+    // Absolute floor (DISPLAY only).
+    if enforce_floor && metric.current < floor {
+        outcome.failed = true;
+        outcome.reasons.push(format!(
+            "{label} {current:.1} MiB/s below absolute floor {floor:.0} MiB/s",
+            label = metric.label,
+            current = metric.current,
+            floor = floor
+        ));
+    }
+
+    // Relative regression vs committed baseline.
+    if let Some(base) = metric.baseline
+        && base > 0.0
+    {
+        let delta_pct = (metric.current - base) / base * 100.0;
+        outcome.delta_pct = Some(delta_pct);
+        if delta_pct < -threshold {
+            outcome.failed = true;
+            outcome.reasons.push(format!(
+                "{label} regression {delta:.2}% vs baseline {base:.1} MiB/s (threshold -{threshold:.0}%)",
+                label = metric.label,
+                delta = delta_pct,
+                base = base,
+                threshold = threshold
+            ));
+        }
+    }
+
+    outcome
+}

--- a/tools/copybook-bench/tests/gate_test.rs
+++ b/tools/copybook-bench/tests/gate_test.rs
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Tests for the blocking perf gate logic (`bench-report gate`).
+//!
+//! The gate's pure evaluation logic lives in `copybook_bench::slo` and is
+//! exercised here directly. The binary's IO/exit-code wiring is thin and
+//! mirrors these cases one-to-one.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::float_cmp)]
+
+use copybook_bench::GateMetric;
+use copybook_bench::evaluate_metric;
+use copybook_bench::slo::{
+    COMP3_FLOOR_MIBPS, DISPLAY_FLOOR_MIBPS, REGRESSION_THRESHOLD_PCT, evaluate_metric as eval,
+};
+
+const THRESHOLD: f64 = REGRESSION_THRESHOLD_PCT;
+
+// ---------------------------------------------------------------------------
+// (a) Passing gate: both metrics above floor and within tolerance of baseline
+// ---------------------------------------------------------------------------
+
+#[test]
+fn gate_passes_when_above_floor_and_within_regression_tolerance() {
+    let display = GateMetric {
+        label: "DISPLAY",
+        current: 200.0,
+        baseline: Some(200.0),
+    };
+    let comp3 = GateMetric {
+        label: "COMP-3",
+        current: 60.0,
+        baseline: Some(60.0),
+    };
+
+    let d = evaluate_metric(&display, true, DISPLAY_FLOOR_MIBPS, THRESHOLD);
+    let c = evaluate_metric(&comp3, false, COMP3_FLOOR_MIBPS, THRESHOLD);
+
+    assert!(!d.failed, "DISPLAY should pass: {}", d.reasons.join("; "));
+    assert!(!c.failed, "COMP-3 should pass: {}", c.reasons.join("; "));
+    // Delta should be ~0% (no regression).
+    assert_eq!(d.delta_pct, Some(0.0));
+    assert_eq!(c.delta_pct, Some(0.0));
+}
+
+// ---------------------------------------------------------------------------
+// (b) DISPLAY absolute floor breach (no baseline needed)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn display_floor_breach_fails_without_baseline() {
+    let display = GateMetric {
+        label: "DISPLAY",
+        current: 70.0,
+        baseline: None,
+    };
+    let d = evaluate_metric(&display, true, DISPLAY_FLOOR_MIBPS, THRESHOLD);
+
+    assert!(d.failed);
+    assert!(d.reasons.iter().any(|r| r.contains("below absolute floor")));
+    // Floor is only enforced for DISPLAY.
+    assert_eq!(d.floor_enforced, Some(DISPLAY_FLOOR_MIBPS));
+}
+
+// ---------------------------------------------------------------------------
+// (c) DISPLAY regression > threshold vs baseline
+// ---------------------------------------------------------------------------
+
+#[test]
+fn display_regression_beyond_threshold_fails() {
+    // 10% slower than baseline 200 -> current 180, delta -10% < -5%.
+    let display = GateMetric {
+        label: "DISPLAY",
+        current: 180.0,
+        baseline: Some(200.0),
+    };
+    let d = evaluate_metric(&display, true, DISPLAY_FLOOR_MIBPS, THRESHOLD);
+
+    assert!(d.failed);
+    assert!(d.reasons.iter().any(|r| r.contains("regression")));
+    assert_eq!(d.delta_pct, Some(-10.0));
+}
+
+#[test]
+fn display_regression_within_threshold_passes() {
+    // 4% slower than baseline 200 -> current 192, delta -4% > -5% threshold.
+    let display = GateMetric {
+        label: "DISPLAY",
+        current: 192.0,
+        baseline: Some(200.0),
+    };
+    let d = evaluate_metric(&display, true, DISPLAY_FLOOR_MIBPS, THRESHOLD);
+
+    assert!(
+        !d.failed,
+        "within-threshold regression should not fail: {}",
+        d.reasons.join("; ")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (d) COMP-3 regression > threshold vs baseline (relative gate still applies)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn comp3_regression_beyond_threshold_fails_even_though_below_floor() {
+    // Current 10 MiB/s is below the (un-enforced) COMP-3 floor of 40, but that
+    // floor is not enforced for COMP-3. The relative gate still catches a
+    // 50% regression from baseline 20 -> current 10.
+    let comp3 = GateMetric {
+        label: "COMP-3",
+        current: 10.0,
+        baseline: Some(20.0),
+    };
+    let c = evaluate_metric(&comp3, false, COMP3_FLOOR_MIBPS, THRESHOLD);
+
+    assert!(c.failed);
+    assert!(c.reasons.iter().any(|r| r.contains("regression")));
+    assert!(
+        !c.reasons.iter().any(|r| r.contains("absolute floor")),
+        "COMP-3 must not enforce absolute floor"
+    );
+    assert_eq!(c.floor_enforced, None, "COMP-3 floor not enforced");
+}
+
+// ---------------------------------------------------------------------------
+// (e) Missing baseline: relative gate skipped, never fails on absence
+// ---------------------------------------------------------------------------
+
+#[test]
+fn missing_baseline_does_not_fail_relative_gate() {
+    // DISPLAY below floor still fails the absolute check, but the *relative*
+    // gate contributes no reason. COMP-3 with no baseline and below-floor
+    // value passes entirely (floor unenforced, no baseline to compare).
+    let comp3 = GateMetric {
+        label: "COMP-3",
+        current: 5.0,
+        baseline: None,
+    };
+    let c = evaluate_metric(&comp3, false, COMP3_FLOOR_MIBPS, THRESHOLD);
+
+    assert!(
+        !c.failed,
+        "COMP-3 with no baseline must pass: {}",
+        c.reasons.join("; ")
+    );
+    assert!(c.reasons.is_empty());
+    assert_eq!(c.delta_pct, None);
+}
+
+#[test]
+fn zero_baseline_is_treated_as_missing() {
+    // A zero/missing baseline value is skipped (graceful), not a failure.
+    let comp3 = GateMetric {
+        label: "COMP-3",
+        current: 5.0,
+        baseline: Some(0.0),
+    };
+    let c = evaluate_metric(&comp3, false, COMP3_FLOOR_MIBPS, THRESHOLD);
+    assert!(!c.failed);
+}
+
+// ---------------------------------------------------------------------------
+// Boundary: regression exactly at the threshold should pass (strict <)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn regression_exactly_at_threshold_passes() {
+    // 5% regression exactly -> delta == -threshold, not < -threshold.
+    // current = baseline * 0.95. Use baseline 200, current 190.
+    let display = GateMetric {
+        label: "DISPLAY",
+        current: 190.0,
+        baseline: Some(200.0),
+    };
+    let d = evaluate_metric(&display, true, DISPLAY_FLOOR_MIBPS, 5.0);
+    assert!(
+        !d.failed,
+        "regression exactly at threshold should pass: {}",
+        d.reasons.join("; ")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Improvement is never a failure
+// ---------------------------------------------------------------------------
+
+#[test]
+fn improvement_does_not_fail() {
+    let display = GateMetric {
+        label: "DISPLAY",
+        current: 300.0,
+        baseline: Some(200.0),
+    };
+    let d = evaluate_metric(&display, true, DISPLAY_FLOOR_MIBPS, THRESHOLD);
+    assert!(!d.failed);
+    assert_eq!(d.delta_pct, Some(50.0));
+}
+
+// ---------------------------------------------------------------------------
+// Constants sanity (guard against accidental drift)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn slo_constants_match_documented_values() {
+    assert_eq!(DISPLAY_FLOOR_MIBPS, 80.0);
+    assert_eq!(COMP3_FLOOR_MIBPS, 40.0);
+    assert_eq!(REGRESSION_THRESHOLD_PCT, 5.0);
+}
+
+// ---------------------------------------------------------------------------
+// Ensure the aliased re-export and direct path agree (regression guard
+// against a future refactor that moves one but not the other).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn reexported_evaluate_metric_matches_direct_path() {
+    let m = GateMetric {
+        label: "DISPLAY",
+        current: 100.0,
+        baseline: Some(100.0),
+    };
+    let via_reexport = evaluate_metric(&m, true, DISPLAY_FLOOR_MIBPS, THRESHOLD);
+    let via_path = eval(&m, true, DISPLAY_FLOOR_MIBPS, THRESHOLD);
+    assert_eq!(via_reexport.failed, via_path.failed);
+    assert_eq!(via_reexport.delta_pct, via_path.delta_pct);
+}


### PR DESCRIPTION
## Summary

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches codec/bench CI paths and can block merges on runner variance or baseline drift; gate logic is well-tested but COMP-3 absolute floor is intentionally deferred.
> 
> **Overview**
> Adds a **blocking** CI workflow (`perf-gate.yml`) that runs canonical SLO benches on `ubuntu-latest` and fails PRs when `bench-report gate` detects a DISPLAY absolute floor breach (≥80 MiB/s) or a >5% slowdown vs the committed baseline for DISPLAY or COMP-3.
> 
> Introduces **`copybook-bench::slo`** as the single source for floor/threshold constants, a **`bench-report gate`** subcommand (markdown table, `::error::` annotations, non-zero exit), **`scripts/bench/baseline.json`** for regression comparison, and **`gate_test.rs`** covering floor, regression, and baseline edge cases. COMP-3’s 40 MiB/s absolute floor is **not** enforced in the gate (small fixture); COMP-3 is guarded only by relative regression.
> 
> Docs (**PERFORMANCE_GOVERNANCE**, **ROADMAP**) and **CHANGELOG** are updated to describe blocking vs advisory perf checks and the deferred COMP-3 floor follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db83fba96e39e3eebf6319b3bd3112654b9a97ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->