### PR TITLE
fix(error): add CBKR101 + CBKR201 error codes, fix file-open mapping

### DIFF
--- a/crates/copybook-codec/src/iterator.rs
+++ b/crates/copybook-codec/src/iterator.rs
@@ -576,12 +576,10 @@ pub fn iter_records_from_file<P: AsRef<std::path::Path>>(
     options: &DecodeOptions,
 ) -> Result<RecordIterator<std::fs::File>> {
     let file = std::fs::File::open(file_path).map_err(|e| {
-        // TODO(error-taxonomy): once CBKR201_RDW_READ_ERROR is added to the
-        // ErrorCode enum (it is documented but missing - see processor.rs
-        // drift), use it here. CBKI001 is the only infrastructure-level code
-        // currently available; CBKF104 (RDW suspect ASCII) was semantically
-        // wrong for a file-open I/O failure.
-        Error::new(ErrorCode::CBKI001_INVALID_STATE, format!("failed to open input file: {e}"))
+        Error::new(
+            ErrorCode::CBKR201_RDW_READ_ERROR,
+            format!("failed to open input file: {e}"),
+        )
     })?;
 
     RecordIterator::new(file, schema, options)

--- a/crates/copybook-error-reporter/src/lib.rs
+++ b/crates/copybook-error-reporter/src/lib.rs
@@ -358,6 +358,9 @@ impl ErrorReporter {
             | ErrorCode::CBKE515_STRING_LENGTH_VIOLATION
             // JSON write errors are typically fatal
             | ErrorCode::CBKC201_JSON_WRITE_ERROR
+            // Record framing/read errors are fatal (unrecoverable I/O)
+            | ErrorCode::CBKR101_FIXED_RECORD_ERROR
+            | ErrorCode::CBKR201_RDW_READ_ERROR
             // Iterator/internal state errors are fatal
             | ErrorCode::CBKI001_INVALID_STATE => ErrorSeverity::Fatal,
 

--- a/crates/copybook-error/src/lib.rs
+++ b/crates/copybook-error/src/lib.rs
@@ -162,6 +162,10 @@ pub enum ErrorCode {
     // =============================================================================
     // Record Errors (CBKR*) - Record format and RDW processing
     // =============================================================================
+    /// CBKR101: Fixed-length record framing error
+    CBKR101_FIXED_RECORD_ERROR,
+    /// CBKR201: Error reading an RDW (Record Descriptor Word) header or payload
+    CBKR201_RDW_READ_ERROR,
     /// CBKR211: RDW reserved bytes contain non-zero values
     CBKR211_RDW_RESERVED_NONZERO,
 
@@ -294,6 +298,8 @@ impl fmt::Display for ErrorCode {
             ErrorCode::CBKS701_PROJECTION_INVALID_ODO => "CBKS701_PROJECTION_INVALID_ODO",
             ErrorCode::CBKS702_PROJECTION_UNRESOLVED_ALIAS => "CBKS702_PROJECTION_UNRESOLVED_ALIAS",
             ErrorCode::CBKS703_PROJECTION_FIELD_NOT_FOUND => "CBKS703_PROJECTION_FIELD_NOT_FOUND",
+            ErrorCode::CBKR101_FIXED_RECORD_ERROR => "CBKR101_FIXED_RECORD_ERROR",
+            ErrorCode::CBKR201_RDW_READ_ERROR => "CBKR201_RDW_READ_ERROR",
             ErrorCode::CBKR211_RDW_RESERVED_NONZERO => "CBKR211_RDW_RESERVED_NONZERO",
             ErrorCode::CBKC201_JSON_WRITE_ERROR => "CBKC201_JSON_WRITE_ERROR",
             ErrorCode::CBKC301_INVALID_EBCDIC_BYTE => "CBKC301_INVALID_EBCDIC_BYTE",
@@ -366,7 +372,9 @@ impl ErrorCode {
             | Self::CBKS701_PROJECTION_INVALID_ODO
             | Self::CBKS702_PROJECTION_UNRESOLVED_ALIAS
             | Self::CBKS703_PROJECTION_FIELD_NOT_FOUND => "CBKS",
-            Self::CBKR211_RDW_RESERVED_NONZERO => "CBKR",
+            Self::CBKR101_FIXED_RECORD_ERROR
+            | Self::CBKR201_RDW_READ_ERROR
+            | Self::CBKR211_RDW_RESERVED_NONZERO => "CBKR",
             Self::CBKC201_JSON_WRITE_ERROR | Self::CBKC301_INVALID_EBCDIC_BYTE => "CBKC",
             Self::CBKD101_INVALID_FIELD_TYPE
             | Self::CBKD301_RECORD_TOO_SHORT

--- a/docs/reference/iterators.md
+++ b/docs/reference/iterators.md
@@ -94,7 +94,7 @@ The iterator **never panics**. Errors surface as `Result` values:
 
 - **RDW underflow** (corrupt/truncated RDW header) → `Err(CBKF221_RDW_UNDERFLOW)`.
 
-- **File-open failure** (`iter_records_from_file`) → `Err(CBKI001_INVALID_STATE)`
+- **File-open failure** (`iter_records_from_file`) → `Err(CBKR201_RDW_READ_ERROR)`
   with a message like `"failed to open input file: ..."`.
 
 > **Lazy validation note:** `RecordIterator::new` does **not** validate


### PR DESCRIPTION
## Summary

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small breaking change for callers matching on `CBKI001` for file-open failures; otherwise enum and severity wiring only.
> 
> **Overview**
> Adds **CBKR101** (`FIXED_RECORD_ERROR`) and **CBKR201** (`RDW_READ_ERROR`) to the stable `ErrorCode` taxonomy (display strings and **CBKR** family prefix), and treats both as **fatal** in `ErrorReporter`.
> 
> **`iter_records_from_file`** no longer returns `CBKI001_INVALID_STATE` when the input file cannot be opened; it now returns **`CBKR201_RDW_READ_ERROR`** with the same `"failed to open input file: …"` message. Iterator reference docs were updated to match.
> 
> `CBKR201` aligns the enum with existing bulk-path RDW read usage; this PR does not change fixed-record read errors in the iterator (still `CBKD301` / `CBKF221` there).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 327429fab702fa78d4fa5cf847e1bc67e97357ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->