### PR TITLE
chore: remove stale dead_code allowances

### DIFF
--- a/crates/copybook-codec/src/fidelity.rs
+++ b/crates/copybook-codec/src/fidelity.rs
@@ -3,8 +3,6 @@
 //!
 //! Implements comprehensive validation ensuring lossless data preservation
 //! across encode/decode cycles with cryptographic integrity verification.
-#![allow(dead_code)]
-
 use crate::{DecodeOptions, EncodeOptions, decode_record, encode_record, memory::ScratchBuffers};
 use copybook_core::{Field, FieldKind, Schema};
 use serde_json::Value as JsonValue;

--- a/crates/copybook-codec/tests/canonical_fixtures.rs
+++ b/crates/copybook-codec/tests/canonical_fixtures.rs
@@ -49,7 +49,6 @@ fn binary_to_hex(data: &[u8]) -> String {
 }
 
 /// Convert hex string back to binary data
-#[allow(dead_code)]
 fn hex_to_binary(hex: &str) -> Result<Vec<u8>, hex::FromHexError> {
     hex::decode(hex)
 }


### PR DESCRIPTION
## Summary
- Remove stale #![allow(dead_code)] from crates/copybook-codec/src/fidelity.rs.
- Remove unused #[allow(dead_code)] on test helper hex_to_binary in crates/copybook-codec/tests/canonical_fixtures.rs.

## Why
This is a hygiene cleanup matching the existing issue-triage references for low-risk cleanups around dead code allowances.

## Validation
- Not run locally in this PR (policy: avoid broad validation in narrow docs/cleanup follow-up).
- No behavior change expected.