### PR TITLE
fix(codec): use canonical __raw_b64 for field-level raw capture

### DIFF
--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -437,7 +437,7 @@ fn process_scalar_field_standard(
 
     // Emit field-level raw bytes when RawMode::Field is active
     if matches!(options.emit_raw, crate::options::RawMode::Field) {
-        let raw_key = format!("{}_raw_b64", field.name);
+        let raw_key = format!("{}__raw_b64", field.name);
         let raw_b64 = base64::engine::general_purpose::STANDARD.encode(field_data);
         json_obj.insert(raw_key, Value::String(raw_b64));
     }
@@ -541,7 +541,7 @@ fn process_scalar_field_with_scratch(
 
     // Emit field-level raw bytes when RawMode::Field is active
     if matches!(options.emit_raw, crate::options::RawMode::Field) {
-        let raw_key = format!("{}_raw_b64", field.name);
+        let raw_key = format!("{}__raw_b64", field.name);
         let raw_b64 = base64::engine::general_purpose::STANDARD.encode(field_data);
         json_obj.insert(raw_key, Value::String(raw_b64));
     }

--- a/crates/copybook-codec/tests/codec_integration.rs
+++ b/crates/copybook-codec/tests/codec_integration.rs
@@ -236,18 +236,18 @@ fn decode_raw_mode_field() {
     let opts = ascii_decode_opts().with_emit_raw(RawMode::Field);
     let json = decode_record(&schema, data, &opts).unwrap();
 
-    // Field-level raw capture: each field should have {FIELD}_raw_b64
+    // Field-level raw capture: each field should have {FIELD}__raw_b64
     assert!(
-        json.get("FLD1_raw_b64").is_some(),
-        "RawMode::Field should emit FLD1_raw_b64, got keys: {:?}",
+        json.get("FLD1__raw_b64").is_some(),
+        "RawMode::Field should emit FLD1__raw_b64, got keys: {:?}",
         json.as_object().map(|o| o.keys().collect::<Vec<_>>())
     );
     assert!(
-        json.get("FLD2_raw_b64").is_some(),
-        "RawMode::Field should emit FLD2_raw_b64"
+        json.get("FLD2__raw_b64").is_some(),
+        "RawMode::Field should emit FLD2__raw_b64"
     );
     // Verify the raw bytes decode correctly
-    let raw1 = json["FLD1_raw_b64"].as_str().unwrap();
+    let raw1 = json["FLD1__raw_b64"].as_str().unwrap();
     let decoded1 = base64::engine::general_purpose::STANDARD
         .decode(raw1)
         .unwrap();
@@ -264,7 +264,7 @@ fn decode_raw_mode_field_no_record_level_raw() {
     let json = decode_record(&schema, data, &opts).unwrap();
 
     assert!(
-        json.get("FLD_raw_b64").is_some(),
+        json.get("FLD__raw_b64").is_some(),
         "RawMode::Field should emit field-level raw"
     );
 }


### PR DESCRIPTION
# Pull Request

## Summary

`decode_record`'s field-level `RawMode::Field` path (`crates/copybook-codec/src/lib_api.rs`) emitted field raw-capture keys as `<FIELD>_raw_b64` (single underscore). This contradicts:

- **CLAUDE.md's documented Raw Data Capture Convention**: *"`RawMode::Field` stores field-level raw values in `<FIELD_NAME>__raw_b64`"* (double underscore).
- The **dual-key pattern already used for record-level raw capture** in `lib_api/envelope.rs`, which emits both `raw_b64` and `__raw_b64` for `RawMode::Record`/`RawMode::RecordRDW`.

This PR changes both scalar-field decode call sites (`lib_api.rs`, the standard and scratch-buffer-optimized paths) to emit `<FIELD>__raw_b64`, and updates `codec_integration.rs`'s `decode_raw_mode_field`/`decode_raw_mode_field_no_record_level_raw` tests, which had pinned the old single-underscore key name as expected behavior.

**Note on discovery**: while investigating, I found `crates/copybook-codec/src/json.rs` (~2,400 lines: `JsonWriter`, `JsonEncoder`, `OrderedJsonWriter`) is not part of the compiled crate at all — no `mod json;` declaration exists in `lib.rs`, and nothing in the workspace references these types. That file's double-underscore logic is unreachable dead code, not a second live path; this PR is a straightforward fix to the one real implementation, not a merge of two behaviors. Cleanup of the orphaned file is being handled separately.

## Type of Change

- [x] Bugfix (fixes an issue)

## COBOL/Mainframe Context

- **COBOL features affected**: N/A — raw-capture is a decode-output feature independent of COBOL field types
- **Data processing impact**: Changes the JSON key name for field-level raw capture output (`RawMode::Field`) from `<FIELD>_raw_b64` to `<FIELD>__raw_b64`. Record-level raw capture (`RawMode::Record`/`RawMode::RecordRDW`) is unaffected — it already emitted both key forms.
- **Mainframe compatibility**: N/A

## Workspace Crates Affected

- [x] copybook-codec (encoding, decoding, character conversion)

## Checklist

- [x] Tests added/updated (updated `codec_integration.rs` assertions to the corrected key)
- [x] Documentation updated (matches existing CLAUDE.md convention; no doc changes needed)
- [ ] CHANGELOG.md updated (if user-facing change) — this is a JSON output format change, should be noted
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace -- -D warnings -W clippy::pedantic` passes on the changed files (pre-existing unrelated doc-markdown clippy failures exist elsewhere in the test suite, confirmed via `git stash` to predate this change)
- [x] `cargo test --workspace` passes
- [x] Follows conventional commit format
- [ ] MSRV compliance — N/A, no dependency changes
- [ ] Golden fixtures updated if applicable — none reference field-level raw keys

## Breaking Changes

- [x] Breaking changes with migration path (describe below)

### Migration Guide (if breaking)

Callers using `decode_record`/`iterator`-based decoding with `--emit-raw field` (or `RawMode::Field` via the library API) who parse the emitted JSON and look up `<FIELD>_raw_b64` need to update to `<FIELD>__raw_b64`. The CLI's streaming decode path was already unaffected (it goes through the same `lib_api.rs` functions, so it was already producing the single-underscore key prior to this fix — this PR corrects it for CLI users too).

## Related Issues

Surfaced during the docs/code alignment audit accompanying #521–#524.

## Additional Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCJysQy9bFsm9HEcoH8uw4

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCJysQy9bFsm9HEcoH8uw4)_