### PR TITLE
fix(codec): keep field raw capture field-scoped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **codec**: Keep `RawMode::Field` output scoped to `<field>_raw_b64` values instead of also emitting whole-record `raw_b64` and `__raw_b64` payloads
 - Release prep: resolve clippy/rustdoc gate failures across core, codec, arrow examples, and test suites
 - Release prep: stabilize enterprise throughput assertions in `enterprise_mainframe_production_scenarios` for CI-consistent performance checks
 - **ci**: Add `workflow_dispatch` trigger to CI Quick and Feature Flags CI workflows

--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -166,8 +166,8 @@ pub fn decode_record_with_raw_data(
 
     let mut record_raw = None;
     match options.emit_raw {
-        RawMode::Off => {}
-        RawMode::Record | RawMode::Field => {
+        RawMode::Off | RawMode::Field => {}
+        RawMode::Record => {
             let raw_b64 = base64::engine::general_purpose::STANDARD.encode(data);
             record_raw = Some(raw_b64);
         }

--- a/crates/copybook-codec/tests/codec_integration.rs
+++ b/crates/copybook-codec/tests/codec_integration.rs
@@ -256,16 +256,19 @@ fn decode_raw_mode_field() {
 
 #[test]
 fn decode_raw_mode_field_no_record_level_raw() {
-    // Field mode should still produce record-level __raw_b64 (existing behavior)
-    // but also field-level entries
+    // Field mode should produce field-level entries without whole-record raw payloads.
     let schema = parse_copybook("01 FLD PIC X(5).").unwrap();
     let data = b"HELLO";
     let opts = ascii_decode_opts().with_emit_raw(RawMode::Field);
     let json = decode_record(&schema, data, &opts).unwrap();
 
     assert!(
-        json.get("FLD_raw_b64").is_some(),
-        "RawMode::Field should emit field-level raw"
+        json.get("FLD_raw_b64").is_some()
+            && json.get("raw_b64").is_none()
+            && json.get("__raw_b64").is_none(),
+        "RawMode::Field should emit field-level raw without record-level raw, got keys: {:?}",
+        json.as_object()
+            .map(|object| object.keys().collect::<Vec<_>>())
     );
 }
 


### PR DESCRIPTION
<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
# Pull Request

## Summary

`RawMode::Field` correctly emitted per-field `<field>_raw_b64` values, but the record-envelope branch also emitted whole-record `raw_b64` and `__raw_b64`. That contradicted the canonical CLI, JSONL, and library API contracts, which reserve record-level payloads for `record` and `record+rdw`.

This PR keeps field mode field-scoped, adds a regression that asserts both record-level keys are absent, and records the user-visible correction in the changelog.

Root cause: `decode_record_with_raw_data` grouped `RawMode::Field` with `RawMode::Record` while constructing the record envelope.

## Type of Change

- [x] Bugfix (fixes an issue)
- [x] Tests (test additions or improvements)
- [x] Documentation (changelog)

## COBOL/Mainframe Context

- **COBOL features affected**: Raw byte capture; independent of field type or dialect
- **Data processing impact**: Decode JSON shape for `RawMode::Field` / `--emit-raw field`
- **Mainframe compatibility**: No encoding, framing, or dialect semantics changed

## Workspace Crates Affected

- [x] copybook-codec (encoding, decoding, character conversion)

## Checklist

- [x] Tests added/updated
- [x] CHANGELOG.md updated
- [x] `cargo fmt -p copybook-codec --check` passes
- [x] `cargo clippy -p copybook-codec --lib --all-features -- -D warnings -W clippy::pedantic` passes
- [x] `cargo test --workspace --exclude copybook-bench` passes
- [x] Follows conventional commit format
- [x] MSRV compliance N/A (no dependency or language-feature changes)
- [x] Golden fixtures N/A

Local `cargo fmt --all --check` is not claimable on this Windows checkout because rustfmt exits with OS error 206 (expanded filename/command length). The changed crate's formatter check passes; Linux CI provides the workspace-wide formatter proof.

## Testing Instructions

```bash
cargo test -p copybook-codec --test codec_integration decode_raw_mode_field -- --nocapture
cargo test -p copybook-codec
cargo clippy -p copybook-codec --lib --all-features -- -D warnings -W clippy::pedantic
cargo test --workspace --exclude copybook-bench
```

Local results:

- Focused regression before fix: fails and reports keys `["FLD_raw_b64", "raw_b64", "__raw_b64", ...]`
- Focused raw-mode tests after fix: 2 passed
- copybook-codec: 1,887 passed, 2 ignored
- workspace: 10,105 passed, 7 ignored
- package pedantic Clippy: pass

## Performance Impact

- [x] No performance regression expected; field mode now skips one whole-record base64 encode and two envelope insertions

## Breaking Changes

- [x] No documented-contract breaking change

Behavioral compatibility note: callers that relied on the undocumented whole-record keys in field mode should request `RawMode::Record` / `--emit-raw record` instead.

## Related Issues

Supersedes #525, which proposed changing the already-canonical per-field key spelling based on stale non-canonical guidance.

## Additional Notes

The canonical references already specify `<field>_raw_b64` and limit `raw_b64` to record modes, so no contract-doc rewrite is needed in this code PR. Stale agent-facing guidance is being reconciled separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated field-level raw output to include only `<field>_raw_b64` values.
  * Prevented record-level `raw_b64` and `__raw_b64` payloads from being emitted in field-raw mode.
  * Preserved full-record raw output when record-raw mode is selected.

* **Documentation**
  * Updated the changelog to reflect the revised raw output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->