### PR TITLE
fix(ci): restore Clippy 1.97 and RustSec gates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/copybook-codec/tests/encode_edge_cases.rs
+++ b/crates/copybook-codec/tests/encode_edge_cases.rs
@@ -491,7 +491,7 @@ fn test_sign_separate_buffer_too_small() {
 #[test]
 fn test_overpunch_ascii_positive_digits() {
     // +0={, +1=A, ..., +9=I
-    let expected = [b'{', b'A', b'B', b'C', b'D', b'E', b'F', b'G', b'H', b'I'];
+    let expected = *b"{ABCDEFGHI";
     for digit in 0..=9 {
         let result =
             encode_overpunch_byte(digit, false, Codepage::ASCII, ZeroSignPolicy::Positive).unwrap();
@@ -505,7 +505,7 @@ fn test_overpunch_ascii_positive_digits() {
 #[test]
 fn test_overpunch_ascii_negative_digits() {
     // -0=}, -1=J, ..., -9=R
-    let expected = [b'}', b'J', b'K', b'L', b'M', b'N', b'O', b'P', b'Q', b'R'];
+    let expected = *b"}JKLMNOPQR";
     for digit in 0..=9 {
         let result =
             encode_overpunch_byte(digit, true, Codepage::ASCII, ZeroSignPolicy::Positive).unwrap();

--- a/crates/copybook-corruption-rdw/src/lib.rs
+++ b/crates/copybook-corruption-rdw/src/lib.rs
@@ -120,7 +120,7 @@ mod tests {
 
     #[test]
     fn ascii_heuristic_and_reference_match() {
-        let header = [b'0', b'1', b'2', b'3'];
+        let header = *b"0123";
         assert_eq!(
             detect_rdw_ascii_corruption(&header).is_some(),
             expected_corruption_present(&header)

--- a/crates/copybook-overpunch/src/lib.rs
+++ b/crates/copybook-overpunch/src/lib.rs
@@ -603,7 +603,7 @@ mod tests {
 
     #[test]
     fn test_ascii_encode_each_digit_positive() {
-        let expected_bytes: [u8; 10] = [b'{', b'A', b'B', b'C', b'D', b'E', b'F', b'G', b'H', b'I'];
+        let expected_bytes: [u8; 10] = *b"{ABCDEFGHI";
         for digit in 0u8..=9 {
             let enc =
                 encode_overpunch_byte(digit, false, Codepage::ASCII, ZeroSignPolicy::Positive)
@@ -617,7 +617,7 @@ mod tests {
 
     #[test]
     fn test_ascii_encode_each_digit_negative() {
-        let expected_bytes: [u8; 10] = [b'}', b'J', b'K', b'L', b'M', b'N', b'O', b'P', b'Q', b'R'];
+        let expected_bytes: [u8; 10] = *b"}JKLMNOPQR";
         for digit in 0u8..=9 {
             let enc = encode_overpunch_byte(digit, true, Codepage::ASCII, ZeroSignPolicy::Positive)
                 .unwrap();

--- a/crates/copybook-overpunch/tests/comprehensive.rs
+++ b/crates/copybook-overpunch/tests/comprehensive.rs
@@ -95,7 +95,7 @@ fn decode_ascii_negative_j_through_r() {
 
 #[test]
 fn encode_ascii_positive_all_digits() {
-    let expected_bytes = [b'{', b'A', b'B', b'C', b'D', b'E', b'F', b'G', b'H', b'I'];
+    let expected_bytes = *b"{ABCDEFGHI";
     for digit in 0u8..=9 {
         let byte =
             encode_overpunch_byte(digit, false, Codepage::ASCII, ZeroSignPolicy::Positive).unwrap();
@@ -122,7 +122,7 @@ fn encode_ebcdic_positive_all_digits_all_codepages() {
 
 #[test]
 fn encode_ascii_negative_all_digits() {
-    let expected_bytes = [b'}', b'J', b'K', b'L', b'M', b'N', b'O', b'P', b'Q', b'R'];
+    let expected_bytes = *b"}JKLMNOPQR";
     for digit in 0u8..=9 {
         let byte =
             encode_overpunch_byte(digit, true, Codepage::ASCII, ZeroSignPolicy::Positive).unwrap();
@@ -299,7 +299,7 @@ fn full_roundtrip_all_digits_signs_codepages() {
 
 #[test]
 fn is_valid_overpunch_ascii_positive_chars() {
-    for byte in [b'{', b'A', b'B', b'C', b'D', b'E', b'F', b'G', b'H', b'I'] {
+    for byte in *b"{ABCDEFGHI" {
         assert!(
             is_valid_overpunch(byte, Codepage::ASCII),
             "byte 0x{byte:02X}"
@@ -309,7 +309,7 @@ fn is_valid_overpunch_ascii_positive_chars() {
 
 #[test]
 fn is_valid_overpunch_ascii_negative_chars() {
-    for byte in [b'}', b'J', b'K', b'L', b'M', b'N', b'O', b'P', b'Q', b'R'] {
+    for byte in *b"}JKLMNOPQR" {
         assert!(
             is_valid_overpunch(byte, Codepage::ASCII),
             "byte 0x{byte:02X}"

--- a/crates/copybook-overpunch/tests/overpunch_comprehensive.rs
+++ b/crates/copybook-overpunch/tests/overpunch_comprehensive.rs
@@ -223,8 +223,8 @@ fn roundtrip_decode_then_encode_ebcdic_c_and_d_zones() {
 
 #[test]
 fn roundtrip_decode_then_encode_ascii_overpunch_chars() {
-    let positive_chars = [b'{', b'A', b'B', b'C', b'D', b'E', b'F', b'G', b'H', b'I'];
-    let negative_chars = [b'}', b'J', b'K', b'L', b'M', b'N', b'O', b'P', b'Q', b'R'];
+    let positive_chars = *b"{ABCDEFGHI";
+    let negative_chars = *b"}JKLMNOPQR";
 
     for &byte in positive_chars.iter().chain(negative_chars.iter()) {
         let (d, is_neg) = decode_overpunch_byte(byte, Codepage::ASCII).unwrap();

--- a/crates/copybook-overpunch/tests/overpunch_deep.rs
+++ b/crates/copybook-overpunch/tests/overpunch_deep.rs
@@ -106,7 +106,7 @@ fn ebcdic_decode_unsigned_zone_f_for_each_digit() {
 
 #[test]
 fn ascii_encode_positive_each_digit() {
-    let expected: [u8; 10] = [b'{', b'A', b'B', b'C', b'D', b'E', b'F', b'G', b'H', b'I'];
+    let expected: [u8; 10] = *b"{ABCDEFGHI";
     for digit in 0u8..=9 {
         let enc =
             encode_overpunch_byte(digit, false, Codepage::ASCII, ZeroSignPolicy::Positive).unwrap();
@@ -116,7 +116,7 @@ fn ascii_encode_positive_each_digit() {
 
 #[test]
 fn ascii_encode_negative_each_digit() {
-    let expected: [u8; 10] = [b'}', b'J', b'K', b'L', b'M', b'N', b'O', b'P', b'Q', b'R'];
+    let expected: [u8; 10] = *b"}JKLMNOPQR";
     for digit in 0u8..=9 {
         let enc =
             encode_overpunch_byte(digit, true, Codepage::ASCII, ZeroSignPolicy::Positive).unwrap();

--- a/crates/copybook-rdw-predicates/src/lib.rs
+++ b/crates/copybook-rdw-predicates/src/lib.rs
@@ -98,7 +98,7 @@ mod tests {
     fn reserved_bytes_do_not_affect_detection() {
         // Detection only looks at first two bytes
         assert!(rdw_is_suspect_ascii_corruption([b'0', b'0', 0xFF, 0xFF]));
-        assert!(rdw_is_suspect_ascii_corruption([b'9', b'9', b'A', b'B']));
+        assert!(rdw_is_suspect_ascii_corruption(*b"99AB"));
     }
 
     #[test]

--- a/crates/copybook-rdw-predicates/tests/comprehensive_predicate_tests.rs
+++ b/crates/copybook-rdw-predicates/tests/comprehensive_predicate_tests.rs
@@ -61,7 +61,7 @@ fn second_byte_non_digit_not_suspect() {
 fn reserved_bytes_do_not_influence_detection() {
     // Detection is only based on bytes 0 and 1
     assert!(rdw_is_suspect_ascii_corruption([b'1', b'2', 0xFF, 0xFF]));
-    assert!(rdw_is_suspect_ascii_corruption([b'1', b'2', b'A', b'B']));
+    assert!(rdw_is_suspect_ascii_corruption(*b"12AB"));
     assert!(rdw_is_suspect_ascii_corruption([b'1', b'2', 0x00, 0x00]));
 }
 
@@ -119,7 +119,7 @@ fn slice_agrees_with_array_variant() {
         [b'1', b'2', 0x00, 0x00],
         [0x00, 0x50, 0x00, 0x00],
         [b'0', b'0', 0xFF, 0xFF],
-        [b'9', b'9', b'A', b'B'],
+        *b"99AB",
         [b'A', b'0', 0x00, 0x00],
         [0xFF, 0xFF, 0xFF, 0xFF],
     ];

--- a/crates/copybook-rdw-predicates/tests/predicate_tests.rs
+++ b/crates/copybook-rdw-predicates/tests/predicate_tests.rs
@@ -41,7 +41,7 @@ fn invalid_ascii_corrupted_header_suspect() {
 #[test]
 fn invalid_ascii_corrupted_header_all_digits() {
     // All four bytes are ASCII digits
-    assert!(rdw_is_suspect_ascii_corruption([b'9', b'9', b'0', b'0']));
+    assert!(rdw_is_suspect_ascii_corruption(*b"9900"));
 }
 
 #[test]
@@ -119,7 +119,7 @@ fn reserved_bytes_ascii_printable_does_not_affect_predicate() {
     // Reserved bytes being printable ASCII doesn't change the predicate outcome
     // (the predicate only inspects bytes 0 and 1)
     assert!(!rdw_is_suspect_ascii_corruption([0x00, 0x50, b'A', b'B']));
-    assert!(rdw_is_suspect_ascii_corruption([b'1', b'2', b'A', b'B']));
+    assert!(rdw_is_suspect_ascii_corruption(*b"12AB"));
 }
 
 // ===========================================================================
@@ -280,7 +280,7 @@ fn array_and_slice_agree_on_representative_inputs() {
     let cases: &[[u8; 4]] = &[
         [b'0', b'0', 0x00, 0x00],
         [b'5', b'5', 0xFF, 0xFF],
-        [b'9', b'9', b'Z', b'Z'],
+        *b"99ZZ",
         [0x00, 0x50, 0x00, 0x00],
         [0x00, 0x00, 0x00, 0x00],
         [0xFF, 0xFF, 0xFF, 0xFF],

--- a/crates/copybook-rdw/tests/rdw_deep.rs
+++ b/crates/copybook-rdw/tests/rdw_deep.rs
@@ -191,7 +191,7 @@ fn rdw_try_peek_len_two_bytes_returns_some() {
 fn ascii_corruption_detected_for_digit_bytes() {
     assert!(rdw_is_suspect_ascii_corruption([b'1', b'2', 0, 0]));
     assert!(rdw_is_suspect_ascii_corruption([b'0', b'0', 0, 0]));
-    assert!(rdw_is_suspect_ascii_corruption([b'9', b'9', b'3', b'4']));
+    assert!(rdw_is_suspect_ascii_corruption(*b"9934"));
 }
 
 #[test]


### PR DESCRIPTION
<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
# Pull Request

## Summary

Restore two repository-wide CI gates that drifted after this branch was opened:

1. Clippy 1.97 introduced `clippy::byte_char_slices` under `-D warnings`, failing every Feature Flags CI matrix entry in the shared workspace-test Clippy step.
2. RustSec published `RUSTSEC-2026-0204` for locked `crossbeam-epoch 0.9.18`; `cargo deny` requires the fixed `0.9.20` floor.

The first commit rewrites only byte-array representations; byte values, ordering, lengths, and assertions are unchanged. The second commit performs a lockfile-only `crossbeam-epoch 0.9.18 → 0.9.20` update and leaves 58 other outdated packages untouched.

## Type of Change

- [x] Bugfix (restores CI gates)
- [x] Tests (representation-only cleanup)
- [x] Security dependency update

## COBOL/Mainframe Context

- **COBOL features affected**: ASCII/EBCDIC overpunch expectations and RDW corruption inputs
- **Data processing impact**: None from literal cleanup; transitive dependency patch fixes invalid pointer dereference in crossbeam formatting
- **Mainframe compatibility**: Unchanged

## Workspace Crates Affected

- [x] copybook-codec
- [x] copybook-overpunch
- [x] copybook-rdw / copybook-rdw-predicates
- [x] copybook-corruption-rdw
- [x] copybook-cli / BDD / benchmark dependency graph via `crossbeam-epoch`

## Checklist

- [x] Tests updated
- [x] Documentation N/A
- [x] CHANGELOG N/A (no shipped feature change)
- [x] Affected-package formatting passes
- [x] Exact Clippy 1.97 failing command passes
- [x] `cargo deny check advisories` passes
- [x] Full `cargo deny check` passes
- [x] Workspace all-feature build passes
- [x] Affected crate tests pass
- [x] Conventional commit format
- [x] MSRV compatibility preserved
- [x] Golden fixtures N/A

## Testing Instructions

```bash
cargo deny check advisories
cargo deny check
cargo check --workspace --all-features
cargo test -p copybook-codec -p copybook-overpunch -p copybook-corruption-rdw -p copybook-rdw-predicates -p copybook-rdw
cargo test -p copybook-cli --all-features
cargo test -p xtask
cargo check -p copybook-bench --tests
rustup run 1.97.0 cargo clippy --workspace --tests -- -D warnings \
  -A clippy::unwrap_used -A clippy::expect_used -A clippy::panic \
  -A clippy::dbg_macro -A clippy::print_stdout -A clippy::print_stderr \
  -A clippy::missing_inline_in_public_items -A clippy::duplicated_attributes \
  -A deprecated
```

Local results:

- Affected crates: 2,550 passed, 2 ignored
- CLI all features: 409 passed, 1 ignored
- xtask: 61 passed
- Benchmark test targets: compile
- Workspace all-feature build: pass
- Clippy 1.97 workspace tests: pass
- Cargo deny: advisories/bans/licenses/sources pass
- Full BDD execution: not run to completion locally (timed out); BDD compiles in all-feature and Clippy gates, and CI supplies execution proof

## Dependency / Security Impact

- `crossbeam-epoch 0.9.18 → 0.9.20` in `Cargo.lock` only
- Fixes `RUSTSEC-2026-0204`, an invalid pointer dereference in formatting invalid/null `Atomic` and `Shared` pointers
- Transitive paths include runtime metrics plus dev/BDD/benchmark consumers
- No manifest constraints, licenses, sources, permissions, secrets, or deployment requirements changed
- Rollback is the isolated lockfile commit, but would reintroduce the advisory and fail security CI

## Performance Impact

- [x] No performance regression expected

## Breaking Changes

- [x] No breaking changes

## Related Issues

Prerequisite for #527. Feature Flags run 29054089589 and Security job 86244714684 captured the two gate failures.

## Additional Notes

The commits remain separate so the Clippy migration and security dependency patch are independently reviewable.