### PR TITLE
docs(stability): verify stability registry against workspace metadata

### DIFF
--- a/docs/STABILITY_GUARANTEES.md
+++ b/docs/STABILITY_GUARANTEES.md
@@ -23,6 +23,28 @@ This document defines what users can expect to remain stable across releases, pr
 - Zoned decimal metadata preservation for maintaining copybook semantics
 - Codepage conversion accuracy (EBCDIC <-> ASCII)
 
+## Stability Surface Registry
+
+The canonical machine-readable surface classification is:
+
+- `docs/stability/surface-registry.json`
+
+Allowed classes:
+
+- `stable`: Included in the current stable product promise
+- `beta`: Usable, but subject to ongoing compatibility or policy changes
+- `experimental`: Opt-in and may change without major-version compatibility
+- `internal-dev-only`: Not a user-facing support commitment
+
+All public packages and public Cargo features are declared in this registry.
+`rtk cargo run -p xtask -- docs verify-all` enforces:
+
+- registry coverage for every workspace package
+- package-level class validation
+- public feature-level class validation
+- non-placeholder stability statements and non-empty beta/experimental criteria
+- source-of-truth path checks
+
 ## What May Change
 
 **Internal APIs**

--- a/docs/stability/surface-registry.json
+++ b/docs/stability/surface-registry.json
@@ -1,0 +1,944 @@
+{
+  "schema_version": "1.0.0",
+  "packages": [
+    {
+      "name": "copybook",
+      "publish": true,
+      "class": "stable",
+      "stability_statement": "Canonical public facade and primary installation surface for users.",
+      "limitations": [],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-arrow",
+      "publish": true,
+      "class": "experimental",
+      "stability_statement": "Arrow/Parquet interop is opt-in and may change behavior in place.",
+      "limitations": [
+        "Schema and conversion API may add, remove, or rename public helpers before graduation.",
+        "Benchmarks and parity guarantees are best-effort while the surface is experimental."
+      ],
+      "graduation_criteria": [
+        "Stability and compatibility evidence for all documented conversion paths are established.",
+        "The CLI and library contracts for Arrow/Parquet are declared in the API/feature registry."
+      ],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": [
+        {
+          "name": "comprehensive-tests",
+          "class": "internal-dev-only",
+          "stability_statement": "Test-only feature entrypoint; not a user support guarantee.",
+          "limitations": [],
+          "graduation_criteria": []
+        },
+        {
+          "name": "experimental",
+          "class": "experimental",
+          "stability_statement": "Opt-in feature gate that keeps the crate on the experimental track.",
+          "limitations": [
+            "Can change API shape without a major-version-compatible migration."
+          ],
+          "graduation_criteria": [
+            "Feature remains stable through a full compatibility evidence cycle and no public break without migration docs."
+          ]
+        }
+      ]
+    },
+    {
+      "name": "copybook-bdd",
+      "publish": false,
+      "class": "internal-dev-only",
+      "stability_statement": "BDD test harness crate for repository validation only.",
+      "limitations": [
+        "Not intended for downstream consumption.",
+        "No stability guarantees are made for downstream API usage."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": [
+        {
+          "name": "audit",
+          "class": "internal-dev-only",
+          "stability_statement": "Test-helper feature only; not part of product support promises.",
+          "limitations": [
+            "Reserved for local validation and CI workflows."
+          ],
+          "graduation_criteria": []
+        }
+      ]
+    },
+    {
+      "name": "copybook-bench",
+      "publish": false,
+      "class": "internal-dev-only",
+      "stability_statement": "Benchmarking crate used for local and CI performance evaluation.",
+      "limitations": [
+        "Not part of stable user-facing support commitments.",
+        "Benchmarks and flags may change for internal experimentation."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": [
+        {
+          "name": "comprehensive-tests",
+          "class": "internal-dev-only",
+          "stability_statement": "Test coverage feature gate.",
+          "limitations": [
+            "Only used for internal validation paths."
+          ],
+          "graduation_criteria": []
+        },
+        {
+          "name": "diagnostics",
+          "class": "internal-dev-only",
+          "stability_statement": "Internal diagnostics mode.",
+          "limitations": [
+            "No external usage or API compatibility promise."
+          ],
+          "graduation_criteria": []
+        },
+        {
+          "name": "perf",
+          "class": "internal-dev-only",
+          "stability_statement": "Performance-only toggle for internal workflows.",
+          "limitations": [
+            "Behavior may change when performance harness evolves."
+          ],
+          "graduation_criteria": []
+        },
+        {
+          "name": "progressive",
+          "class": "internal-dev-only",
+          "stability_statement": "Progressive mode is test-only.",
+          "limitations": [
+            "No downstream compatibility promises."
+          ],
+          "graduation_criteria": []
+        }
+      ]
+    },
+    {
+      "name": "copybook-charset",
+      "publish": true,
+      "class": "stable",
+      "stability_statement": "Character-set conversion helpers used by parser and codec entrypoints.",
+      "limitations": [],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": [
+        {
+          "name": "clap",
+          "class": "beta",
+          "stability_statement": "Optional CLI integration feature for downstream command wiring.",
+          "limitations": [
+            "Public feature surface is not included in the v1 compatibility contract."
+          ],
+          "graduation_criteria": [
+            "Cross-version compatibility verification for downstream CLI integrations is added.",
+            "Feature stability is validated in the API baseline run."
+          ]
+        },
+        {
+          "name": "comprehensive-tests",
+          "class": "internal-dev-only",
+          "stability_statement": "Feature is for repository test matrix execution.",
+          "limitations": [
+            "Not part of user-facing support promises."
+          ],
+          "graduation_criteria": []
+        }
+      ]
+    },
+    {
+      "name": "copybook-cli",
+      "publish": true,
+      "class": "stable",
+      "stability_statement": "Supported CLI surface for parse/encode/decode/verify/use-case workflows.",
+      "limitations": [],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md",
+        "docs/CLI_REFERENCE.md"
+      ],
+      "features": [
+        {
+          "name": "arrow",
+          "class": "experimental",
+          "stability_statement": "Optional Arrow runtime surface is explicitly experimental.",
+          "limitations": [
+            "May change command output, option names, and crate API shape."
+          ],
+          "graduation_criteria": [
+            "Arrow behavior is covered by stable schema/CLI evidence and frozen for v1."
+          ]
+        },
+        {
+          "name": "audit",
+          "class": "internal-dev-only",
+          "stability_statement": "Debug/audit mode for internal compliance-focused workflows.",
+          "limitations": [
+            "No downstream stability promise."
+          ],
+          "graduation_criteria": []
+        },
+        {
+          "name": "comprehensive-tests",
+          "class": "internal-dev-only",
+          "stability_statement": "Feature is for repository test coverage only.",
+          "limitations": [
+            "Not documented as supported behavior."
+          ],
+          "graduation_criteria": []
+        },
+        {
+          "name": "metrics",
+          "class": "beta",
+          "stability_statement": "Optional metrics integration for operational observability.",
+          "limitations": [
+            "Optional observability paths are not yet in the v1 freeze."
+          ],
+          "graduation_criteria": [
+            "Metrics contract is documented with a stable output schema and compatibility checks."
+          ]
+        },
+        {
+          "name": "soak",
+          "class": "internal-dev-only",
+          "stability_statement": "Soak/benchmarking path not part of the supported CLI contract.",
+          "limitations": [
+            "Used only for sustained-load validation."
+          ],
+          "graduation_criteria": []
+        }
+      ]
+    },
+    {
+      "name": "copybook-cli-determinism",
+      "publish": true,
+      "class": "stable",
+      "stability_statement": "Determinism-focused CLI subcommands and fixtures for reproducible behavior checks.",
+      "limitations": [],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-codec",
+      "publish": true,
+      "class": "stable",
+      "stability_statement": "Core parse/decode/encode implementation for supported data pipelines.",
+      "limitations": [],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/reference/LIBRARY_API.md",
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": [
+        {
+          "name": "audit",
+          "class": "experimental",
+          "stability_statement": "Audit controls and diagnostics are not part of the v1 stable codec promise.",
+          "limitations": [
+            "Behavior may evolve as audit-policy semantics are refined."
+          ],
+          "graduation_criteria": [
+            "Audit workflows are fully documented with migration rules and compatibility evidence."
+          ]
+        },
+        {
+          "name": "comp3_fast",
+          "class": "internal-dev-only",
+          "stability_statement": "Performance-tuned COMP-3 path; implementation detail for advanced users.",
+          "limitations": [
+            "Not covered by the v1 stable codec contract."
+          ],
+          "graduation_criteria": []
+        },
+        {
+          "name": "comp3_unsafe",
+          "class": "internal-dev-only",
+          "stability_statement": "Unsafe COMP-3 optimization path.",
+          "limitations": [
+            "May change with implementation and does not carry user-facing stability."
+          ],
+          "graduation_criteria": []
+        },
+        {
+          "name": "comprehensive-tests",
+          "class": "internal-dev-only",
+          "stability_statement": "Test-only test-integration feature.",
+          "limitations": [
+            "Not intended for downstream use."
+          ],
+          "graduation_criteria": []
+        },
+        {
+          "name": "metrics",
+          "class": "beta",
+          "stability_statement": "Optional telemetry support and counters for integrations.",
+          "limitations": [
+            "Telemetry naming and availability can change before graduation."
+          ],
+          "graduation_criteria": [
+            "Stability of metrics hooks is proven across release evidence and documented."
+          ]
+        }
+      ]
+    },
+    {
+      "name": "copybook-codec-memory",
+      "publish": true,
+      "class": "internal-dev-only",
+      "stability_statement": "Performance memory helpers for codec internals.",
+      "limitations": [
+        "Internal performance crate with no external support obligation.",
+        "API is free to evolve while under this class."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-codepage",
+      "publish": true,
+      "class": "stable",
+      "stability_statement": "Canonical supported codepage policy and conversion surface.",
+      "limitations": [],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/reference/LIBRARY_API.md",
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": [
+        {
+          "name": "clap",
+          "class": "beta",
+          "stability_statement": "CLI-facing integration feature for downstream command assembly.",
+          "limitations": [
+            "Not part of the v1 stable API contract."
+          ],
+          "graduation_criteria": [
+            "Downstream CLI compatibility matrix includes this feature with migration steps."
+          ]
+        },
+        {
+          "name": "comprehensive-tests",
+          "class": "internal-dev-only",
+          "stability_statement": "Internal test-only feature.",
+          "limitations": [
+            "No user-facing stability promise."
+          ],
+          "graduation_criteria": []
+        }
+      ]
+    },
+    {
+      "name": "copybook-contracts",
+      "publish": true,
+      "class": "stable",
+      "stability_statement": "Governance and feature contracts are part of the supported compatibility baseline.",
+      "limitations": [],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-core",
+      "publish": true,
+      "class": "stable",
+      "stability_statement": "Core parser and schema construction APIs are a stable platform surface.",
+      "limitations": [],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/reference/LIBRARY_API.md",
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": [
+        {
+          "name": "audit",
+          "class": "experimental",
+          "stability_statement": "Audit module remains experimental and may change.",
+          "limitations": [
+            "Behavior, API shape, and output payloads can change while experimental."
+          ],
+          "graduation_criteria": [
+            "Audit surface is moved to beta only after deterministic compatibility evidence."
+          ]
+        },
+        {
+          "name": "comprehensive-tests",
+          "class": "internal-dev-only",
+          "stability_statement": "Test fixture feature only.",
+          "limitations": [
+            "Not a supported feature for external users."
+          ],
+          "graduation_criteria": []
+        }
+      ]
+    },
+    {
+      "name": "copybook-corruption",
+      "publish": true,
+      "class": "internal-dev-only",
+      "stability_statement": "Internal corruption and validation helpers.",
+      "limitations": [
+        "No explicit support commitment for downstream consumers."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-corruption-detectors",
+      "publish": true,
+      "class": "internal-dev-only",
+      "stability_statement": "Internal corruption detector modules for repository internals.",
+      "limitations": [
+        "No downstream API promises."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-corruption-predicates",
+      "publish": true,
+      "class": "internal-dev-only",
+      "stability_statement": "Internal predicate helpers for corruption workflows.",
+      "limitations": [
+        "No public support guarantee."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-corruption-rdw",
+      "publish": true,
+      "class": "internal-dev-only",
+      "stability_statement": "RDW corruption support helpers used by internal pipelines.",
+      "limitations": [
+        "Not part of user-facing stable compatibility promises."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-determinism",
+      "publish": true,
+      "class": "internal-dev-only",
+      "stability_statement": "Determinism helper crate for internal test evidence paths.",
+      "limitations": [
+        "No downstream API compatibility commitments."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-dialect",
+      "publish": true,
+      "class": "internal-dev-only",
+      "stability_statement": "Dialect parsing surface exposed for parser behavior specialization.",
+      "limitations": [
+        "Not part of default v1 compatibility commitments."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": [
+        {
+          "name": "comprehensive-tests",
+          "class": "internal-dev-only",
+          "stability_statement": "Internal fixture feature only.",
+          "limitations": [
+            "Test-only feature."
+          ],
+          "graduation_criteria": []
+        }
+      ]
+    },
+    {
+      "name": "copybook-e2e",
+      "publish": false,
+      "class": "internal-dev-only",
+      "stability_statement": "End-to-end integration test crate for repository pipelines.",
+      "limitations": [
+        "Not intended for downstream reuse or support."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-error",
+      "publish": true,
+      "class": "stable",
+      "stability_statement": "Versioned error taxonomy and reporting contracts used by core APIs.",
+      "limitations": [],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/reference/ERROR_CODES.md",
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-error-reporter",
+      "publish": true,
+      "class": "stable",
+      "stability_statement": "Supported error reporting and formatting interfaces for diagnostics.",
+      "limitations": [],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-fixed",
+      "publish": true,
+      "class": "internal-dev-only",
+      "stability_statement": "Specialized fixed-field helpers for internal parser composition.",
+      "limitations": [
+        "No downstream support contract."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": [
+        {
+          "name": "comprehensive-tests",
+          "class": "internal-dev-only",
+          "stability_statement": "Test-only feature gate.",
+          "limitations": [
+            "No user-facing support promise."
+          ],
+          "graduation_criteria": []
+        }
+      ]
+    },
+    {
+      "name": "copybook-gen",
+      "publish": false,
+      "class": "internal-dev-only",
+      "stability_statement": "Code-generation utilities for repository build workflows.",
+      "limitations": [
+        "Internal-only and can change without compatibility commitments."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": [
+        {
+          "name": "comprehensive-tests",
+          "class": "internal-dev-only",
+          "stability_statement": "Fixture-focused feature for internal testing.",
+          "limitations": [
+            "No downstream API promise."
+          ],
+          "graduation_criteria": []
+        }
+      ]
+    },
+    {
+      "name": "copybook-governance",
+      "publish": true,
+      "class": "beta",
+      "stability_statement": "Compatibility runtime facade with user-facing imports but not yet v1 guaranteed.",
+      "limitations": [
+        "Governance behavior may evolve as feature lifecycle definitions are finalized.",
+        "No strict freeze guarantees until beta criteria are met."
+      ],
+      "graduation_criteria": [
+        "Documented mapping between governance, support-matrix, and runtime policy is stable.",
+        "No compatibility regressions and evidence is added through API baseline checks."
+      ],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-governance-contracts",
+      "publish": true,
+      "class": "beta",
+      "stability_statement": "Interoperability contracts for governance and support are currently beta.",
+      "limitations": [
+        "The stability of the mapping layer may change across minor releases.",
+        "API shape may adjust during migration to final v1 contract."
+      ],
+      "graduation_criteria": [
+        "Feature contracts are complete, documented, and covered by regression evidence."
+      ],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-governance-grid",
+      "publish": true,
+      "class": "beta",
+      "stability_statement": "Governance mapping grid is stable for internal usage but not yet v1 guaranteed.",
+      "limitations": [
+        "Grid rows and coverage diagnostics may still evolve."
+      ],
+      "graduation_criteria": [
+        "Coverage diagnostics, completeness checks, and migration behavior are documented and stable."
+      ],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-governance-runtime",
+      "publish": true,
+      "class": "beta",
+      "stability_statement": "Runtime governance evaluation is useful and used internally but still beta.",
+      "limitations": [
+        "Runtime summaries and availability logic may change for compatibility."
+      ],
+      "graduation_criteria": [
+        "Runtime states and summaries are compatibility-verified and accompanied by migration notes."
+      ],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-lexer",
+      "publish": true,
+      "class": "internal-dev-only",
+      "stability_statement": "Tokenizer and lexer internals for parser composition.",
+      "limitations": [
+        "No downstream support commitments."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": [
+        {
+          "name": "comprehensive-tests",
+          "class": "internal-dev-only",
+          "stability_statement": "Test-only fixture feature.",
+          "limitations": [
+            "Only for repository CI validation."
+          ],
+          "graduation_criteria": []
+        }
+      ]
+    },
+    {
+      "name": "copybook-options",
+      "publish": true,
+      "class": "internal-dev-only",
+      "stability_statement": "Internal options parsing and policy types.",
+      "limitations": [
+        "No user-facing support contract."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-overflow",
+      "publish": true,
+      "class": "internal-dev-only",
+      "stability_statement": "Overflow-aware behavior and helpers for parser internals.",
+      "limitations": [
+        "Not guaranteed for downstream API compatibility."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-overpunch",
+      "publish": true,
+      "class": "internal-dev-only",
+      "stability_statement": "Overpunch conversion helpers for signed-data support.",
+      "limitations": [
+        "Internal helper behavior may change."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-proptest",
+      "publish": false,
+      "class": "internal-dev-only",
+      "stability_statement": "Property-based testing crate for resilience checks.",
+      "limitations": [
+        "Used for internal test generation only."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": [
+        {
+          "name": "comp3_fast",
+          "class": "internal-dev-only",
+          "stability_statement": "Experimental fast-COMP3 test feature.",
+          "limitations": [
+            "Internal and not part of product guarantees."
+          ],
+          "graduation_criteria": []
+        }
+      ]
+    },
+    {
+      "name": "copybook-rdw",
+      "publish": true,
+      "class": "internal-dev-only",
+      "stability_statement": "RDW record format helper crate.",
+      "limitations": [
+        "No external user support commitments."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": [
+        {
+          "name": "comprehensive-tests",
+          "class": "internal-dev-only",
+          "stability_statement": "Test-only coverage feature.",
+          "limitations": [
+            "Internal usage only."
+          ],
+          "graduation_criteria": []
+        }
+      ]
+    },
+    {
+      "name": "copybook-rdw-predicates",
+      "publish": true,
+      "class": "internal-dev-only",
+      "stability_statement": "RDW predicate surface for internal validation paths.",
+      "limitations": [
+        "No public compatibility promises."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-record-io",
+      "publish": true,
+      "class": "internal-dev-only",
+      "stability_statement": "Record I/O helpers used to support parser/codec internals.",
+      "limitations": [
+        "No v1 guarantee for downstream API compatibility."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": [
+        {
+          "name": "comprehensive-tests",
+          "class": "internal-dev-only",
+          "stability_statement": "Test-only feature.",
+          "limitations": [
+            "Internal usage only."
+          ],
+          "graduation_criteria": []
+        }
+      ]
+    },
+    {
+      "name": "copybook-rs",
+      "publish": true,
+      "class": "internal-dev-only",
+      "stability_statement": "Compatibility alias that preserves the canonical `copybook` name for downstream crates and installs.",
+      "limitations": [
+        "No independent compatibility surface; supported behavior follows `copybook`.",
+        "Stability is not separately guaranteed beyond redirect compatibility."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-safe-index",
+      "publish": true,
+      "class": "internal-dev-only",
+      "stability_statement": "Safety and indexing primitives for internal bounded operations.",
+      "limitations": [
+        "Not intended for downstream API guarantees."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-safe-ops",
+      "publish": true,
+      "class": "internal-dev-only",
+      "stability_statement": "Low-level safe operation helpers for internal execution paths.",
+      "limitations": [
+        "No external support or stability obligations."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-safe-text",
+      "publish": true,
+      "class": "internal-dev-only",
+      "stability_statement": "Text safety helpers for internal parser and codec use.",
+      "limitations": [
+        "Not covered by downstream stability guarantees."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-scripts",
+      "publish": false,
+      "class": "internal-dev-only",
+      "stability_statement": "Script utilities for repository maintenance and automation.",
+      "limitations": [
+        "No downstream consumption or support contract."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-sequence-ring",
+      "publish": true,
+      "class": "internal-dev-only",
+      "stability_statement": "Internal bounded-sequence data structure with deterministic iteration helper.",
+      "limitations": [
+        "Internal utility crate with no downstream stability promise."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-support-matrix",
+      "publish": true,
+      "class": "beta",
+      "stability_statement": "Support feature matrix is foundational but currently beta as process and coverage are still under hardening.",
+      "limitations": [
+        "Feature IDs and status semantics may still evolve while beta.",
+        "Evidence mapping is being aligned before v1 lock."
+      ],
+      "graduation_criteria": [
+        "Support matrix status model is aligned with API baseline and governance bindings.",
+        "Full compatibility evidence is added for documented matrix rows."
+      ],
+      "source_of_truth": [
+        "docs/ROADMAP.md",
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-utils",
+      "publish": true,
+      "class": "internal-dev-only",
+      "stability_statement": "Utility helpers for parser/codec internals and test fixtures.",
+      "limitations": [
+        "No user-facing compatibility contract."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "copybook-zoned-format",
+      "publish": true,
+      "class": "internal-dev-only",
+      "stability_statement": "Zoned-format helpers for internal numeric conversion workflows.",
+      "limitations": [
+        "Behavioral contracts can change while in internal class."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    },
+    {
+      "name": "xtask",
+      "publish": false,
+      "class": "internal-dev-only",
+      "stability_statement": "Build and maintenance automation tasks.",
+      "limitations": [
+        "Not a distributable user API."
+      ],
+      "graduation_criteria": [],
+      "source_of_truth": [
+        "docs/STABILITY_GUARANTEES.md"
+      ],
+      "features": []
+    }
+  ]
+}

--- a/tools/xtask/src/docs_verify.rs
+++ b/tools/xtask/src/docs_verify.rs
@@ -2,7 +2,14 @@
 use anyhow::{Context, Result, bail};
 use copybook_bench::{COMP3_CI_FLOOR_MIBPS, DISPLAY_FLOOR_MIBPS};
 use regex::Regex;
-use std::{collections::BTreeSet, fs, path::Path};
+use serde::Deserialize;
+use serde_json::Value;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    env, fs,
+    path::Path,
+    process::Command,
+};
 
 use super::{verify, verify_support_matrix};
 use xtask::junit_xml_path;
@@ -11,7 +18,7 @@ use xtask::perf;
 type Verifier = (&'static str, fn() -> Result<()>);
 
 pub(crate) fn run() -> Result<()> {
-    let checks: [Verifier; 10] = [
+    let checks: [Verifier; 11] = [
         (
             "workspace-version-and-msrv",
             verify_workspace_version_and_msrv,
@@ -33,6 +40,7 @@ pub(crate) fn run() -> Result<()> {
             "publish-workflow-inventory",
             verify_publish_workflow_inventory,
         ),
+        ("stability-registry", verify_stability_registry),
         ("quick-start-versioning", verify_quick_start_versioning),
     ];
     run_checks(&checks)
@@ -45,6 +53,374 @@ fn run_checks(checks: &[Verifier]) -> Result<()> {
 
     println!("docs verify-all completed");
     Ok(())
+}
+
+const STABILITY_SCHEMA_VERSION: &str = "1.0.0";
+const STABILITY_REGISTRY_PATH: &str = "docs/stability/surface-registry.json";
+const STABILITY_MANUAL_REVIEW_PLACEHOLDERS: [&str; 2] = ["tbd", "set during manual review"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StabilityClass {
+    Stable,
+    Beta,
+    Experimental,
+    InternalDevOnly,
+}
+
+impl StabilityClass {
+    fn requires_contracts(self) -> bool {
+        matches!(self, Self::Beta | Self::Experimental)
+    }
+}
+
+fn parse_stability_class(value: &str, context: &str) -> Result<StabilityClass> {
+    match value {
+        "stable" => Ok(StabilityClass::Stable),
+        "beta" => Ok(StabilityClass::Beta),
+        "experimental" => Ok(StabilityClass::Experimental),
+        "internal-dev-only" => Ok(StabilityClass::InternalDevOnly),
+        other => bail!("unknown stability class `{other}` in {context}"),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct StabilityRegistry {
+    schema_version: String,
+    packages: Vec<StabilityPackage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StabilityPackage {
+    name: String,
+    publish: bool,
+    class: String,
+    stability_statement: String,
+    limitations: Vec<String>,
+    graduation_criteria: Vec<String>,
+    source_of_truth: Vec<String>,
+    #[serde(default)]
+    features: Vec<StabilityFeature>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StabilityFeature {
+    name: String,
+    class: String,
+    stability_statement: String,
+    limitations: Vec<String>,
+    graduation_criteria: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoMetadata {
+    workspace_members: Vec<String>,
+    packages: Vec<CargoMetadataPackage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoMetadataPackage {
+    id: String,
+    name: String,
+    #[serde(default)]
+    features: BTreeMap<String, Value>,
+    #[serde(default)]
+    publish: Option<Value>,
+}
+
+#[derive(Debug, Clone)]
+struct WorkspacePackageInventory {
+    publish: bool,
+    features: BTreeSet<String>,
+}
+
+fn verify_stability_registry() -> Result<()> {
+    let registry = load_stability_registry()?;
+    let metadata = load_cargo_metadata()?;
+    verify_stability_registry_against_metadata(&registry, &metadata)
+}
+
+fn load_stability_registry() -> Result<StabilityRegistry> {
+    let registry_path = resolve_workspace_file(STABILITY_REGISTRY_PATH)
+        .ok_or_else(|| anyhow::anyhow!("loading docs/stability/surface-registry.json"))?;
+    let source = fs::read_to_string(&registry_path)
+        .with_context(|| format!("loading {}", registry_path.display()))?;
+    let registry: StabilityRegistry =
+        serde_json::from_str(&source).context("parsing docs/stability/surface-registry.json")?;
+    Ok(registry)
+}
+
+fn load_cargo_metadata() -> Result<CargoMetadata> {
+    let output = Command::new("cargo")
+        .args(["metadata", "--format-version", "1", "--no-deps", "--locked"])
+        .output()
+        .context("failed to execute cargo metadata")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("cargo metadata failed:\n{stderr}");
+    }
+    let metadata_text =
+        String::from_utf8(output.stdout).context("cargo metadata output not valid UTF-8")?;
+    let metadata: CargoMetadata =
+        serde_json::from_str(&metadata_text).context("failed to parse cargo metadata output")?;
+    Ok(metadata)
+}
+
+fn verify_stability_registry_against_metadata(
+    registry: &StabilityRegistry,
+    metadata: &CargoMetadata,
+) -> Result<()> {
+    if registry.schema_version != STABILITY_SCHEMA_VERSION {
+        bail!(
+            "stability schema version mismatch: expected {STABILITY_SCHEMA_VERSION}, found {}",
+            registry.schema_version
+        );
+    }
+
+    let workspace = collect_workspace_packages(metadata);
+    if workspace.is_empty() {
+        bail!("no workspace packages found for stability registry validation");
+    }
+
+    let registry_by_name = index_registry_packages(registry)?;
+    ensure_package_coverage(&workspace, &registry_by_name)?;
+
+    for (package_name, package_inventory) in workspace {
+        let entry = registry_by_name.get(&package_name).context(format!(
+            "missing stability entry for package {package_name}"
+        ))?;
+        verify_stability_package_entry(entry, package_name.as_str(), &package_inventory)?;
+    }
+
+    Ok(())
+}
+
+fn index_registry_packages(
+    registry: &StabilityRegistry,
+) -> Result<BTreeMap<String, &StabilityPackage>> {
+    let mut registry_by_name = BTreeMap::new();
+
+    for package in &registry.packages {
+        if registry_by_name
+            .insert(package.name.clone(), package)
+            .is_some()
+        {
+            bail!(
+                "stability registry duplicate package entry: {}",
+                package.name
+            );
+        }
+    }
+
+    Ok(registry_by_name)
+}
+
+fn ensure_package_coverage(
+    workspace: &BTreeMap<String, WorkspacePackageInventory>,
+    registry_by_name: &BTreeMap<String, &StabilityPackage>,
+) -> Result<()> {
+    let workspace_names: BTreeSet<String> = workspace.keys().cloned().collect();
+    let registry_names: BTreeSet<String> = registry_by_name.keys().cloned().collect();
+    let missing_from_registry = workspace_names
+        .difference(&registry_names)
+        .collect::<Vec<_>>();
+    let extra_in_registry = registry_names
+        .difference(&workspace_names)
+        .collect::<Vec<_>>();
+
+    if !missing_from_registry.is_empty() {
+        bail!("stability registry missing packages: {missing_from_registry:?}");
+    }
+    if !extra_in_registry.is_empty() {
+        bail!("stability registry has unknown packages: {extra_in_registry:?}");
+    }
+
+    Ok(())
+}
+
+fn verify_stability_package_entry(
+    entry: &StabilityPackage,
+    package_name: &str,
+    package_inventory: &WorkspacePackageInventory,
+) -> Result<()> {
+    let context = format!("package `{package_name}`");
+
+    if entry.publish != package_inventory.publish {
+        bail!(
+            "stability registry publish mismatch for `{package_name}`: registry={}, metadata={}",
+            entry.publish,
+            package_inventory.publish
+        );
+    }
+
+    let class = parse_stability_class(&entry.class, &context)?;
+    validate_stability_entry(
+        &context,
+        class,
+        &entry.stability_statement,
+        &entry.limitations,
+        &entry.graduation_criteria,
+    )?;
+
+    if entry.source_of_truth.is_empty() {
+        bail!("{context} missing source_of_truth");
+    }
+    for doc in &entry.source_of_truth {
+        if resolve_source_of_truth_path(doc).is_none() {
+            bail!("{context} references missing source-of-truth path `{doc}`");
+        }
+    }
+
+    let mut feature_names = BTreeSet::new();
+    for feature in &entry.features {
+        if !feature_names.insert(feature.name.clone()) {
+            bail!("{context} has duplicate feature entry: {}", feature.name);
+        }
+        if !package_inventory.features.contains(&feature.name) {
+            bail!(
+                "{context} has stability entry for unknown feature `{}`",
+                feature.name
+            );
+        }
+
+        let feature_context = format!("{context} feature `{}`", feature.name);
+        let feature_class = parse_stability_class(&feature.class, &feature_context)?;
+        validate_stability_entry(
+            &feature_context,
+            feature_class,
+            &feature.stability_statement,
+            &feature.limitations,
+            &feature.graduation_criteria,
+        )?;
+    }
+
+    verify_feature_coverage(&context, &package_inventory.features, &feature_names)?;
+    Ok(())
+}
+
+fn verify_feature_coverage(
+    context: &str,
+    package_features: &BTreeSet<String>,
+    registry_features: &BTreeSet<String>,
+) -> Result<()> {
+    let missing_features = package_features
+        .difference(registry_features)
+        .collect::<Vec<_>>();
+    if !missing_features.is_empty() {
+        bail!("{context} missing feature-level registry rows for {missing_features:?}");
+    }
+
+    Ok(())
+}
+
+fn resolve_workspace_file(doc: &str) -> Option<std::path::PathBuf> {
+    let relative = Path::new(doc);
+    if relative.exists() {
+        return Some(relative.to_path_buf());
+    }
+
+    let mut current = env::current_dir().ok()?;
+    while let Some(parent) = current.parent() {
+        if current.join(relative).exists() {
+            return Some(current.join(relative));
+        }
+        current = parent.to_path_buf();
+    }
+
+    None
+}
+
+fn resolve_source_of_truth_path(doc: &str) -> Option<std::path::PathBuf> {
+    resolve_workspace_file(doc)
+}
+
+fn collect_workspace_packages(
+    metadata: &CargoMetadata,
+) -> BTreeMap<String, WorkspacePackageInventory> {
+    let members: BTreeSet<&str> = metadata
+        .workspace_members
+        .iter()
+        .map(String::as_str)
+        .collect();
+    let mut packages = BTreeMap::new();
+
+    for package in metadata
+        .packages
+        .iter()
+        .filter(|pkg| members.contains(package_id_as_str(pkg)))
+    {
+        let mut features = BTreeSet::new();
+        for feature_name in package.features.keys() {
+            if feature_name != "default" {
+                features.insert(feature_name.clone());
+            }
+        }
+
+        packages.insert(
+            package.name.clone(),
+            WorkspacePackageInventory {
+                publish: is_publishable_package(package.publish.as_ref()),
+                features,
+            },
+        );
+    }
+
+    packages
+}
+
+fn package_id_as_str(package: &CargoMetadataPackage) -> &str {
+    package.id.as_str()
+}
+
+fn is_publishable_package(publish: Option<&Value>) -> bool {
+    match publish {
+        Some(Value::Bool(false)) => false,
+        Some(Value::Array(values)) => !values.is_empty(),
+        Some(_) | None => true,
+    }
+}
+
+fn validate_stability_entry(
+    context: &str,
+    class: StabilityClass,
+    statement: &str,
+    limitations: &[String],
+    graduation: &[String],
+) -> Result<()> {
+    let normalized_statement = statement.trim();
+    if normalized_statement.is_empty() || is_placeholder_text(normalized_statement) {
+        bail!("{context} has missing stability_statement");
+    }
+
+    if class.requires_contracts() {
+        if limitations.is_empty() {
+            bail!("{context} needs explicit stability limitations (beta/experimental)");
+        }
+        if graduation.is_empty() {
+            bail!("{context} needs explicit graduation criteria (beta/experimental)");
+        }
+    }
+
+    for limit in limitations {
+        let value = limit.trim();
+        if value.is_empty() || is_placeholder_text(value) {
+            bail!("{context} has invalid stability limitation placeholder");
+        }
+    }
+    for criterion in graduation {
+        let value = criterion.trim();
+        if value.is_empty() || is_placeholder_text(value) {
+            bail!("{context} has invalid graduation criteria placeholder");
+        }
+    }
+
+    Ok(())
+}
+
+fn is_placeholder_text(value: &str) -> bool {
+    let normalized = value.trim().to_ascii_lowercase();
+    STABILITY_MANUAL_REVIEW_PLACEHOLDERS
+        .iter()
+        .any(|placeholder| normalized == *placeholder)
 }
 
 fn verify_workspace_version_and_msrv() -> Result<()> {
@@ -546,6 +922,7 @@ fn snake_case(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::sync::{Mutex, OnceLock};
 
     use super::*;
@@ -640,5 +1017,334 @@ mod tests {
         let source = "enum Commands {\n    Parse {\n    }\n    Decode {\n    }\n}\n";
         let commands = parse_cli_command_variants(source).unwrap();
         assert_eq!(commands, vec!["parse", "decode"]);
+    }
+
+    fn metadata_package(
+        name: &str,
+        id: &str,
+        publish: Option<Value>,
+        features: &[&str],
+    ) -> CargoMetadataPackage {
+        let mut feature_map = BTreeMap::new();
+        for feature in features {
+            feature_map.insert((*feature).to_string(), Value::Array(vec![]));
+        }
+
+        CargoMetadataPackage {
+            id: id.to_string(),
+            name: name.to_string(),
+            publish,
+            features: feature_map,
+        }
+    }
+
+    fn package_entry(
+        name: &str,
+        class: &str,
+        publish: bool,
+        features: Vec<StabilityFeature>,
+    ) -> StabilityPackage {
+        StabilityPackage {
+            name: name.to_string(),
+            publish,
+            class: class.to_string(),
+            stability_statement: format!("{name} surface class {class}"),
+            limitations: if class == "beta" || class == "experimental" {
+                vec!["Documented stability limitations".to_string()]
+            } else {
+                Vec::new()
+            },
+            graduation_criteria: if class == "beta" || class == "experimental" {
+                vec!["Graduation criteria are satisfied in planning".to_string()]
+            } else {
+                Vec::new()
+            },
+            source_of_truth: vec!["docs/STABILITY_GUARANTEES.md".to_string()],
+            features,
+        }
+    }
+
+    fn feature_entry(name: &str, class: &str) -> StabilityFeature {
+        StabilityFeature {
+            name: name.to_string(),
+            class: class.to_string(),
+            stability_statement: format!("{name} feature class {class}"),
+            limitations: if class == "beta" || class == "experimental" {
+                vec!["Documented feature limitations".to_string()]
+            } else {
+                Vec::new()
+            },
+            graduation_criteria: if class == "beta" || class == "experimental" {
+                vec!["Feature graduation criteria".to_string()]
+            } else {
+                Vec::new()
+            },
+        }
+    }
+
+    #[test]
+    fn verify_stability_registry_catches_unknown_package() {
+        let metadata = CargoMetadata {
+            workspace_members: vec!["id-core".to_string()],
+            packages: vec![metadata_package("copybook-core", "id-core", None, &[])],
+        };
+
+        let registry = StabilityRegistry {
+            schema_version: STABILITY_SCHEMA_VERSION.to_string(),
+            packages: vec![package_entry("copybook", "stable", true, vec![])],
+        };
+
+        assert!(verify_stability_registry_against_metadata(&registry, &metadata).is_err());
+    }
+
+    #[test]
+    fn verify_stability_registry_catches_unknown_feature() {
+        let metadata = CargoMetadata {
+            workspace_members: vec!["id-core".to_string(), "id-charset".to_string()],
+            packages: vec![
+                metadata_package("copybook-core", "id-core", None, &[]),
+                metadata_package("copybook-charset", "id-charset", None, &["clap"]),
+            ],
+        };
+
+        let registry = StabilityRegistry {
+            schema_version: STABILITY_SCHEMA_VERSION.to_string(),
+            packages: vec![
+                package_entry("copybook-core", "stable", true, vec![]),
+                package_entry(
+                    "copybook-charset",
+                    "stable",
+                    true,
+                    vec![feature_entry("unknown", "internal-dev-only")],
+                ),
+            ],
+        };
+
+        assert!(verify_stability_registry_against_metadata(&registry, &metadata).is_err());
+    }
+
+    #[test]
+    fn verify_stability_registry_catches_publish_mismatch() {
+        let metadata = CargoMetadata {
+            workspace_members: vec!["id-core".to_string()],
+            packages: vec![metadata_package(
+                "copybook-core",
+                "id-core",
+                Some(Value::Bool(false)),
+                &[],
+            )],
+        };
+
+        let registry = StabilityRegistry {
+            schema_version: STABILITY_SCHEMA_VERSION.to_string(),
+            packages: vec![package_entry("copybook-core", "stable", true, vec![])],
+        };
+
+        assert!(verify_stability_registry_against_metadata(&registry, &metadata).is_err());
+    }
+
+    #[test]
+    fn verify_stability_registry_catches_invalid_class() {
+        let metadata = CargoMetadata {
+            workspace_members: vec!["id-core".to_string()],
+            packages: vec![metadata_package("copybook-core", "id-core", None, &[])],
+        };
+
+        let mut entry = package_entry("copybook-core", "stable", true, vec![]);
+        entry.class = "deprecated".to_string();
+        let registry = StabilityRegistry {
+            schema_version: STABILITY_SCHEMA_VERSION.to_string(),
+            packages: vec![entry],
+        };
+
+        assert!(verify_stability_registry_against_metadata(&registry, &metadata).is_err());
+    }
+
+    #[test]
+    fn verify_stability_registry_catches_beta_without_contracts() {
+        let metadata = CargoMetadata {
+            workspace_members: vec!["id-core".to_string()],
+            packages: vec![metadata_package("copybook-core", "id-core", None, &[])],
+        };
+
+        let mut entry = package_entry("copybook-core", "beta", true, vec![]);
+        entry.limitations.clear();
+        entry.graduation_criteria.clear();
+        let registry = StabilityRegistry {
+            schema_version: STABILITY_SCHEMA_VERSION.to_string(),
+            packages: vec![entry],
+        };
+
+        assert!(verify_stability_registry_against_metadata(&registry, &metadata).is_err());
+    }
+
+    #[test]
+    fn verify_stability_registry_catches_duplicate_package_entries() {
+        let metadata = CargoMetadata {
+            workspace_members: vec!["id-core".to_string()],
+            packages: vec![metadata_package("copybook-core", "id-core", None, &[])],
+        };
+
+        let registry = StabilityRegistry {
+            schema_version: STABILITY_SCHEMA_VERSION.to_string(),
+            packages: vec![
+                package_entry("copybook-core", "stable", true, vec![]),
+                package_entry("copybook-core", "stable", true, vec![]),
+            ],
+        };
+
+        assert!(verify_stability_registry_against_metadata(&registry, &metadata).is_err());
+    }
+
+    #[test]
+    fn verify_stability_registry_catches_duplicate_feature_entries() {
+        let metadata = CargoMetadata {
+            workspace_members: vec!["id-core".to_string()],
+            packages: vec![metadata_package(
+                "copybook-core",
+                "id-core",
+                None,
+                &["audit", "comprehensive-tests"],
+            )],
+        };
+
+        let registry = StabilityRegistry {
+            schema_version: STABILITY_SCHEMA_VERSION.to_string(),
+            packages: vec![package_entry(
+                "copybook-core",
+                "stable",
+                true,
+                vec![
+                    feature_entry("audit", "experimental"),
+                    feature_entry("audit", "internal-dev-only"),
+                ],
+            )],
+        };
+
+        assert!(verify_stability_registry_against_metadata(&registry, &metadata).is_err());
+    }
+
+    #[test]
+    fn verify_stability_registry_catches_missing_source_of_truth() {
+        let metadata = CargoMetadata {
+            workspace_members: vec!["id-core".to_string()],
+            packages: vec![metadata_package("copybook-core", "id-core", None, &[])],
+        };
+
+        let mut entry = package_entry("copybook-core", "stable", true, vec![]);
+        entry.source_of_truth.clear();
+
+        let registry = StabilityRegistry {
+            schema_version: STABILITY_SCHEMA_VERSION.to_string(),
+            packages: vec![entry],
+        };
+
+        assert!(verify_stability_registry_against_metadata(&registry, &metadata).is_err());
+    }
+
+    #[test]
+    fn verify_stability_registry_catches_nonexistent_source_of_truth_path() {
+        let metadata = CargoMetadata {
+            workspace_members: vec!["id-core".to_string()],
+            packages: vec![metadata_package("copybook-core", "id-core", None, &[])],
+        };
+
+        let mut entry = package_entry("copybook-core", "stable", true, vec![]);
+        entry.source_of_truth = vec!["docs/does_not_exist.md".to_string()];
+
+        let registry = StabilityRegistry {
+            schema_version: STABILITY_SCHEMA_VERSION.to_string(),
+            packages: vec![entry],
+        };
+
+        assert!(verify_stability_registry_against_metadata(&registry, &metadata).is_err());
+    }
+
+    #[test]
+    fn verify_stability_registry_catches_schema_version_mismatch() {
+        let metadata = CargoMetadata {
+            workspace_members: vec!["id-core".to_string()],
+            packages: vec![metadata_package("copybook-core", "id-core", None, &[])],
+        };
+
+        let registry = StabilityRegistry {
+            schema_version: "2.0.0".to_string(),
+            packages: vec![package_entry("copybook-core", "stable", true, vec![])],
+        };
+
+        assert!(verify_stability_registry_against_metadata(&registry, &metadata).is_err());
+    }
+
+    #[test]
+    fn verify_stability_registry_matches_current_workspace() {
+        let registry = load_stability_registry().expect("failed to load surface registry");
+        let metadata = load_cargo_metadata().expect("failed to load cargo metadata");
+
+        assert!(verify_stability_registry_against_metadata(&registry, &metadata).is_ok());
+    }
+
+    #[test]
+    fn verify_stability_registry_rejects_placeholder_text() {
+        let metadata = CargoMetadata {
+            workspace_members: vec!["id-core".to_string()],
+            packages: vec![metadata_package("copybook-core", "id-core", None, &[])],
+        };
+
+        let mut entry = package_entry("copybook-core", "stable", true, vec![]);
+        entry.stability_statement = "TBD".to_string();
+
+        let registry = StabilityRegistry {
+            schema_version: STABILITY_SCHEMA_VERSION.to_string(),
+            packages: vec![entry],
+        };
+
+        assert!(verify_stability_registry_against_metadata(&registry, &metadata).is_err());
+    }
+
+    #[test]
+    fn verify_stability_registry_accepts_valid_minimal_inventory() {
+        let metadata = CargoMetadata {
+            workspace_members: vec!["id-core".to_string(), "id-charset".to_string()],
+            packages: vec![
+                metadata_package(
+                    "copybook-core",
+                    "id-core",
+                    None,
+                    &["audit", "comprehensive-tests"],
+                ),
+                metadata_package(
+                    "copybook-charset",
+                    "id-charset",
+                    None,
+                    &["clap", "comprehensive-tests"],
+                ),
+            ],
+        };
+
+        let registry = StabilityRegistry {
+            schema_version: STABILITY_SCHEMA_VERSION.to_string(),
+            packages: vec![
+                package_entry(
+                    "copybook-core",
+                    "stable",
+                    true,
+                    vec![
+                        feature_entry("audit", "experimental"),
+                        feature_entry("comprehensive-tests", "internal-dev-only"),
+                    ],
+                ),
+                package_entry(
+                    "copybook-charset",
+                    "stable",
+                    true,
+                    vec![
+                        feature_entry("clap", "beta"),
+                        feature_entry("comprehensive-tests", "internal-dev-only"),
+                    ],
+                ),
+            ],
+        };
+
+        assert!(verify_stability_registry_against_metadata(&registry, &metadata).is_ok());
     }
 }


### PR DESCRIPTION
## Summary
- Add docs/stability/surface-registry.json as the canonical machine-readable stability registry for all publishable workspace crates.
- Extend xtask docs verification with a new stability-registry check.
- Validate package/class/feature coverage against cargo metadata, placeholder text, required contracts for beta/experimental, publish flags, and source-of-truth references.
- Classify copybook-rs as redirect/search-only (internal-dev-only) while keeping copybook as canonical stable facade.
- Add targeted unit tests for new verifier behavior and integration check against current workspace.
- Update docs/STABILITY_GUARANTEES.md with the registry contract.

## Validation
- tk cargo test -p xtask
- tk cargo run -p xtask -- docs support-matrix? (support-matrix check remains green)
- tk cargo run -p xtask -- docs sync-tests && rtk cargo run -p xtask -- docs verify-all

Closes #541

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the stability policy with a structured registry covering APIs, outputs, data fidelity, and change expectations.
  * Added stability classifications, versioning guidance, limitations, and graduation criteria.
  * Documented the registry location and verification process.

* **Validation**
  * Added automated checks to ensure the stability registry matches available packages and features.
  * Added validation for required statements, source documents, classifications, and supporting criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->