### PR TITLE
fix(release): drive publish plan from workspace metadata

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -38,19 +38,54 @@ jobs:
         git rev-parse HEAD
         git describe --tags --always
 
-    - name: Dry run publish (leaf crates)
+    - name: Prepare publish plan
+      id: publish-plan
       run: |
-        echo "=== Dry-run publish for leaf crates (no workspace deps) ==="
+        set -euo pipefail
 
-        # Level 0: No internal dependencies
-        for crate in \
-          copybook-error \
-          copybook-determinism \
-          copybook-dialect \
-          copybook-codepage \
-          copybook-contracts \
-          copybook-support-matrix \
-          copybook-sequence-ring; do
+        PLAN_JSON="${{ runner.temp }}/publish-plan.json"
+        cargo run -p xtask -- publish plan --check
+        cargo run -p xtask -- publish plan --format json > "${PLAN_JSON}"
+
+        PLAN_COUNT=$(python - "${PLAN_JSON}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    print(len(json.load(handle)))
+PY
+        )
+
+        if [ "${PLAN_COUNT}" -le 0 ]; then
+          echo "No publishable crates found."
+          exit 1
+        fi
+
+        echo "plan_json=${PLAN_JSON}" >> "${GITHUB_OUTPUT}"
+        echo "plan_count=${PLAN_COUNT}" >> "${GITHUB_OUTPUT}"
+
+    - name: Dry run publish (publishable crates)
+      run: |
+        set -euo pipefail
+
+        echo "=== Dry-run publish for all publishable crates ==="
+        PLAN_JSON="${{ steps.publish-plan.outputs.plan_json }}"
+        mapfile -t PUBLISH_CRATES < <(python - "$PLAN_JSON" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    for crate in json.load(handle):
+        print(crate)
+PY
+        )
+
+        if [ "${#PUBLISH_CRATES[@]}" -ne "${{ steps.publish-plan.outputs.plan_count }}" ]; then
+          echo "Publish plan count mismatch."
+          exit 1
+        fi
+
+        for crate in "${PUBLISH_CRATES[@]}"; do
           echo "Testing ${crate}..."
           cargo publish -p "${crate}" --dry-run
           echo "  ${crate} dry-run successful"
@@ -58,35 +93,21 @@ jobs:
 
     - name: Package manifest check (all publishable crates)
       run: |
-        echo "=== Package manifest check for all 25 publishable crates ==="
+        set -euo pipefail
 
-        # All publishable crates in dependency order
-        for crate in \
-          copybook-error \
-          copybook-determinism \
-          copybook-dialect \
-          copybook-codepage \
-          copybook-contracts \
-          copybook-support-matrix \
-          copybook-sequence-ring \
-          copybook-overflow \
-          copybook-error-reporter \
-          copybook-charset \
-          copybook-governance-contracts \
-          copybook-codec-memory \
-          copybook-overpunch \
-          copybook-utils \
-          copybook-governance-grid \
-          copybook-options \
-          copybook-governance-runtime \
-          copybook-core \
-          copybook-governance \
-          copybook-fixed \
-          copybook-rdw \
-          copybook-record-io \
-          copybook-codec \
-          copybook-arrow \
-          copybook-cli; do
+        echo "=== Package manifest check for all publishable crates ==="
+        PLAN_JSON="${{ steps.publish-plan.outputs.plan_json }}"
+        mapfile -t PUBLISH_CRATES < <(python - "$PLAN_JSON" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    for crate in json.load(handle):
+        print(crate)
+PY
+        )
+
+        for crate in "${PUBLISH_CRATES[@]}"; do
           echo "Checking ${crate}..."
           cargo package -p "${crate}" --list > /dev/null
           echo "  ${crate} package file list OK"
@@ -97,18 +118,19 @@ jobs:
       run: |
         echo "Publish preflight checks passed!"
         echo ""
-        echo "Validated 25 publishable crates:"
-        echo "  Level 0 (7): copybook-error, copybook-determinism, copybook-dialect,"
-        echo "               copybook-codepage, copybook-contracts, copybook-support-matrix,"
-        echo "               copybook-sequence-ring"
-        echo "  Level 1 (6): copybook-overflow, copybook-error-reporter, copybook-charset,"
-        echo "               copybook-governance-contracts, copybook-codec-memory, copybook-overpunch"
-        echo "  Level 2 (3): copybook-utils, copybook-governance-grid, copybook-options"
-        echo "  Level 3 (2): copybook-governance-runtime, copybook-core"
-        echo "  Level 4 (3): copybook-governance, copybook-fixed, copybook-rdw"
-        echo "  Level 5 (1): copybook-record-io"
-        echo "  Level 6 (1): copybook-codec"
-        echo "  Level 7 (2): copybook-arrow, copybook-cli"
+        echo "Validated ${{ steps.publish-plan.outputs.plan_count }} publishable crates:"
+        mapfile -t PUBLISH_CRATES < <(python - "${{ steps.publish-plan.outputs.plan_json }}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    for crate in json.load(handle):
+        print(crate)
+PY
+        )
+        for crate in "${PUBLISH_CRATES[@]}"; do
+          echo "  - ${crate}"
+        done
         echo ""
         echo "Downstream publish dry-runs are run just-in-time in .github/workflows/publish.yml"
         echo "after upstream crates exist on crates.io."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -114,6 +114,32 @@ jobs:
         cargo package -p copybook-determinism --no-verify
         cargo package -p copybook-rdw-predicates --no-verify
 
+    - name: Build publish plan
+      id: publish-plan
+      run: |
+        set -euo pipefail
+
+        PLAN_JSON="${{ runner.temp }}/publish-plan.json"
+        cargo run -p xtask -- publish plan --check
+        cargo run -p xtask -- publish plan --format json > "${PLAN_JSON}"
+
+        PLAN_COUNT=$(python - "${PLAN_JSON}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    print(len(json.load(handle)))
+PY
+        )
+
+        if [ "${PLAN_COUNT}" -le 0 ]; then
+          echo "No publishable crates found."
+          exit 1
+        fi
+
+        echo "plan_json=${PLAN_JSON}" >> "${GITHUB_OUTPUT}"
+        echo "plan_count=${PLAN_COUNT}" >> "${GITHUB_OUTPUT}"
+
     - name: Publish all crates in dependency order
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -187,83 +213,38 @@ jobs:
           sleep "${seconds}"
         }
 
-        # Level 0: No internal dependencies (11 crates)
-        echo "=== Level 0: Foundation crates ==="
-        publish_crate copybook-error
-        publish_crate copybook-determinism
-        publish_crate copybook-dialect
-        publish_crate copybook-codepage
-        publish_crate copybook-contracts
-        publish_crate copybook-support-matrix
-        publish_crate copybook-sequence-ring
-        publish_crate copybook-corruption-predicates
-        publish_crate copybook-rdw-predicates
-        publish_crate copybook-zoned-format
-        publish_crate copybook-lexer
-        wait_for_index 60
+        PLAN_JSON="${{ steps.publish-plan.outputs.plan_json }}"
+        PLAN_COUNT="${{ steps.publish-plan.outputs.plan_count }}"
+        mapfile -t PUBLISH_CRATES < <(python - "$PLAN_JSON" <<'PY'
+import json
+import sys
 
-        # Level 1: Depends only on Level 0 (8 crates)
-        echo "=== Level 1: Core primitives ==="
-        publish_crate copybook-overflow
-        publish_crate copybook-error-reporter
-        publish_crate copybook-charset
-        publish_crate copybook-governance-contracts
-        publish_crate copybook-codec-memory
-        publish_crate copybook-overpunch
-        publish_crate copybook-safe-index
-        publish_crate copybook-safe-text
-        wait_for_index 60
+with open(sys.argv[1], encoding="utf-8") as handle:
+    for crate in json.load(handle):
+        print(crate)
+PY
+        )
 
-        # Level 2: Depends on Level 0-1 (3 crates)
-        echo "=== Level 2: Utilities ==="
-        publish_crate copybook-governance-grid
-        publish_crate copybook-options
-        publish_crate copybook-safe-ops
-        wait_for_index 60
+        if [ "${#PUBLISH_CRATES[@]}" -le 0 ]; then
+          echo "Publish plan empty."
+          exit 1
+        fi
 
-        # Level 3: Depends on Level 0-2 (2 crates)
-        echo "=== Level 3: Core + governance runtime ==="
-        publish_crate copybook-governance-runtime
-        publish_crate copybook-utils
-        wait_for_index 60
+        if [ "${PLAN_COUNT}" -ne "${#PUBLISH_CRATES[@]}" ]; then
+          echo "Publish plan count mismatch: expected ${PLAN_COUNT}, observed ${#PUBLISH_CRATES[@]}"
+          exit 1
+        fi
 
-        # Level 4: Depends on Level 0-3 (2 crates)
-        echo "=== Level 4: Record formats + governance ==="
-        publish_crate copybook-core
-        publish_crate copybook-governance
-        wait_for_index 60
-
-        # Level 5: Depends on Level 0-4 (4 crates)
-        echo "=== Level 5: Record format and corruption primitives ==="
-        publish_crate copybook-fixed
-        publish_crate copybook-rdw
-        publish_crate copybook-corruption-detectors
-        publish_crate copybook-corruption-rdw
-        wait_for_index 60
-
-        # Level 6: Depends on Level 0-5 (2 crates)
-        echo "=== Level 6: Record I/O + corruption facade ==="
-        publish_crate copybook-record-io
-        publish_crate copybook-corruption
-        wait_for_index 60
-
-        # Level 7: Depends on Level 0-6 (1 crate)
-        echo "=== Level 7: Codec ==="
-        publish_crate copybook-codec
-        wait_for_index 60
-
-        # Level 8: Depends on Level 0-7 (2 crates)
-        echo "=== Level 8: Arrow + CLI determinism ==="
-        publish_crate copybook-arrow
-        publish_crate copybook-cli-determinism
-        wait_for_index 60
-
-        # Level 9: Depends on Level 0-8 (1 crate)
-        echo "=== Level 9: CLI ==="
-        publish_crate copybook-cli
+        for crate in "${PUBLISH_CRATES[@]}"; do
+          echo "=== Publishing ${crate} ==="
+          publish_crate "${crate}"
+          if [[ "${crate}" != "copybook-rs" ]]; then
+            wait_for_index 60
+          fi
+        done
 
         echo ""
-        echo "All 36 publishable crates published successfully!"
+        echo "All ${PLAN_COUNT} publishable crates published successfully!"
 
     - name: Create GitHub Release
       env:
@@ -275,57 +256,32 @@ jobs:
         version="${tag#v}"
         repo_url="https://github.com/${{ github.repository }}"
 
-        cat > release-notes.md <<EOF
-        ## copybook-rs ${version}
+        PLAN_JSON="${{ steps.publish-plan.outputs.plan_json }}"
+        python - "${PLAN_JSON}" "${version}" "${repo_url}" "${tag}" <<'PY' > release-notes.md
+import json
+import sys
 
-        **Installation:**
-        \`\`\`bash
-        cargo install copybook-cli@${version}
-        \`\`\`
+plan_path, version, repo_url, tag = sys.argv[1:]
 
-        **Published Crates (36):**
+with open(plan_path, encoding="utf-8") as handle:
+    crates = json.load(handle)
 
-        | Crate | crates.io | docs.rs |
-        |-------|-----------|---------|
-        | copybook-error | [${version}](https://crates.io/crates/copybook-error/${version}) | [docs](https://docs.rs/copybook-error/${version}) |
-        | copybook-determinism | [${version}](https://crates.io/crates/copybook-determinism/${version}) | [docs](https://docs.rs/copybook-determinism/${version}) |
-        | copybook-dialect | [${version}](https://crates.io/crates/copybook-dialect/${version}) | [docs](https://docs.rs/copybook-dialect/${version}) |
-        | copybook-codepage | [${version}](https://crates.io/crates/copybook-codepage/${version}) | [docs](https://docs.rs/copybook-codepage/${version}) |
-        | copybook-contracts | [${version}](https://crates.io/crates/copybook-contracts/${version}) | [docs](https://docs.rs/copybook-contracts/${version}) |
-        | copybook-support-matrix | [${version}](https://crates.io/crates/copybook-support-matrix/${version}) | [docs](https://docs.rs/copybook-support-matrix/${version}) |
-        | copybook-sequence-ring | [${version}](https://crates.io/crates/copybook-sequence-ring/${version}) | [docs](https://docs.rs/copybook-sequence-ring/${version}) |
-        | copybook-corruption-predicates | [${version}](https://crates.io/crates/copybook-corruption-predicates/${version}) | [docs](https://docs.rs/copybook-corruption-predicates/${version}) |
-        | copybook-rdw-predicates | [${version}](https://crates.io/crates/copybook-rdw-predicates/${version}) | [docs](https://docs.rs/copybook-rdw-predicates/${version}) |
-        | copybook-zoned-format | [${version}](https://crates.io/crates/copybook-zoned-format/${version}) | [docs](https://docs.rs/copybook-zoned-format/${version}) |
-        | copybook-lexer | [${version}](https://crates.io/crates/copybook-lexer/${version}) | [docs](https://docs.rs/copybook-lexer/${version}) |
-        | copybook-overflow | [${version}](https://crates.io/crates/copybook-overflow/${version}) | [docs](https://docs.rs/copybook-overflow/${version}) |
-        | copybook-error-reporter | [${version}](https://crates.io/crates/copybook-error-reporter/${version}) | [docs](https://docs.rs/copybook-error-reporter/${version}) |
-        | copybook-charset | [${version}](https://crates.io/crates/copybook-charset/${version}) | [docs](https://docs.rs/copybook-charset/${version}) |
-        | copybook-governance-contracts | [${version}](https://crates.io/crates/copybook-governance-contracts/${version}) | [docs](https://docs.rs/copybook-governance-contracts/${version}) |
-        | copybook-codec-memory | [${version}](https://crates.io/crates/copybook-codec-memory/${version}) | [docs](https://docs.rs/copybook-codec-memory/${version}) |
-        | copybook-overpunch | [${version}](https://crates.io/crates/copybook-overpunch/${version}) | [docs](https://docs.rs/copybook-overpunch/${version}) |
-        | copybook-safe-index | [${version}](https://crates.io/crates/copybook-safe-index/${version}) | [docs](https://docs.rs/copybook-safe-index/${version}) |
-        | copybook-safe-text | [${version}](https://crates.io/crates/copybook-safe-text/${version}) | [docs](https://docs.rs/copybook-safe-text/${version}) |
-        | copybook-governance-grid | [${version}](https://crates.io/crates/copybook-governance-grid/${version}) | [docs](https://docs.rs/copybook-governance-grid/${version}) |
-        | copybook-options | [${version}](https://crates.io/crates/copybook-options/${version}) | [docs](https://docs.rs/copybook-options/${version}) |
-        | copybook-safe-ops | [${version}](https://crates.io/crates/copybook-safe-ops/${version}) | [docs](https://docs.rs/copybook-safe-ops/${version}) |
-        | copybook-governance-runtime | [${version}](https://crates.io/crates/copybook-governance-runtime/${version}) | [docs](https://docs.rs/copybook-governance-runtime/${version}) |
-        | copybook-utils | [${version}](https://crates.io/crates/copybook-utils/${version}) | [docs](https://docs.rs/copybook-utils/${version}) |
-        | copybook-core | [${version}](https://crates.io/crates/copybook-core/${version}) | [docs](https://docs.rs/copybook-core/${version}) |
-        | copybook-governance | [${version}](https://crates.io/crates/copybook-governance/${version}) | [docs](https://docs.rs/copybook-governance/${version}) |
-        | copybook-fixed | [${version}](https://crates.io/crates/copybook-fixed/${version}) | [docs](https://docs.rs/copybook-fixed/${version}) |
-        | copybook-rdw | [${version}](https://crates.io/crates/copybook-rdw/${version}) | [docs](https://docs.rs/copybook-rdw/${version}) |
-        | copybook-corruption-detectors | [${version}](https://crates.io/crates/copybook-corruption-detectors/${version}) | [docs](https://docs.rs/copybook-corruption-detectors/${version}) |
-        | copybook-corruption-rdw | [${version}](https://crates.io/crates/copybook-corruption-rdw/${version}) | [docs](https://docs.rs/copybook-corruption-rdw/${version}) |
-        | copybook-record-io | [${version}](https://crates.io/crates/copybook-record-io/${version}) | [docs](https://docs.rs/copybook-record-io/${version}) |
-        | copybook-corruption | [${version}](https://crates.io/crates/copybook-corruption/${version}) | [docs](https://docs.rs/copybook-corruption/${version}) |
-        | copybook-codec | [${version}](https://crates.io/crates/copybook-codec/${version}) | [docs](https://docs.rs/copybook-codec/${version}) |
-        | copybook-arrow | [${version}](https://crates.io/crates/copybook-arrow/${version}) | [docs](https://docs.rs/copybook-arrow/${version}) |
-        | copybook-cli-determinism | [${version}](https://crates.io/crates/copybook-cli-determinism/${version}) | [docs](https://docs.rs/copybook-cli-determinism/${version}) |
-        | copybook-cli | [${version}](https://crates.io/crates/copybook-cli/${version}) | [docs](https://docs.rs/copybook-cli/${version}) |
-
-        See [CHANGELOG.md](${repo_url}/blob/${tag}/CHANGELOG.md) for details.
-        EOF
+print(f"## copybook-rs {version}")
+print("")
+print("**Installation:**")
+print("```bash")
+print(f"cargo install copybook-cli@{version}")
+print("```")
+print("")
+print(f"**Published Crates ({len(crates)}):**")
+print("")
+print("| Crate | crates.io | docs.rs |")
+print("|-------|-----------|---------|")
+for crate in crates:
+    print(f"| {crate} | [{version}](https://crates.io/crates/{crate}/{version}) | [docs](https://docs.rs/{crate}/{version}) |")
+print("")
+print(f"See [CHANGELOG.md]({repo_url}/blob/{tag}/CHANGELOG.md) for details.")
+PY
 
         if gh release view "${tag}" >/dev/null 2>&1; then
           gh release edit "${tag}" --title "copybook-rs ${version}" --notes-file release-notes.md
@@ -367,6 +323,32 @@ jobs:
 
         echo "Arrow feature resolves from crates.io"
 
+    - name: Validate facade + redirect crates from crates.io
+      run: |
+        set -euo pipefail
+
+        VERSION="${{ github.ref_name || github.event.inputs.tag }}"
+        VERSION=${VERSION#v}
+
+        WORKDIR="$(mktemp -d)"
+        mkdir -p "${WORKDIR}/src"
+        cat > "${WORKDIR}/Cargo.toml" <<EOF
+[package]
+name = "copybook-smoke"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+copybook = "=${VERSION}"
+copybook-rs = "=${VERSION}"
+EOF
+        cat > "${WORKDIR}/src/main.rs" <<EOF
+fn main() {}
+EOF
+
+        cargo build --manifest-path "${WORKDIR}/Cargo.toml"
+        echo "Smoke test passed: copybook and copybook-rs resolve and compile from crates.io version ${VERSION}"
+
     - name: Validate docs.rs builds
       run: |
         VERSION="${{ github.ref_name || github.event.inputs.tag }}"
@@ -378,7 +360,7 @@ jobs:
         sleep 300
 
         # Check if docs are available (docs.rs builds asynchronously)
-        for crate in copybook-core copybook-codec copybook-arrow copybook-cli; do
+        for crate in copybook copybook-rs copybook-core copybook-codec copybook-arrow copybook-cli; do
           url="https://docs.rs/${crate}/${VERSION}"
           echo "Docs will be available at: ${url}"
         done
@@ -402,12 +384,16 @@ jobs:
         echo ""
         echo "Documentation:"
         echo "   https://docs.rs/copybook-core/${VERSION}"
+        echo "   https://docs.rs/copybook/${VERSION}"
+        echo "   https://docs.rs/copybook-rs/${VERSION}"
         echo "   https://docs.rs/copybook-codec/${VERSION}"
         echo "   https://docs.rs/copybook-arrow/${VERSION}"
         echo "   https://docs.rs/copybook-cli/${VERSION}"
         echo ""
         echo "Crates.io:"
         echo "   https://crates.io/crates/copybook-core"
+        echo "   https://crates.io/crates/copybook"
         echo "   https://crates.io/crates/copybook-codec"
+        echo "   https://crates.io/crates/copybook-rs"
         echo "   https://crates.io/crates/copybook-arrow"
         echo "   https://crates.io/crates/copybook-cli"

--- a/tools/xtask/src/lib.rs
+++ b/tools/xtask/src/lib.rs
@@ -7,6 +7,7 @@ use anyhow::{Result, bail};
 use std::{fs, path::Path};
 
 pub mod perf;
+pub mod publish;
 
 #[derive(Default, Debug, Clone)]
 pub struct Counts {

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -1,19 +1,17 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
 use copybook_core::support_matrix;
 use std::{fs, path::Path};
-use xtask::{Counts, counts, perf};
+use xtask::{counts, perf, Counts};
+use xtask::publish::{run_plan, PlanFormat};
 
 mod pr_insights;
 
 fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().skip(1).collect();
-    match args
-        .iter()
-        .map(std::string::String::as_str)
-        .collect::<Vec<_>>()
-        .as_slice()
-    {
+    let arg_refs = args.iter().map(std::string::String::as_str).collect::<Vec<_>>();
+
+    match arg_refs.as_slice() {
         ["docs", "sync-tests"] => sync(),
         ["docs", "verify-tests"] => verify(),
         ["docs", "verify-support-matrix"] => verify_support_matrix(),
@@ -22,30 +20,69 @@ fn main() -> Result<()> {
         ["perf", "--out-dir", out_dir] => perf::run(false, Some(out_dir)),
         ["perf", "--enforce", "--out-dir", out_dir] => perf::run(true, Some(out_dir)),
         ["perf", "--summarize-last" | "--summarize"] => perf_summarize_last(),
+        ["publish", "plan", rest @ ..] => publish_plan(rest),
         ["pr-insights"] => pr_insights::generate_summary(),
-        _ => {
-            eprintln!(
-                "Usage: cargo run -p xtask -- [docs|perf|pr-insights] <subcommand>\n\
-                 \n\
-                 docs sync-tests                 Sync test status from junit.xml\n\
-                 docs verify-tests               Verify test status is in sync\n\
-                 docs verify-support-matrix      Verify support matrix registry ↔ docs\n\
-                 perf                            Run perf benchmark runner\n\
-                 perf --enforce                  Run perf with SLO enforcement\n\
-                 perf --out-dir <path>           Run perf with custom output directory\n\
-                 perf --summarize-last           Summarize latest perf.json with SLO comparison\n\
-                 pr-insights                     Generate PR insights report (nextest + perf)"
-            );
-            Ok(())
-        }
+        _ => usage(),
     }
+}
+
+fn publish_plan(args: &[&str]) -> Result<()> {
+    let mut format = PlanFormat::Plain;
+    let mut check_only = false;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i] {
+            "--check" => {
+                check_only = true;
+            }
+            "--format" => {
+                let value = args.get(i + 1).copied().ok_or_else(|| {
+                    bail!("Missing value for --format. Expected: plain or json.")
+                })?;
+                format = match value {
+                    "plain" => PlanFormat::Plain,
+                    "json" => PlanFormat::Json,
+                    other => {
+                        bail!("Unknown format '{other}'. Expected: plain or json.");
+                    }
+                };
+                i += 1;
+            }
+            other => {
+                bail!(
+                    "Unknown publish plan argument '{other}'. Expected: --check and optional --format <plain|json>."
+                );
+            }
+        }
+        i += 1;
+    }
+
+    run_plan(format, check_only)
+}
+
+fn usage() -> Result<()> {
+    eprintln!(
+        "Usage: cargo run -p xtask -- [docs|perf|publish|pr-insights] <subcommand>\n\
+         \n\
+         docs sync-tests                     Sync test status from junit.xml\n\
+         docs verify-tests                   Verify test status is in sync\n\
+         docs verify-support-matrix          Verify support matrix registry -> docs\n\
+         perf                                Run perf benchmark runner\n\
+         perf --enforce                      Run perf with SLO enforcement\n\
+         perf --out-dir <path>               Run perf with custom output directory\n\
+         perf --summarize-last               Summarize latest perf.json with SLO comparison\n\
+         publish plan [--format <plain|json>] [--check]  Print and validate publish order\n\
+         pr-insights                         Generate PR insights report (nextest + perf)"
+    );
+    Ok(())
 }
 
 fn block(c: &Counts) -> String {
     let p = c.passed;
     let s = c.skipped;
     format!(
-        "**conformance:** {p}/{p} • **roundtrip:** N/A • **negative:** N/A • **skipped:** {s} • **leaks:** 0  \n\
+        "**conformance:** {p}/{p} â€¢ **roundtrip:** N/A â€¢ **negative:** N/A â€¢ **skipped:** {s} â€¢ **leaks:** 0  \n\
          _Source: CI receipts (nextest/junit). This block is updated automatically._"
     )
 }
@@ -71,7 +108,7 @@ fn sync() -> Result<()> {
     replace_in_file("README.md", &b)?;
     replace_in_file("docs/REPORT.md", &b)?;
 
-    println!("✓ Synced test status to README.md and docs/REPORT.md");
+    println!("âœ“ Synced test status to README.md and docs/REPORT.md");
     Ok(())
 }
 
@@ -86,7 +123,7 @@ fn verify() -> Result<()> {
         }
     }
 
-    println!("✓ Test status is in sync");
+    println!("âœ“ Test status is in sync");
     Ok(())
 }
 
@@ -98,8 +135,8 @@ fn verify_support_matrix() -> Result<()> {
     let mut missing = Vec::new();
 
     for feature in all_features {
-        let id =
-            serde_plain::to_string(&feature.id).unwrap_or_else(|_| format!("{:?}", feature.id));
+        let id = serde_plain::to_string(&feature.id)
+            .unwrap_or_else(|_| format!("{:?}", feature.id));
 
         // Check if the feature ID appears anywhere in the doc
         // We're lenient: just check for the kebab-case ID string
@@ -118,7 +155,7 @@ fn verify_support_matrix() -> Result<()> {
     }
 
     println!(
-        "✓ Support matrix registry ↔ docs in sync ({} features verified)",
+        "âœ“ Support matrix registry â†” docs in sync ({} features verified)",
         all_features.len()
     );
     Ok(())
@@ -154,7 +191,7 @@ fn perf_summarize_last() -> Result<()> {
             anyhow::bail!(
                 "No benchmark receipt directories found under {}",
                 benchmarks_dir.display()
-            );
+            )
         };
         let latest_dir = &latest_entry.path();
         let latest_perf = latest_dir.join("perf.json");

--- a/tools/xtask/src/publish.rs
+++ b/tools/xtask/src/publish.rs
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+use serde_json::Value;
+use std::{collections::{HashMap, HashSet}, process::Command};
+
+#[derive(Debug, Deserialize)]
+struct Metadata {
+    workspace_members: Vec<String>,
+    packages: Vec<Package>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Package {
+    id: String,
+    name: String,
+    #[serde(default)]
+    publish: Option<Value>,
+    #[serde(default)]
+    dependencies: Vec<Dependency>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Dependency {
+    name: String,
+    #[serde(default)]
+    kind: Option<String>,
+    #[serde(default)]
+    package: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum PlanFormat {
+    Plain,
+    Json,
+}
+
+pub fn run_plan(format: PlanFormat, check_only: bool) -> Result<()> {
+    let plan = build_publish_plan()?;
+    if check_only {
+        validate_publish_plan(&plan)?;
+        println!("publish plan validated: {} publishable crate(s)", plan.len());
+        return Ok(());
+    }
+
+    match format {
+        PlanFormat::Plain => {
+            for crate_name in plan {
+                println!("{crate_name}");
+            }
+        }
+        PlanFormat::Json => {
+            let json = serde_json::to_string_pretty(&plan)?;
+            println!("{json}");
+        }
+    }
+
+    Ok(())
+}
+
+fn build_publish_plan() -> Result<Vec<String>> {
+    let output = Command::new("cargo")
+        .args(["metadata", "--format-version", "1", "--no-deps"])
+        .output()
+        .context("failed to execute cargo metadata")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("cargo metadata failed:\n{stderr}");
+    }
+
+    let metadata_text = String::from_utf8(output.stdout).context("cargo metadata output not valid UTF-8")?;
+    let metadata: Metadata = serde_json::from_str(&metadata_text)
+        .context("failed to parse cargo metadata output")?;
+
+    let plan = ordered_publish_plan(metadata)?;
+    Ok(plan)
+}
+
+fn ordered_publish_plan(metadata: Metadata) -> Result<Vec<String>> {
+    let workspace_members = metadata.workspace_members.into_iter().collect::<HashSet<_>>();
+
+    let publishable_packages = metadata
+        .packages
+        .into_iter()
+        .filter(|package| {
+            workspace_members.contains(&package.id) && is_publishable_package(&package.publish)
+        })
+        .collect::<Vec<_>>();
+
+    if publishable_packages.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut publishable_ids = HashSet::new();
+    let mut id_to_name = HashMap::new();
+    for package in &publishable_packages {
+        publishable_ids.insert(package.id.clone());
+        id_to_name.insert(package.id.clone(), package.name.clone());
+    }
+
+    let mut in_degree: HashMap<String, usize> = HashMap::new();
+    let mut dependents: HashMap<String, Vec<String>> = HashMap::new();
+    let mut seen_edges = HashSet::new();
+
+    for package in &publishable_packages {
+        in_degree.entry(package.name.clone()).or_insert(0);
+    }
+
+    for package in &publishable_packages {
+        for dependency in package
+            .dependencies
+            .iter()
+            .filter(|dep| dep.kind.as_deref() == Some("normal"))
+        {
+            let Some(dep_id) = &dependency.package else {
+                continue;
+            };
+            if !publishable_ids.contains(dep_id) {
+                continue;
+            }
+
+            let Some(dep_name) = id_to_name.get(dep_id) else {
+                continue;
+            };
+            let edge = (dep_name.clone(), package.name.clone());
+            if !seen_edges.insert(edge.clone()) {
+                continue;
+            }
+            dependents
+                .entry(dep_name.clone())
+                .or_default()
+                .push(package.name.clone());
+            *in_degree
+                .entry(package.name.clone())
+                .or_default() += 1;
+        }
+    }
+
+    let mut ready = in_degree
+        .iter()
+        .filter_map(|(name, degree)| (*degree == 0).then_some(name.clone()))
+        .collect::<Vec<_>>();
+    ready.sort_unstable();
+
+    let mut ordered = Vec::new();
+    while let Some(crate_name) = ready.first().cloned() {
+        ready.remove(0);
+        ordered.push(crate_name.clone());
+
+        if let Some(children) = dependents.get(&crate_name) {
+            for child in children {
+                let child_degree = in_degree.get_mut(child).expect("in-degree exists");
+                if *child_degree > 0 {
+                    *child_degree -= 1;
+                }
+                if *child_degree == 0 {
+                    ready.push(child.clone());
+                }
+            }
+        }
+        ready.sort_unstable();
+        ready.dedup();
+    }
+
+    if ordered.len() != in_degree.len() {
+        bail!("failed to resolve publish order: dependency cycle or missing dependency");
+    }
+
+    Ok(ordered)
+}
+
+fn validate_publish_plan(plan: &[String]) -> Result<()> {
+    let mut cursor = HashMap::<String, usize>::new();
+    for (index, name) in plan.iter().enumerate() {
+        cursor.insert(name.clone(), index);
+    }
+
+    if !cursor.contains_key("copybook") {
+        bail!("publish plan must include copybook");
+    }
+
+    if !cursor.contains_key("copybook-rs") {
+        bail!("publish plan must include copybook-rs");
+    }
+
+    if let (Some(&core_pos), Some(&facade_pos)) =
+        (cursor.get("copybook-core"), cursor.get("copybook"))
+    {
+        if core_pos > facade_pos {
+            bail!("copybook-core must appear before copybook");
+        }
+    }
+
+    if let (Some(&facade_pos), Some(&rs_pos)) = (cursor.get("copybook"), cursor.get("copybook-rs")) {
+        if facade_pos > rs_pos {
+            bail!("copybook must appear before copybook-rs");
+        }
+    }
+
+    let mut unique = HashSet::new();
+    for crate_name in plan {
+        if !unique.insert(crate_name) {
+            bail!("duplicate crate in publish plan: {crate_name}");
+        }
+    }
+
+    Ok(())
+}
+
+fn is_publishable_package(publish: &Option<Value>) -> bool {
+    match publish {
+        None => true,
+        Some(Value::Bool(false)) => false,
+        Some(Value::Array(values)) => !values.is_empty(),
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_plan(metadata_json: &str) -> Result<Vec<String>> {
+        let metadata: Metadata = serde_json::from_str(metadata_json).unwrap();
+        ordered_publish_plan(metadata)
+    }
+
+    #[test]
+    fn publish_plan_orders_dependencies() {
+        let plan = parse_plan(
+            r#"{
+                "workspace_members":["id-core", "id-codec", "id-facade", "id-rs", "id-tool"],
+                "packages":[
+                    {"id":"id-tool","name":"copybook-scripts","publish":false,"dependencies":[]},
+                    {"id":"id-core","name":"copybook-core","dependencies":[]},
+                    {"id":"id-codec","name":"copybook-codec","publish":["crates-io"],"dependencies":[
+                        {"name":"copybook-core","kind":"normal","package":"id-core"}
+                    ]},
+                    {"id":"id-facade","name":"copybook","dependencies":[
+                        {"name":"copybook-core","kind":"normal","package":"id-core"},
+                        {"name":"copybook-codec","kind":"normal","package":"id-codec"}
+                    ]},
+                    {"id":"id-rs","name":"copybook-rs","dependencies":[
+                        {"name":"copybook","kind":"normal","package":"id-facade"}
+                    ]}
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            plan,
+            vec![
+                "copybook-core".to_string(),
+                "copybook-codec".to_string(),
+                "copybook".to_string(),
+                "copybook-rs".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn publish_plan_rejects_cycles() {
+        let result = parse_plan(
+            r#"{
+                "workspace_members":["id-a", "id-b"],
+                "packages":[
+                    {"id":"id-a","name":"crate-a","dependencies":[{"name":"crate-b","kind":"normal","package":"id-b"}]},
+                    {"id":"id-b","name":"crate-b","dependencies":[{"name":"crate-a","kind":"normal","package":"id-a"}]}
+                ]
+            }"#,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn publish_plan_excludes_non_publishable() {
+        let plan = parse_plan(
+            r#"{
+                "workspace_members":["id-core", "id-private"],
+                "packages":[
+                    {"id":"id-core","name":"copybook-core","dependencies":[]},
+                    {"id":"id-private","name":"copybook-private","publish":[],"dependencies":[
+                        {"name":"copybook-core","kind":"normal","package":"id-core"}
+                    ]}
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(plan, vec!["copybook-core".to_string()]);
+    }
+
+    #[test]
+    fn validate_publish_plan_enforces_facade_order() {
+        let plan = vec![
+            "copybook-core".to_string(),
+            "copybook".to_string(),
+            "copybook-rs".to_string(),
+        ];
+        assert!(validate_publish_plan(&plan).is_ok());
+    }
+
+    #[test]
+    fn validate_publish_plan_rejects_duplicate_crates() {
+        let plan = vec![
+            "copybook-core".to_string(),
+            "copybook".to_string(),
+            "copybook".to_string(),
+        ];
+        assert!(validate_publish_plan(&plan).is_err());
+    }
+
+    #[test]
+    fn validate_publish_plan_requires_facades() {
+        let plan = vec![
+            "copybook-core".to_string(),
+            "copybook-codec".to_string(),
+        ];
+        assert!(validate_publish_plan(&plan).is_err());
+    }
+}


### PR DESCRIPTION
## Summary\n\n- Add an xtask publish plan command that computes dependency-ordered publishable crates from workspace metadata.\n- Wire publish plan into tools/xtask CLI.\n- Update .github/workflows/publish.yml and .github/workflows/publish-dry-run.yml to consume the generated plan for publish order, crate counts, package checks, and release notes.\n- Add smoke verification for copybook and copybook-rs via crates.io in the publish smoke flow.\n\n## Validation\n\n- cargo run -p xtask -- publish plan --check\n- cargo run -p xtask -- publish plan\n\nCloses #538\n