### PR TITLE
docs: add iterator reference + streaming-decode how-to, fix fabricated API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **ci**: Add blocking performance regression gate (`perf-gate.yml`) enforcing absolute floors (DISPLAY ≥80, COMP-3 ≥8 MiB/s) and >5% relative regression vs committed baseline; ships `bench-report gate` subcommand, `scripts/bench/baseline.json`, and canonical SLO constants in `copybook-bench::slo`. COMP-3 floor is CI-grounded (12–14 MiB/s observed on `ubuntu-latest`; throughput decreases with larger payloads, so 8 MiB/s gives ~35% headroom).
+- **docs**: Add iterator reference (`docs/reference/iterators.md`) and streaming-decode how-to; fix fabricated `RecordDecoder` type in `LIBRARY_API.md`/`MIGRATION_GUIDE.md` and a file-open error-code bug in `iter_records_from_file`
 - **audit**: Implement `Display` for `AuditEventType` and `AuditSeverity` enums
 - **audit**: Add additional Clippy lint enforcement to audit module
 - **feature-flags**: Promote COMP-1/COMP-2 and SIGN SEPARATE features to stable

--- a/crates/copybook-codec/src/iterator.rs
+++ b/crates/copybook-codec/src/iterator.rs
@@ -575,8 +575,14 @@ pub fn iter_records_from_file<P: AsRef<std::path::Path>>(
     schema: &Schema,
     options: &DecodeOptions,
 ) -> Result<RecordIterator<std::fs::File>> {
-    let file = std::fs::File::open(file_path)
-        .map_err(|e| Error::new(ErrorCode::CBKF104_RDW_SUSPECT_ASCII, e.to_string()))?;
+    let file = std::fs::File::open(file_path).map_err(|e| {
+        // TODO(error-taxonomy): once CBKR201_RDW_READ_ERROR is added to the
+        // ErrorCode enum (it is documented but missing - see processor.rs
+        // drift), use it here. CBKI001 is the only infrastructure-level code
+        // currently available; CBKF104 (RDW suspect ASCII) was semantically
+        // wrong for a file-open I/O failure.
+        Error::new(ErrorCode::CBKI001_INVALID_STATE, format!("failed to open input file: {e}"))
+    })?;
 
     RecordIterator::new(file, schema, options)
 }

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -231,7 +231,7 @@ copybook decode customer.cpy data.bin \
 **After (copybook-rs Rust API):**
 ```rust
 use copybook_core::parse_copybook;
-use copybook_codec::{RecordDecoder, DecodeOptions, Codepage};
+use copybook_codec::{iter_records_from_file, DecodeOptions, Codepage};
 
 let copybook_text = std::fs::read_to_string("customer.cpy")?;
 let schema = parse_copybook(&copybook_text)?;
@@ -242,8 +242,8 @@ let opts = DecodeOptions {
     ..Default::default()
 };
 
-let mut decoder = RecordDecoder::new(&schema, &opts)?;
-for record_result in decoder.decode_file("data.bin")? {
+let iterator = iter_records_from_file("data.bin", &schema, &opts)?;
+for record_result in iterator {
     let json = record_result?;
     println!("{}", serde_json::to_string(&json)?);
 }
@@ -469,21 +469,20 @@ copybook encode customer.cpy transformed.jsonl \
 
 ```rust
 // Rust streaming integration
-use copybook_codec::RecordDecoder;
+use copybook_codec::decode_record;
 use tokio::io::{AsyncBufReadExt, BufReader};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut decoder = RecordDecoder::new(&schema, &opts)?;
     let file = tokio::fs::File::open("data.bin").await?;
     let reader = BufReader::new(file);
-    
+
     let mut lines = reader.lines();
     while let Some(line) = lines.next_line().await? {
-        let json = decoder.decode_record(line.as_bytes())?;
+        let json = decode_record(&schema, line.as_bytes(), &opts)?;
         // Process record
     }
-    
+
     Ok(())
 }
 ```

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,7 +7,7 @@
 ## Principles
 
 - **Stability first**: No breaking public behaviors without a minor+ bump; API freeze before v1.0.
-- **Performance budgeted**: Track throughput against realistic MiB/s floors; CI enforces DISPLAY >= 80 MiB/s, COMP-3 >= 40 MiB/s.
+- **Performance budgeted**: Track throughput against realistic MiB/s floors; CI enforces DISPLAY >= 80 MiB/s, COMP-3 >= 8 MiB/s.
 - **Single source of truth**: Raw performance receipts live in `scripts/bench/perf.json`; feature truth in [COBOL_SUPPORT_MATRIX.md](reference/COBOL_SUPPORT_MATRIX.md).
 - **Determinism**: Parallel decode remains deterministic; round-trip remains lossless.
 
@@ -23,6 +23,7 @@
 | Quality gates (#97-100) | All four issues closed |
 | SIGN SEPARATE, COMP-1/COMP-2 | Promoted to stable and default-enabled in v0.4.3 |
 | Blocking perf regression gate (#512) | `perf-gate.yml` fails PRs on DISPLAY ≥80 / COMP-3 ≥8 MiB/s floors + >5% relative regression vs committed baseline |
+| Iterator module examples (#514) | Reference + how-to docs for the streaming iterator API; fixed fabricated `RecordDecoder` in LIBRARY_API.md/MIGRATION_GUIDE.md and a file-open error-code bug |
 
 **Test status**: 10,250+ passing (15 ignored), zero unsafe, clippy pedantic compliant.
 
@@ -33,7 +34,6 @@ These items must ship before v1.0.0 can be tagged.
 | Item | Est. Effort | Why it blocks |
 |------|-------------|---------------|
 | Enterprise audit/compliance | 8-12 weeks | SOX, HIPAA, GDPR, PCI DSS stubs are experimental; need production-grade outputs |
-| Iterator module examples | 1-2 weeks | Public API lacks usage docs, slows onboarding |
 | Enterprise deployment guide | 1-2 weeks | No production operations documentation |
 | API freeze window | 4 weeks | Only doc/bench/test changes; stabilizes public surface |
 

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -13,6 +13,8 @@ Use these documents when you need to solve a specific problem or perform an expl
   Tune decode/encode paths, scratch buffers, and throughput diagnostics.
 - **[Configure Security Scanning](configure-security-scanning.md)**  
   Set up CI scanning controls for dependencies and container images.
+- **[Stream Records with the Iterator API](streaming-decode.md)**  
+  Decode records one at a time with bounded memory, error recovery, and raw-byte access.
 
 ## Typical Use Cases
 

--- a/docs/how-to/streaming-decode.md
+++ b/docs/how-to/streaming-decode.md
@@ -1,0 +1,191 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# How-To: Stream Records with the Iterator API
+
+Decode COBOL records one at a time with bounded memory, choosing how to handle
+errors, collect results, or access raw bytes.
+
+## Goal
+
+Use `copybook_codec`'s `RecordIterator` to decode fixed-length or RDW
+variable-length records from a file or in-memory buffer, processing each record
+individually without loading the entire file.
+
+## Prerequisites
+
+- A parsed copybook schema (`copybook_core::parse_copybook`)
+- `copybook-codec` as a dependency (`cargo add copybook-codec`)
+- Record data as a file path, byte slice, or any `std::io::Read`
+
+For full API details, see the [Record Iterators reference](../reference/iterators.md).
+
+## 1. Iterate records from an in-memory buffer
+
+The simplest case: wrap a byte slice in `Cursor` and iterate.
+
+```rust
+use copybook_codec::{iter_records, DecodeOptions};
+use copybook_core::parse_copybook;
+use std::io::Cursor;
+
+let copybook = "01 CUSTOMER.  05 ID PIC 9(5).  05 NAME PIC X(10).";
+let schema = parse_copybook(copybook)?;
+let options = DecodeOptions::default();
+
+// Three 15-byte records (5-digit ID + 10-char name)
+let data = b"00001ALICE      00002BOB        00003CAROL      ";
+
+let iterator = iter_records(Cursor::new(data), &schema, &options)?;
+for result in iterator {
+    match result {
+        Ok(json) => println!("{json}"),
+        Err(e) => eprintln!("error: {e}"),
+    }
+}
+```
+
+## 2. Iterate records from a file
+
+Use `iter_records_from_file` to open the file for you:
+
+```rust
+use copybook_codec::{iter_records_from_file, Codepage, DecodeOptions, RecordFormat};
+use copybook_core::parse_copybook;
+
+let schema = parse_copybook(include_str!("customer.cbl"))?;
+let options = DecodeOptions::new()
+    .with_format(RecordFormat::Fixed)
+    .with_codepage(Codepage::CP037); // EBCDIC
+
+let iterator = iter_records_from_file("customers.dat", &schema, &options)?;
+for result in iterator {
+    match result {
+        Ok(json) => println!("{json}"),
+        Err(e) => eprintln!("error: {e}"),
+    }
+}
+```
+
+## 3. Recover from errors without stopping
+
+Decode errors yield `Some(Err(...))` and **iteration continues** — so you can
+skip bad records and keep going. Track a count to report at the end:
+
+```rust
+use copybook_codec::{iter_records, DecodeOptions};
+use copybook_core::parse_copybook;
+use std::io::Cursor;
+
+let schema = parse_copybook("01 REC.  05 ID PIC 9(5).  05 VAL PIC X(10).")?;
+let options = DecodeOptions::default();
+
+// Third record has non-numeric ID data -> decode error, others succeed
+let data = b"00001GOODDATA00\
+             00002GOODDATA01\
+             XXXXXBADDATA02\
+             00003GOODDATA03";
+
+let mut ok = 0;
+let mut err = 0;
+for result in iter_records(Cursor::new(data), &schema, &options)? {
+    match result {
+        Ok(_) => ok += 1,
+        Err(_) => err += 1,
+    }
+}
+println!("decoded {ok} records, {err} errors");
+```
+
+## 4. Collect records into a Vec
+
+For small inputs, collect the successful records into a vector:
+
+```rust
+use copybook_codec::{iter_records, DecodeOptions};
+use copybook_core::parse_copybook;
+use serde_json::Value;
+use std::io::Cursor;
+
+let schema = parse_copybook("01 REC.  05 ID PIC 9(5).")?;
+let data = b"000010000200003";
+
+let records: Vec<Value> = iter_records(Cursor::new(data), &schema, &DecodeOptions::default())?
+    .filter_map(Result::ok) // skip any decode errors
+    .collect();
+
+assert_eq!(records.len(), 3);
+```
+
+## 5. Access raw record bytes
+
+When you need the undecoded bytes (e.g., to log them alongside the decoded
+JSON, or to feed a secondary pipeline), use `read_raw_record()`:
+
+```rust
+use copybook_codec::{iter_records, DecodeOptions};
+use copybook_core::parse_copybook;
+use std::io::Cursor;
+
+let schema = parse_copybook("01 REC.  05 DATA PIC X(10).")?;
+let options = DecodeOptions::default();
+let data = b"RECORD0001RECORD0002";
+
+let mut iter = iter_records(Cursor::new(data), &schema, &options)?;
+while let Some(raw_bytes) = iter.read_raw_record()? {
+    println!(
+        "record {}: {} bytes",
+        iter.current_record_index(),
+        raw_bytes.len()
+    );
+}
+```
+
+> `read_raw_record()` and `next()` both advance the iterator — pick one mode per
+> loop. See the [reference](../reference/iterators.md#raw-byte-access) for details.
+
+## 6. Decode RDW variable-length records
+
+Switch the format to `RecordFormat::RDW`. Each record is prefixed by a 4-byte
+Record Descriptor Word (RDW) header; the iterator reads the header, then the
+payload:
+
+```rust
+use copybook_codec::{iter_records, DecodeOptions, RecordFormat};
+use copybook_core::parse_copybook;
+use std::io::Cursor;
+
+let schema = parse_copybook("01 REC.  05 DATA PIC X(100).")?;
+let options = DecodeOptions::new().with_format(RecordFormat::RDW);
+
+// (Construct an RDW-framed input from your source — e.g. a file on disk.)
+// let iterator = iter_records_from_file("transactions.dat", &schema, &options)?;
+```
+
+## Validation
+
+Run the bundled example to see all six scenarios in action:
+
+```sh
+cargo run --example record_iterator -p copybook-codec
+```
+
+Confirm your own snippet compiles with:
+
+```sh
+cargo check
+```
+
+## When to use the iterator vs the bulk pipeline
+
+- **Iterator** — per-record control: filtering, transformation, early
+  termination, or raw-byte access. Single-threaded.
+- **[`decode_file_to_jsonl`](../reference/LIBRARY_API.md)** — bulk conversion of
+  a whole file to JSONL output. Multi-threaded via `options.with_threads(n)`.
+
+See the [Record Iterators reference](../reference/iterators.md#iterator-vs-decode_file_to_jsonl)
+for the full comparison.
+
+## Further reading
+
+- [Record Iterators reference](../reference/iterators.md)
+- [Library API](../reference/LIBRARY_API.md)
+- [Getting Started](../tutorials/getting-started.md)

--- a/docs/reference/LIBRARY_API.md
+++ b/docs/reference/LIBRARY_API.md
@@ -560,38 +560,97 @@ let summary = encode_jsonl_to_file(
 
 ### Record-Level Processing
 
+For decoding individual records or streaming through a file, `copybook-codec`
+exposes two complementary APIs. See
+[Record Iterators](iterators.md) for full iterator documentation.
+
+**Single-record decode** (`decode_record`, crate root):
+
 ```rust
-pub struct RecordDecoder {
-    // Internal fields
-}
+/// Decode one record's bytes into a JSON value.
+pub fn decode_record(
+    schema: &Schema,
+    data: &[u8],
+    options: &DecodeOptions,
+) -> Result<serde_json::Value>;
+```
 
-impl RecordDecoder {
-    pub fn new(schema: &Schema, opts: &DecodeOptions) -> Result<Self, Error>;
-    
-    pub fn decode_record(&mut self, data: &[u8]) -> Result<serde_json::Value, Error>;
-    
-    pub fn decode_file<P: AsRef<Path>>(&mut self, path: P) -> Result<RecordIterator, Error>;
-}
+```rust
+use copybook_codec::{decode_record, DecodeOptions};
+use copybook_core::parse_copybook;
 
-// Enhanced RecordIterator with truncated record detection
-pub struct RecordIterator<R: Read> {
-    // Internal fields
-}
+let schema = parse_copybook(copybook_src)?;
+let json = decode_record(&schema, &record_bytes, &DecodeOptions::default())?;
+```
+
+**Bulk file decode** (`decode_file_to_jsonl`, crate root):
+
+```rust
+/// Decode an entire input stream to JSONL written to `output`.
+/// Multi-threaded via `options.with_threads(n)`.
+pub fn decode_file_to_jsonl(
+    schema: &Schema,
+    input: impl Read,
+    output: impl Write,
+    options: &DecodeOptions,
+) -> Result<RunSummary>;
+```
+
+**Streaming record iterator** (`RecordIterator`, crate root):
+
+```rust
+pub struct RecordIterator<R: Read> { /* private fields */ }
 
 impl<R: Read> RecordIterator<R> {
-    /// Create new RecordIterator with enhanced validation
-    /// 
-    /// For fixed-format processing, requires schema.lrecl_fixed to be set
-    /// for proper truncated record detection.
+    /// Construct a new iterator. Validation of `schema.lrecl_fixed` is
+    /// *deferred* to the first read, not performed here — `new` is
+    /// infallible with respect to format/schema configuration.
     pub fn new(reader: R, schema: &Schema, options: &DecodeOptions) -> Result<Self>;
+
+    pub fn current_record_index(&self) -> u64;
+    pub fn is_eof(&self) -> bool;
+    pub fn schema(&self) -> &Schema;
+    pub fn options(&self) -> &DecodeOptions;
+
+    /// Read raw record bytes without JSON decoding.
+    pub fn read_raw_record(&mut self) -> Result<Option<Vec<u8>>>;
 }
 
 impl<R: Read> Iterator for RecordIterator<R> {
-    type Item = Result<serde_json::Value, Error>;
-    
+    type Item = Result<serde_json::Value>;
     fn next(&mut self) -> Option<Self::Item>;
 }
+
+/// Convenience constructors (crate root):
+pub fn iter_records<R: Read>(
+    reader: R, schema: &Schema, options: &DecodeOptions,
+) -> Result<RecordIterator<R>>;
+
+pub fn iter_records_from_file<P: AsRef<Path>>(
+    file_path: P, schema: &Schema, options: &DecodeOptions,
+) -> Result<RecordIterator<std::fs::File>>;
 ```
+
+```rust
+use copybook_codec::{iter_records, DecodeOptions};
+use copybook_core::parse_copybook;
+use std::io::Cursor;
+
+let schema = parse_copybook(copybook_src)?;
+let iter = iter_records(Cursor::new(data), &schema, &DecodeOptions::default())?;
+
+for result in iter {
+    match result {
+        Ok(json) => println!("{json}"),
+        Err(e) => eprintln!("record error: {e}"), // iteration continues
+    }
+}
+```
+
+> **Error recovery:** decode errors yield `Some(Err(...))` and the iterator
+> *continues* to the next record — no need to restart. A truncated trailing
+> record at EOF is a clean stop (`Ok(None)`), not an error. Missing
+> `lrecl_fixed` with `Fixed` format yields `Err(CBKI001)` on the first read.
 
 ### JSON Writer with Schema Access
 
@@ -603,7 +662,7 @@ pub struct JsonWriter<W: Write> {
 impl<W: Write> JsonWriter<W> {
     /// Create a new JSON writer with schema access for field path resolution
     pub fn new(writer: W, schema: Schema, options: DecodeOptions) -> Self;
-    
+
     /// Write a single record as JSON line with schema-based field processing
     pub fn write_record(
         &mut self,
@@ -611,7 +670,7 @@ impl<W: Write> JsonWriter<W> {
         record_index: u64,
         byte_offset: u64,
     ) -> Result<()>;
-    
+
     /// Write a record using optimized streaming approach with direct schema access
     pub fn write_record_streaming(
         &mut self,
@@ -619,7 +678,7 @@ impl<W: Write> JsonWriter<W> {
         record_index: u64,
         byte_offset: u64,
     ) -> Result<()>;
-    
+
     /// Finish writing and return the inner writer
     pub fn finish(self) -> Result<W>;
 }
@@ -631,10 +690,6 @@ impl<W: Write> JsonWriter<W> {
 - **ODO Processing**: Improved counter field lookup using schema-based field path resolution
 - **Metadata Integration**: Automatic schema fingerprint inclusion in JSON output
 - **Streaming Performance**: Optimized JSON generation with schema-aware field ordering
-- **LRECL Requirement**: Fixed-format processing requires `schema.lrecl_fixed` for truncation detection
-- **Fail-Fast Validation**: Constructor validates LRECL availability early
-- **Enhanced Error Messages**: CBKD301_RECORD_TOO_SHORT with precise byte counts
-- **Performance Optimized**: 4-23% performance improvements with validation
 
 **Example:**
 ```rust
@@ -656,29 +711,6 @@ json_writer.write_record_streaming(record_data, 1, record_size as u64)?;
 // Finish and retrieve output
 let cursor = json_writer.finish()?;
 let json_output = cursor.into_inner();
-```
-
-```rust
-let mut decoder = RecordDecoder::new(&schema, &opts)?;
-
-// Decode single record
-let record_data = &[0x01, 0x02, 0x03, /* ... */];
-let json_value = decoder.decode_record(record_data)?;
-
-// Enhanced iterator with truncation detection
-let file = std::fs::File::open("data.bin")?;
-let mut iter = RecordIterator::new(file, &schema, &opts)?;
-
-for record_result in iter {
-    match record_result {
-        Ok(json_value) => println!("{}", serde_json::to_string(&json_value)?),
-        Err(e) => {
-            // Enhanced error messages for truncated records:
-            // "Record 15 too short: expected 120 bytes, got 85 bytes"
-            eprintln!("Record error: {}", e);
-        }
-    }
-}
 ```
 
 ```rust
@@ -1063,8 +1095,10 @@ let handles: Vec<_> = (0..num_threads).map(|i| {
     let opts = Arc::clone(&opts);
     
     thread::spawn(move || {
-        let mut decoder = RecordDecoder::new(&schema, &opts)?;
-        // Process chunk of data
+        // Use decode_record_with_scratch for per-thread decode with reused buffers
+        let mut scratch = copybook_codec::memory::ScratchBuffers::new();
+        // Process chunk of data: decode_record_with_scratch(&schema, data, &opts, &mut scratch)
+        let _ = (schema, opts, scratch);
         Ok(())
     })
 }).collect();
@@ -1147,10 +1181,10 @@ fn streaming_decode(
     let (output_tx, output_rx) = bounded(100);
     
     thread::spawn(move || {
-        let mut decoder = RecordDecoder::new(&schema, &opts).unwrap();
-        
+        use copybook_codec::decode_record;
+
         while let Ok(data) = input_rx.recv() {
-            match decoder.decode_record(&data) {
+            match decode_record(&schema, &data, &opts) {
                 Ok(json) => output_tx.send(json).unwrap(),
                 Err(e) => eprintln!("Decode error: {}", e),
             }
@@ -1166,15 +1200,13 @@ fn streaming_decode(
 ### Memory Management
 
 ```rust
-// Reuse buffers for better performance
-let mut buffer = Vec::with_capacity(1024);
-let mut decoder = RecordDecoder::new(&schema, &opts)?;
+// Reuse scratch buffers for better performance across many records
+use copybook_codec::{decode_record_with_scratch, memory::ScratchBuffers};
 
-for record_data in record_iterator {
-    buffer.clear();
-    buffer.extend_from_slice(record_data);
-    
-    let json_value = decoder.decode_record(&buffer)?;
+let mut scratch = ScratchBuffers::new();
+
+for record_data in record_chunks {
+    let json_value = decode_record_with_scratch(&schema, &record_data, &opts, &mut scratch)?;
     // Process json_value
 }
 ```
@@ -1182,13 +1214,15 @@ for record_data in record_iterator {
 ### Batch Processing
 
 ```rust
-// Process records in batches
+// Process records in batches via the iterator
+use copybook_codec::{iter_records_from_file, DecodeOptions};
+
 const BATCH_SIZE: usize = 1000;
 let mut batch = Vec::with_capacity(BATCH_SIZE);
 
-for record_result in decoder.decode_file("data.bin")? {
+for record_result in iter_records_from_file("data.bin", &schema, &opts)? {
     batch.push(record_result?);
-    
+
     if batch.len() >= BATCH_SIZE {
         process_batch(&batch)?;
         batch.clear();
@@ -1219,10 +1253,9 @@ mod tests {
         
         let schema = parse_copybook(copybook).unwrap();
         let opts = DecodeOptions::default().with_emit_meta(true);
-        let mut decoder = RecordDecoder::new(&schema, &opts).unwrap();
 
         let data = b"1234JOHN      ";
-        let json = decoder.decode_record(data).unwrap();
+        let json = decode_record(&schema, data, &opts).unwrap();
 
         assert_eq!(json["ID"], "1234");
         assert_eq!(json["NAME"], "JOHN      ");
@@ -1459,7 +1492,8 @@ let opts = DecodeOptions {
     strict: true,
     ..Default::default()
 };
-let decoder = RecordDecoder::new(&schema, &opts)?;
+// Decode records via decode_record / decode_file_to_jsonl / the iterator API
+// — see "Record-Level Processing" above.
 ```
 
 ## API Stability

--- a/docs/reference/iterators.md
+++ b/docs/reference/iterators.md
@@ -1,0 +1,151 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# Record Iterators
+
+`copybook-codec` exposes a streaming iterator API for decoding COBOL records
+one at a time with bounded memory. This page documents the public types,
+their error semantics, and when to choose the iterator over the bulk
+[`decode_file_to_jsonl`](LIBRARY_API.md) pipeline.
+
+## Public entry points
+
+All three live at the crate root (`copybook_codec::`) and are defined in
+[`crates/copybook-codec/src/iterator.rs`](../../crates/copybook-codec/src/iterator.rs).
+
+| Entry point | Signature | Use when |
+|---|---|---|
+| `iter_records` | `(reader: R, schema, options) -> Result<RecordIterator<R>>` where `R: Read` | You have any readable source (file, `Cursor`, network stream) |
+| `iter_records_from_file` | `(file_path: P, schema, options) -> Result<RecordIterator<File>>` | You have a file path and want the file opened for you |
+| `RecordIterator::new` | `(reader: R, schema, options) -> Result<Self>` | You want the constructor directly (equivalent to `iter_records`) |
+
+`iter_records` and `iter_records_from_file` are thin convenience wrappers over
+`RecordIterator::new`.
+
+## The `RecordIterator` type
+
+```rust
+pub struct RecordIterator<R: Read> { /* private fields */ }
+
+impl<R: Read> Iterator for RecordIterator<R> {
+    type Item = Result<serde_json::Value>;
+    fn next(&mut self) -> Option<Self::Item>;
+}
+```
+
+Each call to `next()` decodes **one record** into a `serde_json::Value`. The
+iterator owns its own record buffer (typically < 32 KiB per record), so it can
+process multi-gigabyte files in bounded memory.
+
+### Accessor methods
+
+| Method | Returns | Notes |
+|---|---|---|
+| `current_record_index()` | `u64` | 1-based index of the most recently read record |
+| `is_eof()` | `bool` | `true` once the underlying reader is exhausted |
+| `schema()` | `&Schema` | Borrowed reference to the parsed copybook schema |
+| `options()` | `&DecodeOptions` | Borrowed reference to the decode options |
+| `read_raw_record()` | `Result<Option<Vec<u8>>>` | Read raw record **bytes** without JSON decoding |
+
+### Raw byte access
+
+`read_raw_record()` gives you the undecoded record bytes, useful when you need
+the raw data alongside (or instead of) the JSON decode. It advances the
+iterator the same way `next()` does, so the two cannot be freely interleaved
+on the same record — pick one mode per iteration loop.
+
+```rust
+use copybook_codec::{iter_records, DecodeOptions};
+use copybook_core::parse_copybook;
+use std::io::Cursor;
+
+let schema = parse_copybook("01 REC.  05 DATA PIC X(10).")?;
+let options = DecodeOptions::default();
+let mut iter = iter_records(Cursor::new(b"RECORD0001RECORD0002"), &schema, &options)?;
+
+while let Some(raw) = iter.read_raw_record()? {
+    println!("record {} = {} bytes", iter.current_record_index(), raw.len());
+}
+```
+
+## Error semantics
+
+The iterator **never panics**. Errors surface as `Result` values:
+
+- **Decode failure on a record** → `next()` yields `Some(Err(...))`, and
+  **iteration continues** to the next record. This makes error recovery
+  straightforward — `match` on each item and decide whether to skip, log, or
+  stop:
+  ```rust
+  for result in iterator {
+      match result {
+          Ok(value) => { /* process */ }
+          Err(e) => eprintln!("skipping bad record: {e}"),
+      }
+  }
+  ```
+
+- **Truncated record at EOF** → `next()` returns `Ok(None)` (a clean stop),
+  **not** an error. A short trailing record is treated as end-of-input.
+
+- **Missing `lrecl_fixed` with `Fixed` format** → the iterator *constructs
+  successfully* (validation is deferred), but the first `next()` /
+  `read_raw_record()` yields `Err(CBKI001_INVALID_STATE)`. Set
+  `schema.lrecl_fixed` (the parser does this automatically for copybooks with a
+  record length) or use `RecordFormat::RDW`.
+
+- **RDW underflow** (corrupt/truncated RDW header) → `Err(CBKF221_RDW_UNDERFLOW)`.
+
+- **File-open failure** (`iter_records_from_file`) → `Err(CBKI001_INVALID_STATE)`
+  with a message like `"failed to open input file: ..."`.
+
+> **Lazy validation note:** `RecordIterator::new` does **not** validate
+> `schema.lrecl_fixed` at construction time. Validation happens on the first
+> read. This is by design — it keeps construction infallible and surfaces
+> format mismatches at the point they actually matter (when bytes are read).
+
+## Iterator vs `decode_file_to_jsonl`
+
+The crate offers two decode paths. They are **independent implementations**
+(the iterator does its own framing inline rather than reusing
+`FixedRecordReader`/`RDWRecordReader`):
+
+| | `RecordIterator` | `decode_file_to_jsonl` |
+|---|---|---|
+| **Output** | One `serde_json::Value` per record (in memory) | JSONL lines written to a `Write` sink |
+| **Control** | Per-record: filter, transform, short-circuit | Whole-file pipeline |
+| **Parallelism** | Single-threaded | Multi-threaded (`options.with_threads(n)`) |
+| **Error handling** | `Result` per record, iteration continues | Collects into `RunSummary`, continues |
+| **Memory** | One record buffer | Streaming, bounded |
+| **Best for** | Programmatic inspection, transforms, early exit | Bulk file → JSONL conversion |
+
+Use the **iterator** when you need per-record control (filtering, transformation,
+early termination, or access to raw bytes). Use **`decode_file_to_jsonl`** for
+high-throughput bulk conversion to a JSONL file.
+
+## Configuration
+
+Iterators honor the same `DecodeOptions` as the bulk pipeline:
+
+```rust
+use copybook_codec::{iter_records, Codepage, DecodeOptions, RecordFormat};
+
+let options = DecodeOptions::new()
+    .with_format(RecordFormat::RDW)          // Fixed (default) or RDW
+    .with_codepage(Codepage::CP037)          // EBCDIC codepage
+    .with_strict_mode(true)                  // fail-fast on field errors
+    .with_max_errors(100);                   // error budget (bulk path only)
+```
+
+See [`DecodeOptions`](LIBRARY_API.md) for the full builder surface.
+
+## Runnable examples
+
+A complete, runnable example covering six scenarios (basic iteration, error
+recovery, collecting to `Vec`, raw access, file-based, and RDW) lives at
+[`crates/copybook-codec/examples/record_iterator.rs`](../../crates/copybook-codec/examples/record_iterator.rs).
+Run it with:
+
+```sh
+cargo run --example record_iterator -p copybook-codec
+```
+
+For a step-by-step tutorial, see [Streaming Decode How-To](../how-to/streaming-decode.md).


### PR DESCRIPTION
## Summary

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation; the only runtime change is clearer error mapping on file open, which is low-risk and improves diagnosability.
> 
> **Overview**
> Documents the **streaming iterator API** with new `docs/reference/iterators.md` and `docs/how-to/streaming-decode.md`, linked from the how-to index and expanded **Record-Level Processing** in `LIBRARY_API.md`.
> 
> **Replaces nonexistent `RecordDecoder`** across `LIBRARY_API.md` and `MIGRATION_GUIDE.md` with `iter_records` / `iter_records_from_file`, `decode_record`, `decode_file_to_jsonl`, and scratch-buffer patterns.
> 
> **Fixes `iter_records_from_file`** so file-open failures return `CBKI001_INVALID_STATE` with a clear message instead of misusing `CBKF104_RDW_SUSPECT_ASCII`.
> 
> **ROADMAP** marks iterator docs done (#514), drops that v1.0 blocker, and sets the documented COMP-3 CI floor to **8 MiB/s** (was 40 MiB/s).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66211c7648026a05d45189d7577200eb0f5d5dfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->