### PR TITLE
ci(perf): enforce COMP-3 absolute floor (8 MiB/s, CI-grounded)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **ci**: Add blocking performance regression gate (`perf-gate.yml`) enforcing DISPLAY ≥80 MiB/s and >5% relative regression vs committed baseline; ships `bench-report gate` subcommand, `scripts/bench/baseline.json`, and canonical SLO constants in `copybook-bench::slo`
+- **ci**: Add blocking performance regression gate (`perf-gate.yml`) enforcing absolute floors (DISPLAY ≥80, COMP-3 ≥8 MiB/s) and >5% relative regression vs committed baseline; ships `bench-report gate` subcommand, `scripts/bench/baseline.json`, and canonical SLO constants in `copybook-bench::slo`. COMP-3 floor is CI-grounded (12–14 MiB/s observed on `ubuntu-latest`; throughput decreases with larger payloads, so 8 MiB/s gives ~35% headroom).
 - **audit**: Implement `Display` for `AuditEventType` and `AuditSeverity` enums
 - **audit**: Add additional Clippy lint enforcement to audit module
 - **feature-flags**: Promote COMP-1/COMP-2 and SIGN SEPARATE features to stable

--- a/docs/PERFORMANCE_GOVERNANCE.md
+++ b/docs/PERFORMANCE_GOVERNANCE.md
@@ -97,12 +97,14 @@ sensitive paths (`crates/copybook-codec/**`, `tools/copybook-bench/**`, bench
 scripts):
 
 - **DISPLAY absolute floor**: ≥ 80 MiB/s (fails the build on breach).
+- **COMP-3 absolute floor**: ≥ 8 MiB/s. This is CI-grounded, not reference-
+  hardware: COMP-3 packed-decimal decode is throughput-bound at far lower rates
+  than DISPLAY (12–14 MiB/s on `ubuntu-latest`), and the per-record cost is
+  fundamental — throughput *decreases* with larger payloads. The 8 MiB/s floor
+  sits ~35% below the worst observed CI measurement to absorb runner variance.
 - **Relative regression gate**: > 5% slowdown versus the committed baseline at
   [`scripts/bench/baseline.json`](../scripts/bench/baseline.json), applied to
   both DISPLAY and COMP-3.
-- **COMP-3 absolute floor**: *deferred*. The current 600 KB SLO fixture is
-  dominated by per-call overhead and measures ~12 MiB/s on CI runners, so only
-  the relative gate protects COMP-3 until the fixture is enlarged.
 
 The gate runs `bench-report gate` (see `tools/copybook-bench/src/slo.rs` for
 the canonical floor/threshold constants). To update the baseline after an

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,6 +22,7 @@
 | Panic elimination | Zero production panics on main (PR #182) |
 | Quality gates (#97-100) | All four issues closed |
 | SIGN SEPARATE, COMP-1/COMP-2 | Promoted to stable and default-enabled in v0.4.3 |
+| Blocking perf regression gate (#512) | `perf-gate.yml` fails PRs on DISPLAY ≥80 / COMP-3 ≥8 MiB/s floors + >5% relative regression vs committed baseline |
 
 **Test status**: 10,250+ passing (15 ignored), zero unsafe, clippy pedantic compliant.
 
@@ -32,7 +33,6 @@ These items must ship before v1.0.0 can be tagged.
 | Item | Est. Effort | Why it blocks |
 |------|-------------|---------------|
 | Enterprise audit/compliance | 8-12 weeks | SOX, HIPAA, GDPR, PCI DSS stubs are experimental; need production-grade outputs |
-| Performance regression gates (COMP-3 floor) | 1-2 weeks | DISPLAY floor + relative regression are now blocking (`perf-gate.yml`); COMP-3 absolute floor deferred until its 600KB SLO fixture is enlarged (per-call overhead artifact currently caps it at ~12 MiB/s) |
 | Iterator module examples | 1-2 weeks | Public API lacks usage docs, slows onboarding |
 | Enterprise deployment guide | 1-2 weeks | No production operations documentation |
 | API freeze window | 4 weeks | Only doc/bench/test changes; stabilizes public surface |
@@ -56,19 +56,20 @@ These items must ship before v1.0.0 can be tagged.
 ## What Blocks Wider Adoption
 
 1. Enterprise audit system outputs are experimental stubs, not compliance evidence.
-2. Performance regression gates: DISPLAY floor (≥80 MiB/s) and relative regression (>5% vs baseline, both metrics) are now enforced by a blocking CI gate (`perf-gate.yml`); COMP-3 absolute floor deferred pending SLO fixture fix.
-3. Iterator and deployment documentation gaps reduce onboarding velocity.
+2. Iterator and deployment documentation gaps reduce onboarding velocity.
 
 ## Performance Baseline
 
 | Workload | Floor (CI) | Baseline (ref hardware) | Commit |
 |----------|-----------|------------------------|--------|
 | DISPLAY-heavy | 80 MiB/s | 205 MiB/s | 1fa63633 |
-| COMP-3-heavy | 40 MiB/s* | 58 MiB/s | 1fa63633 |
+| COMP-3-heavy | 8 MiB/s† | 58 MiB/s | 1fa63633 |
 
-\* COMP-3 floor is advisory only; the blocking `perf-gate.yml` enforces COMP-3
-via relative regression (>5% vs committed baseline) rather than the absolute
-floor, because the current 600KB SLO fixture measures ~12 MiB/s on CI runners.
+† The COMP-3 floor is CI-grounded, not reference-hardware. COMP-3 packed-decimal
+decode is throughput-bound at far lower rates than DISPLAY (12–14 MiB/s on
+`ubuntu-latest`), and the per-record cost is fundamental — throughput *decreases*
+with larger payloads. The 8 MiB/s floor sits ~35% below the worst observed CI
+measurement, absorbing runner variance while still catching a real regression.
 
 Baseline measured 2025-09-30 on WSL2 / AMD Ryzen 9 9950X3D.
 The committed regression-gate baseline (`scripts/bench/baseline.json`) reflects

--- a/scripts/bench/baseline.json
+++ b/scripts/bench/baseline.json
@@ -6,5 +6,5 @@
   "comp3_mibps": 12.33,
   "source_receipt": "scripts/bench/perf.json",
   "runner": "ubuntu-latest (canonical CI runner)",
-  "note": "Committed regression-gate baseline. Measured on the canonical GitHub-hosted Linux runner. COMP-3 reflects the current 600KB SLO fixture where per-call decode_file_to_jsonl overhead dominates; the COMP-3 absolute floor (40 MiB/s) is therefore deferred and only the relative regression gate is enforced for COMP-3. Update this file via a PR after intentional algorithmic or dependency-driven performance changes, or quarterly per docs/BASELINE_METHODOLOGY.md re-baseline triggers."
+  "note": "Committed regression-gate baseline. Measured on the canonical GitHub-hosted Linux runner (ubuntu-latest). Both metrics enforce an absolute floor (DISPLAY >=80, COMP-3 >=8 MiB/s) plus a >5% relative-regression gate vs this baseline. COMP-3 packed-decimal decode is throughput-bound at ~12-14 MiB/s on CI; the 8 MiB/s floor is CI-grounded, not reference-hardware. Update this file via a PR after intentional algorithmic or dependency-driven performance changes, or quarterly per docs/BASELINE_METHODOLOGY.md re-baseline triggers."
 }

--- a/tools/copybook-bench/src/bin/bench-report.rs
+++ b/tools/copybook-bench/src/bin/bench-report.rs
@@ -10,7 +10,7 @@ use copybook_bench::{
     baseline::BaselineStore,
     evaluate_metric,
     reporting::PerformanceReport,
-    slo::{COMP3_FLOOR_MIBPS, DISPLAY_FLOOR_MIBPS, REGRESSION_THRESHOLD_PCT},
+    slo::{COMP3_CI_FLOOR_MIBPS, COMP3_FLOOR_MIBPS, DISPLAY_FLOOR_MIBPS, REGRESSION_THRESHOLD_PCT},
 };
 use serde_json::Value;
 use std::env;
@@ -242,7 +242,7 @@ fn show_summary(args: &[String]) {
         println!();
         println!("🎯 SLO Targets:");
         println!("   DISPLAY: ≥{DISPLAY_FLOOR_MIBPS:.0} MiB/s");
-        println!("   COMP-3:  ≥{COMP3_FLOOR_MIBPS:.0} MiB/s");
+        println!("   COMP-3:  ≥{COMP3_CI_FLOOR_MIBPS:.0} MiB/s (CI)");
         println!();
         println!("📈 Performance History: {} entries", store.history.len());
         println!("   Baseline file: {}", baseline_path.display());
@@ -251,7 +251,7 @@ fn show_summary(args: &[String]) {
         println!();
         println!("🎯 SLO Targets:");
         println!("   DISPLAY: ≥{DISPLAY_FLOOR_MIBPS:.0} MiB/s");
-        println!("   COMP-3:  ≥{COMP3_FLOOR_MIBPS:.0} MiB/s");
+        println!("   COMP-3:  ≥{COMP3_CI_FLOOR_MIBPS:.0} MiB/s (CI)");
         println!();
         println!("📈 Performance History: 0 entries");
         println!("   Baseline file: {} (not found)", baseline_path.display());
@@ -272,8 +272,10 @@ fn mibps_from(value: &Value, key: &str) -> Option<f64> {
 
 /// `gate` subcommand: enforce perf floors + relative regression.
 ///
-/// Exits non-zero when the DISPLAY absolute floor is breached or when either
-/// metric regresses beyond `--regression-threshold` percent versus the baseline.
+/// Exits non-zero when an absolute floor is breached (DISPLAY ≥80 MiB/s,
+/// COMP-3 ≥8 MiB/s) or when either metric regresses beyond
+/// `--regression-threshold` percent versus the baseline.
+#[allow(clippy::too_many_lines)]
 fn run_gate(args: &[String]) -> Result<ExitCode> {
     if args.len() < 3 {
         eprintln!(
@@ -358,26 +360,28 @@ fn run_gate(args: &[String]) -> Result<ExitCode> {
         baseline: baseline_comp3,
     };
 
-    // DISPLAY enforces the absolute floor; COMP-3 does not (see slo.rs).
+    // Both metrics enforce their absolute floor plus the relative regression gate.
     let outcomes = [
         evaluate_metric(&display, true, DISPLAY_FLOOR_MIBPS, threshold),
-        evaluate_metric(&comp3, false, COMP3_FLOOR_MIBPS, threshold),
+        evaluate_metric(&comp3, true, COMP3_CI_FLOOR_MIBPS, threshold),
     ];
 
     let any_failed = print_gate_table(&outcomes);
 
     let summary = if baseline_path.is_some() {
         format!(
-            "Perf gate: {} (DISPLAY floor ≥{:.0} MiB/s, regression threshold -{:.0}% vs baseline)",
+            "Perf gate: {} (DISPLAY floor ≥{:.0} MiB/s, COMP-3 floor ≥{:.0} MiB/s, regression threshold -{:.0}% vs baseline)",
             if any_failed { "FAILED" } else { "passed" },
             DISPLAY_FLOOR_MIBPS,
+            COMP3_CI_FLOOR_MIBPS,
             threshold
         )
     } else {
         format!(
-            "Perf gate: {} (DISPLAY floor ≥{:.0} MiB/s; no baseline — relative gate skipped)",
+            "Perf gate: {} (DISPLAY floor ≥{:.0} MiB/s, COMP-3 floor ≥{:.0} MiB/s; no baseline — relative gate skipped)",
             if any_failed { "FAILED" } else { "passed" },
             DISPLAY_FLOOR_MIBPS,
+            COMP3_CI_FLOOR_MIBPS,
         )
     };
     println!("{summary}");

--- a/tools/copybook-bench/src/lib.rs
+++ b/tools/copybook-bench/src/lib.rs
@@ -19,8 +19,8 @@ pub use baseline::{BaselineStore, PerformanceBaseline};
 pub use reporting::PerformanceReport;
 // Re-export canonical SLO thresholds (single source of truth for gates)
 pub use slo::{
-    COMP3_FLOOR_MIBPS, DISPLAY_FLOOR_MIBPS, GateMetric, GateOutcome, REGRESSION_THRESHOLD_PCT,
-    evaluate_metric,
+    COMP3_CI_FLOOR_MIBPS, COMP3_FLOOR_MIBPS, DISPLAY_FLOOR_MIBPS, GateMetric, GateOutcome,
+    REGRESSION_THRESHOLD_PCT, evaluate_metric,
 };
 
 // Re-export legacy types for performance regression detection

--- a/tools/copybook-bench/src/slo.rs
+++ b/tools/copybook-bench/src/slo.rs
@@ -13,13 +13,22 @@
 /// subcommand fails the build when a receipt reports below this value.
 pub const DISPLAY_FLOOR_MIBPS: f64 = 80.0;
 
-/// Minimum COMP-3-heavy decode throughput (MiB/s).
+/// Minimum COMP-3-heavy decode throughput enforced by the absolute floor gate
+/// on CI.
 ///
-/// **Not enforced** as an absolute floor by the gate today: the current SLO
-/// fixture processes only 600 KB, where per-call `decode_file_to_jsonl` overhead
-/// dominates and CI measures ~12 MiB/s. COMP-3 is still protected by the
-/// *relative* regression gate against the committed baseline. Making this an
-/// absolute floor requires enlarging the SLO fixture first (tracked follow-up).
+/// Measured in MiB/s. COMP-3 packed-decimal decode is throughput-bound at far
+/// lower rates than DISPLAY: the SLO bench measures 12–14 MiB/s on
+/// `ubuntu-latest` (and the per-record cost is fundamental, not a fixture-size
+/// artifact — throughput *decreases* with larger payloads). This CI-grounded
+/// floor is set ~35% below the worst observed CI measurement to absorb runner
+/// variance while still catching a real (halving) regression.
+pub const COMP3_CI_FLOOR_MIBPS: f64 = 8.0;
+
+/// Reference-hardware COMP-3 baseline (58 MiB/s on WSL2 / Ryzen 9 9950X3D).
+///
+/// **Not enforced** as a gate. Retained for documentation and the
+/// baseline/budget table in `ROADMAP.md`. The enforced floor is
+/// [`COMP3_CI_FLOOR_MIBPS`], which reflects the canonical CI environment.
 pub const COMP3_FLOOR_MIBPS: f64 = 40.0;
 
 /// Maximum acceptable slowdown (percent) versus the committed baseline before
@@ -50,7 +59,7 @@ pub struct GateOutcome {
     pub label: &'static str,
     /// Measured throughput (MiB/s).
     pub current: f64,
-    /// Absolute floor enforced, if any (DISPLAY only today).
+    /// Absolute floor enforced, if any (both metrics enforce one today).
     pub floor_enforced: Option<f64>,
     /// Baseline throughput compared against, if any.
     pub baseline: Option<f64>,
@@ -65,8 +74,8 @@ pub struct GateOutcome {
 /// Evaluate one metric against an (optional) absolute floor and an (optional)
 /// committed baseline.
 ///
-/// - When `enforce_floor` is `true`, `current < floor` fails the gate. Today
-///   only DISPLAY enforces the floor; COMP-3 defers (see `COMP3_FLOOR_MIBPS`).
+/// - When `enforce_floor` is `true`, `current < floor` fails the gate. Both
+///   DISPLAY and COMP-3 enforce their respective floors today.
 /// - When a baseline value is present and positive, a regression worse than
 ///   `threshold` percent fails the gate. A missing/zero baseline is skipped
 ///   (graceful for first runs) and never fails on its own.
@@ -87,7 +96,7 @@ pub fn evaluate_metric(
         reasons: Vec::new(),
     };
 
-    // Absolute floor (DISPLAY only).
+    // Absolute floor.
     if enforce_floor && metric.current < floor {
         outcome.failed = true;
         outcome.reasons.push(format!(

--- a/tools/copybook-bench/tests/gate_test.rs
+++ b/tools/copybook-bench/tests/gate_test.rs
@@ -10,7 +10,8 @@
 use copybook_bench::GateMetric;
 use copybook_bench::evaluate_metric;
 use copybook_bench::slo::{
-    COMP3_FLOOR_MIBPS, DISPLAY_FLOOR_MIBPS, REGRESSION_THRESHOLD_PCT, evaluate_metric as eval,
+    COMP3_CI_FLOOR_MIBPS, COMP3_FLOOR_MIBPS, DISPLAY_FLOOR_MIBPS, REGRESSION_THRESHOLD_PCT,
+    evaluate_metric as eval,
 };
 
 const THRESHOLD: f64 = REGRESSION_THRESHOLD_PCT;
@@ -33,7 +34,7 @@ fn gate_passes_when_above_floor_and_within_regression_tolerance() {
     };
 
     let d = evaluate_metric(&display, true, DISPLAY_FLOOR_MIBPS, THRESHOLD);
-    let c = evaluate_metric(&comp3, false, COMP3_FLOOR_MIBPS, THRESHOLD);
+    let c = evaluate_metric(&comp3, true, COMP3_CI_FLOOR_MIBPS, THRESHOLD);
 
     assert!(!d.failed, "DISPLAY should pass: {}", d.reasons.join("; "));
     assert!(!c.failed, "COMP-3 should pass: {}", c.reasons.join("; "));
@@ -57,7 +58,6 @@ fn display_floor_breach_fails_without_baseline() {
 
     assert!(d.failed);
     assert!(d.reasons.iter().any(|r| r.contains("below absolute floor")));
-    // Floor is only enforced for DISPLAY.
     assert_eq!(d.floor_enforced, Some(DISPLAY_FLOOR_MIBPS));
 }
 
@@ -98,49 +98,66 @@ fn display_regression_within_threshold_passes() {
 }
 
 // ---------------------------------------------------------------------------
-// (d) COMP-3 regression > threshold vs baseline (relative gate still applies)
+// (d) COMP-3 absolute floor breach (CI-grounded floor of 8 MiB/s is enforced)
 // ---------------------------------------------------------------------------
 
 #[test]
-fn comp3_regression_beyond_threshold_fails_even_though_below_floor() {
-    // Current 10 MiB/s is below the (un-enforced) COMP-3 floor of 40, but that
-    // floor is not enforced for COMP-3. The relative gate still catches a
-    // 50% regression from baseline 20 -> current 10.
-    let comp3 = GateMetric {
-        label: "COMP-3",
-        current: 10.0,
-        baseline: Some(20.0),
-    };
-    let c = evaluate_metric(&comp3, false, COMP3_FLOOR_MIBPS, THRESHOLD);
-
-    assert!(c.failed);
-    assert!(c.reasons.iter().any(|r| r.contains("regression")));
-    assert!(
-        !c.reasons.iter().any(|r| r.contains("absolute floor")),
-        "COMP-3 must not enforce absolute floor"
-    );
-    assert_eq!(c.floor_enforced, None, "COMP-3 floor not enforced");
-}
-
-// ---------------------------------------------------------------------------
-// (e) Missing baseline: relative gate skipped, never fails on absence
-// ---------------------------------------------------------------------------
-
-#[test]
-fn missing_baseline_does_not_fail_relative_gate() {
-    // DISPLAY below floor still fails the absolute check, but the *relative*
-    // gate contributes no reason. COMP-3 with no baseline and below-floor
-    // value passes entirely (floor unenforced, no baseline to compare).
+fn comp3_floor_breach_fails_without_baseline() {
+    // 5 MiB/s is below the CI floor of 8. No baseline needed to fail.
     let comp3 = GateMetric {
         label: "COMP-3",
         current: 5.0,
         baseline: None,
     };
-    let c = evaluate_metric(&comp3, false, COMP3_FLOOR_MIBPS, THRESHOLD);
+    let c = evaluate_metric(&comp3, true, COMP3_CI_FLOOR_MIBPS, THRESHOLD);
+
+    assert!(c.failed);
+    assert!(c.reasons.iter().any(|r| r.contains("below absolute floor")));
+    assert_eq!(c.floor_enforced, Some(COMP3_CI_FLOOR_MIBPS));
+}
+
+// ---------------------------------------------------------------------------
+// (e) COMP-3 regression > threshold vs baseline (floor enforced too)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn comp3_regression_beyond_threshold_fails() {
+    // Current 10 vs baseline 20 = -50% regression (fails relative gate).
+    // 10 is above the 8 floor, so the floor does not fire; only regression.
+    let comp3 = GateMetric {
+        label: "COMP-3",
+        current: 10.0,
+        baseline: Some(20.0),
+    };
+    let c = evaluate_metric(&comp3, true, COMP3_CI_FLOOR_MIBPS, THRESHOLD);
+
+    assert!(c.failed);
+    assert!(c.reasons.iter().any(|r| r.contains("regression")));
+    assert!(
+        !c.reasons.iter().any(|r| r.contains("absolute floor")),
+        "above-floor COMP-3 should not trip the absolute check"
+    );
+    assert_eq!(c.floor_enforced, Some(COMP3_CI_FLOOR_MIBPS));
+}
+
+// ---------------------------------------------------------------------------
+// (f) Missing baseline: relative gate skipped, but absolute floor still holds
+// ---------------------------------------------------------------------------
+
+#[test]
+fn missing_baseline_does_not_fail_when_above_floor() {
+    // COMP-3 with no baseline and an above-floor value passes entirely
+    // (floor satisfied, no baseline to compare for regression).
+    let comp3 = GateMetric {
+        label: "COMP-3",
+        current: 15.0,
+        baseline: None,
+    };
+    let c = evaluate_metric(&comp3, true, COMP3_CI_FLOOR_MIBPS, THRESHOLD);
 
     assert!(
         !c.failed,
-        "COMP-3 with no baseline must pass: {}",
+        "COMP-3 above floor with no baseline must pass: {}",
         c.reasons.join("; ")
     );
     assert!(c.reasons.is_empty());
@@ -148,14 +165,28 @@ fn missing_baseline_does_not_fail_relative_gate() {
 }
 
 #[test]
-fn zero_baseline_is_treated_as_missing() {
-    // A zero/missing baseline value is skipped (graceful), not a failure.
+fn missing_baseline_still_fails_on_floor_breach() {
+    // No baseline, but below floor -> absolute gate still fires.
     let comp3 = GateMetric {
         label: "COMP-3",
-        current: 5.0,
+        current: 3.0,
+        baseline: None,
+    };
+    let c = evaluate_metric(&comp3, true, COMP3_CI_FLOOR_MIBPS, THRESHOLD);
+    assert!(c.failed);
+    assert_eq!(c.delta_pct, None, "no baseline => no delta");
+}
+
+#[test]
+fn zero_baseline_is_treated_as_missing() {
+    // A zero/missing baseline value is skipped (graceful), not a failure —
+    // provided the absolute floor is satisfied.
+    let comp3 = GateMetric {
+        label: "COMP-3",
+        current: 15.0,
         baseline: Some(0.0),
     };
-    let c = evaluate_metric(&comp3, false, COMP3_FLOOR_MIBPS, THRESHOLD);
+    let c = evaluate_metric(&comp3, true, COMP3_CI_FLOOR_MIBPS, THRESHOLD);
     assert!(!c.failed);
 }
 
@@ -203,7 +234,10 @@ fn improvement_does_not_fail() {
 #[test]
 fn slo_constants_match_documented_values() {
     assert_eq!(DISPLAY_FLOOR_MIBPS, 80.0);
+    // Reference-hardware value, retained for documentation (not enforced).
     assert_eq!(COMP3_FLOOR_MIBPS, 40.0);
+    // CI-grounded enforced floor.
+    assert_eq!(COMP3_CI_FLOOR_MIBPS, 8.0);
     assert_eq!(REGRESSION_THRESHOLD_PCT, 5.0);
 }
 


### PR DESCRIPTION
## Summary

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only threshold and documentation changes; no codec or runtime behavior changes, though perf-sensitive PRs can now fail on sub-8 MiB/s COMP-3 receipts.
> 
> **Overview**
> The blocking perf gate now applies a **COMP-3 absolute floor of 8 MiB/s** in addition to the existing DISPLAY floor and the >5% relative regression check against `scripts/bench/baseline.json`. COMP-3 was previously protected only by the relative gate because CI throughput (~12–14 MiB/s) sits far below the old 40 MiB/s reference target.
> 
> `copybook-bench::slo` introduces **`COMP3_CI_FLOOR_MIBPS` (8.0)** as the enforced CI constant; **`COMP3_FLOOR_MIBPS` (40.0)** remains documentation-only for reference hardware. `bench-report gate` calls `evaluate_metric` for COMP-3 with floor enforcement enabled and updates summary output accordingly.
> 
> Docs (`CHANGELOG`, `PERFORMANCE_GOVERNANCE`, `ROADMAP`) and `baseline.json` notes are aligned with the CI-grounded rationale (~35% headroom under worst observed CI). Gate unit tests cover COMP-3 floor breaches and baseline-missing behavior when below floor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7b805767a9e91563e527f8ca76b3367511aac31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->