### PR TITLE
docs(api): make copybook the default library entrypoint

### DIFF
--- a/crates/copybook-rs/README.md
+++ b/crates/copybook-rs/README.md
@@ -11,5 +11,8 @@ Use `copybook` directly in new projects:
 
 ```toml
 [dependencies]
-copybook = "0.4.3"
+copybook = "0.4"
 ```
+
+Use `copybook-core` and `copybook-codec` directly only when you need the
+narrowest dependency footprint.

--- a/crates/copybook/README.md
+++ b/crates/copybook/README.md
@@ -44,3 +44,10 @@ Each module re-exports the corresponding published component crate:
 Use the component crates directly when you need the smallest possible dependency
 surface. Use `copybook` when you want the canonical project entrypoint and a
 single dependency over the public crate family.
+
+Add `copybook` in your `Cargo.toml`:
+
+```toml
+[dependencies]
+copybook = "0.4"
+```

--- a/docs/reference/LIBRARY_API.md
+++ b/docs/reference/LIBRARY_API.md
@@ -1,7 +1,7 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 # Library API Reference
 
-Complete reference for using copybook-rs as a Rust library.
+Complete reference for using `copybook` as a Rust library.
 
 ## Overview
 
@@ -20,19 +20,20 @@ Encoding and decoding logic for converting between binary data and structured va
 
 ## Quick Start
 
-Add copybook-rs to your `Cargo.toml`:
+Add the canonical `copybook` facade crate to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-copybook-core = "0.1"
-copybook-codec = "0.1"
+copybook = "0.4"
 ```
+
+`copybook-core` and `copybook-codec` remain available for advanced users who need a smaller dependency surface.
 
 Basic usage:
 
 ```rust
-use copybook_core::parse_copybook;
-use copybook_codec::{decode_file_to_jsonl, DecodeOptions, Codepage, RecordFormat};
+use copybook::core::parse_copybook;
+use copybook::codec::{decode_file_to_jsonl, DecodeOptions, Codepage, RecordFormat};
 
 // Parse copybook
 let copybook_text = std::fs::read_to_string("customer.cpy")?;


### PR DESCRIPTION
Closes #537

## Summary
- Update docs/reference/LIBRARY_API.md quick start to use canonical copybook facade dependency and module-shaped imports (copybook::core, copybook::codec).
- Clarify in the same guide that component crates are an advanced/narrow-surface option.
- Align crates/copybook/README.md with a canonical install example for the facade crate.
- Align crates/copybook-rs/README.md to present copybook as the canonical dependency and call out component-crate usage as an intentional exception.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Rust library setup instructions to use the `copybook` crate version `0.4`.
  * Revised API documentation to reference the unified `copybook` library and its current import paths.
  * Added dependency setup guidance and a `Cargo.toml` example to the crate README.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->