### PR TITLE
docs(api): align API baseline scope to stable registry

### DIFF
--- a/docs/API_FREEZE.md
+++ b/docs/API_FREEZE.md
@@ -17,10 +17,21 @@ API freeze is a development phase where:
 
 ## Public API Scope
 
-The following crates have frozen public APIs:
-- **copybook-core**: Core parsing and schema types
-- **copybook-codec**: Encoding and decoding codecs
-- **copybook-cli**: Command-line interface (binary crate)
+The frozen public API scope is the stable surface in:
+
+- `docs/stability/surface-registry.json`
+
+Current stable packages in that registry are:
+- **copybook**
+- **copybook-charset**
+- **copybook-cli**
+- **copybook-cli-determinism**
+- **copybook-codec**
+- **copybook-codepage**
+- **copybook-contracts**
+- **copybook-core**
+- **copybook-error**
+- **copybook-error-reporter**
 
 The public API includes:
 - All `pub` functions and methods
@@ -123,14 +134,17 @@ bash scripts/api-baseline.sh freeze-status
 
 ```bash
 # Install cargo-semver-checks
-cargo install --locked cargo-semver-checks --version 0.37.0
+cargo install --locked cargo-semver-checks --version 0.46.0
 
 # Check API compatibility
+# Optional raw invocation equivalent for this lane:
+# Exclude workspace packages that are not classified `stable`.
+# The repository script computes this exclusion list from
+# `docs/stability/surface-registry.json` automatically.
 cargo semver-checks check-release \
   --workspace \
-  --baseline-root=origin/main \
-  --current-root=. \
-  --error-on-missing
+  --baseline-rev=<COMMIT_SHA>
+# (add --exclude <crate-name> for each non-stable package)
 ```
 
 ## How to Update Baseline

--- a/scripts/api-baseline.sh
+++ b/scripts/api-baseline.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # API Baseline Management Script
-# This script manages API baselines for semver checking
+# This script manages API baselines for semver checking.
 
 set -euo pipefail
 
@@ -20,120 +20,372 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 BASELINE_DIR="$PROJECT_ROOT/.api-baseline"
 mkdir -p "$BASELINE_DIR"
 
-# Current version from Cargo.toml
-CURRENT_VERSION=$(grep -E '^version\s*=' "$PROJECT_ROOT/Cargo.toml" | head -1 | sed 's/version\s*=\s*"\([^"]*\)"/\1/')
+BASELINE_VERSION_FILE="$BASELINE_DIR/version.txt"
+BASELINE_TIMESTAMP_FILE="$BASELINE_DIR/timestamp.txt"
+BASELINE_REVISION_FILE="$BASELINE_DIR/revision.txt"
+BASELINE_TOOL_VERSION_FILE="$BASELINE_DIR/tool-version.txt"
+BASELINE_STABILITY_SCOPE_FILE="$BASELINE_DIR/stability-scope.txt"
+BASELINE_PACKAGES_FILE="$BASELINE_DIR/stable-packages.txt"
 
-# Function to print colored output
+REQUIRED_SEMVER_CHECKS_VERSION="0.46.0"
+STABILITY_REGISTRY_PATH="$PROJECT_ROOT/docs/stability/surface-registry.json"
+CARGO_SEMVER_CHECKS=""
+CARGO_SEMVER_CHECKS_MODE="detect"
+PYTHON_CMD=""
+
+# Current version from Cargo.toml
+CURRENT_VERSION="$(awk -F\" '/^version = /{print $2; exit}' "$PROJECT_ROOT/Cargo.toml")"
+
 print_info() {
-    echo -e "${BLUE}ℹ${NC} $1"
+    echo -e "${BLUE}INFO:${NC} $1"
 }
 
 print_success() {
-    echo -e "${GREEN}✓${NC} $1"
+    echo -e "${GREEN}OK:${NC} $1"
 }
 
 print_warning() {
-    echo -e "${YELLOW}⚠${NC} $1"
+    echo -e "${YELLOW}WARN:${NC} $1"
 }
 
 print_error() {
-    echo -e "${RED}✗${NC} $1"
+    echo -e "${RED}ERR:${NC} $1"
 }
 
-# Function to check if cargo-semver-checks is installed
-check_semver_checks() {
-    if ! command -v cargo-semver-checks &> /dev/null; then
-        print_error "cargo-semver-checks is not installed"
-        print_info "Install it with: cargo install --locked cargo-semver-checks --version 0.37.0"
+require_cargo_semver_checks() {
+    if command -v python3 &> /dev/null; then
+        PYTHON_CMD="python3"
+    elif command -v python &> /dev/null; then
+        PYTHON_CMD="python"
+    else
+        print_error "python (or python3) is not installed."
+        exit 1
+    fi
+
+    if command -v cargo-semver-checks &> /dev/null; then
+        CARGO_SEMVER_CHECKS="$(command -v cargo-semver-checks)"
+    elif [[ -x "$HOME/.cargo/bin/cargo-semver-checks" ]]; then
+        CARGO_SEMVER_CHECKS="$HOME/.cargo/bin/cargo-semver-checks"
+    elif [[ -x "$HOME/.cargo/bin/cargo-semver-checks.exe" ]]; then
+        CARGO_SEMVER_CHECKS="$HOME/.cargo/bin/cargo-semver-checks.exe"
+    else
+        print_error "cargo-semver-checks is not installed."
+        print_info "Install with: cargo install --locked cargo-semver-checks --version ${REQUIRED_SEMVER_CHECKS_VERSION}"
+        exit 1
+    fi
+
+    if "$CARGO_SEMVER_CHECKS" check-release --help >/dev/null 2>&1; then
+        CARGO_SEMVER_CHECKS_MODE="standalone"
+    elif cargo semver-checks check-release --help >/dev/null 2>&1; then
+        CARGO_SEMVER_CHECKS="cargo"
+        CARGO_SEMVER_CHECKS_MODE="cargo-subcommand"
+    else
+        print_error "Unable to invoke cargo-semver-checks."
+        print_info "Expected either:"
+        print_info "  - cargo-semver-checks check-release (standalone mode)"
+        print_info "  - cargo semver-checks check-release (cargo subcommand mode)"
+        exit 1
+    fi
+
+    local installed_version
+    if [[ "$CARGO_SEMVER_CHECKS_MODE" == "standalone" ]]; then
+        installed_version="$("$CARGO_SEMVER_CHECKS" --version | awk '{print $2}')"
+    else
+        installed_version="$(cargo semver-checks --version | awk '{print $2}')"
+    fi
+
+    local required_floor
+    required_floor="${REQUIRED_SEMVER_CHECKS_VERSION}"
+
+    if [[ "$(printf '%s\n%s\n' "$required_floor" "$installed_version" | sort -V | head -n1)" != "$required_floor" ]]; then
+        print_error "cargo-semver-checks version ${installed_version} is older than required ${REQUIRED_SEMVER_CHECKS_VERSION}."
+        print_info "Upgrade with: cargo install --locked cargo-semver-checks --version ${REQUIRED_SEMVER_CHECKS_VERSION}"
         exit 1
     fi
 }
 
-# Function to generate API baseline for current version
-generate_baseline() {
-    print_info "Generating API baseline for version $CURRENT_VERSION..."
+load_stable_packages() {
+    if [[ ! -f "$STABILITY_REGISTRY_PATH" ]]; then
+        print_error "Missing stability registry: $STABILITY_REGISTRY_PATH"
+        exit 1
+    fi
 
-    cd "$PROJECT_ROOT"
+    "$PYTHON_CMD" - "$STABILITY_REGISTRY_PATH" <<'PY'
+import json
+import sys
 
-    # Build metadata for all workspace crates
-    cargo semver-checks build-metadata --workspace
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    data = json.load(handle)
 
-    # Store the version info
-    echo "$CURRENT_VERSION" > "$BASELINE_DIR/version.txt"
-    echo "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" > "$BASELINE_DIR/timestamp.txt"
-
-    print_success "API baseline generated for version $CURRENT_VERSION"
-    print_info "Baseline stored in: $BASELINE_DIR"
+for package in data.get("packages", []):
+    if package.get("class") == "stable":
+        print(package.get("name", ""))
+PY
 }
 
-# Function to check API compatibility against baseline
-check_api() {
-    print_info "Checking API compatibility against baseline..."
+load_workspace_packages() {
+    local output
 
-    if [ ! -f "$BASELINE_DIR/version.txt" ]; then
+    if ! output="$(
+        "$PYTHON_CMD" - <<'PY' 2>&1
+import subprocess
+import json
+
+data = json.loads(
+    subprocess.check_output(
+        ["cargo", "metadata", "--format-version", "1", "--no-deps", "--locked"],
+        text=True,
+    )
+)
+workspace_members = set(data.get("workspace_members", []))
+
+for package in data.get("packages", []):
+    if package.get("id") in workspace_members:
+        print(package.get("name", ""))
+PY
+    )"; then
+        print_error "Failed to read workspace packages via cargo metadata."
+        print_warning "Captured diagnostics:"
+        echo "$output"
+        print_info "This often means the active Cargo toolchain is too old for the workspace manifest."
+        print_info "Verify toolchain with: cargo --version"
+        exit 1
+    fi
+
+    printf '%s\n' "$output"
+}
+
+validate_stable_workspace_alignment() {
+    local stable_packages="$1"
+    local workspace_packages="$2"
+
+    local missing_from_workspace
+    local extra_in_workspace
+
+    missing_from_workspace="$(comm -23 \
+        <(printf '%s\n' "$stable_packages" | sort) \
+        <(printf '%s\n' "$workspace_packages" | sort) || true)"
+    extra_in_workspace="$(comm -23 \
+        <(printf '%s\n' "$workspace_packages" | sort) \
+        <(printf '%s\n' "$stable_packages" | sort) || true)"
+
+    if [[ -n "$missing_from_workspace" ]]; then
+        print_error "Stability registry references packages missing from workspace: $(echo "$missing_from_workspace" | tr '\n' ' ')"
+        exit 1
+    fi
+
+    if [[ -n "$extra_in_workspace" ]]; then
+        print_warning "Workspace packages not classified as stable (expected): $(echo "$extra_in_workspace" | tr '\n' ' ')"
+    fi
+}
+
+build_exclude_args() {
+    local workspace_packages="$1"
+    local stable_packages="$2"
+    local -a workspace
+    local -a stable
+    local -a excludes
+    local package
+    local stable_package
+
+    mapfile -t workspace <<< "$workspace_packages"
+    mapfile -t stable <<< "$stable_packages"
+
+    for package in "${workspace[@]}"; do
+        local is_stable="false"
+        for stable_package in "${stable[@]}"; do
+            if [[ "$package" == "$stable_package" ]]; then
+                is_stable="true"
+                break
+            fi
+        done
+        if [[ "$is_stable" == "false" ]]; then
+            excludes+=("$package")
+        fi
+    done
+
+    if (( ${#excludes[@]} > 0 )); then
+        printf '%s\n' "${excludes[@]}"
+    fi
+}
+
+run_stable_semver_check() {
+    local baseline_revision="$1"
+    local exclude_args="$2"
+    local -a semver_args
+
+    if [[ "$CARGO_SEMVER_CHECKS_MODE" == "standalone" ]]; then
+        semver_args=(
+            "check-release"
+            "--workspace"
+            "--baseline-rev=${baseline_revision}"
+        )
+    else
+        semver_args=(
+            "semver-checks"
+            "check-release"
+            "--workspace"
+            "--baseline-rev=${baseline_revision}"
+        )
+    fi
+
+    if [[ -n "$exclude_args" ]]; then
+        while IFS= read -r package_name; do
+            semver_args+=("--exclude")
+            semver_args+=("$package_name")
+        done <<< "$exclude_args"
+    fi
+
+    if [[ "$CARGO_SEMVER_CHECKS_MODE" == "standalone" ]]; then
+        (cd "$PROJECT_ROOT" && "$CARGO_SEMVER_CHECKS" "${semver_args[@]}")
+    else
+        (cd "$PROJECT_ROOT" && "${CARGO_SEMVER_CHECKS}" "${semver_args[@]}")
+    fi
+}
+
+record_baseline_state() {
+    local stable_packages="$1"
+    local baseline_revision="$2"
+    local semver_version
+    if [[ "$CARGO_SEMVER_CHECKS_MODE" == "standalone" ]]; then
+        semver_version="$("$CARGO_SEMVER_CHECKS" --version | awk '{print $2}')"
+    else
+        semver_version="$(cargo semver-checks --version | awk '{print $2}')"
+    fi
+
+    printf '%s\n' "$CURRENT_VERSION" > "$BASELINE_VERSION_FILE"
+    printf '%s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" > "$BASELINE_TIMESTAMP_FILE"
+    printf '%s\n' "$baseline_revision" > "$BASELINE_REVISION_FILE"
+    printf '%s\n' "$semver_version" > "$BASELINE_TOOL_VERSION_FILE"
+    printf 'stable-crate-only\n' > "$BASELINE_STABILITY_SCOPE_FILE"
+    printf '%s\n' "$stable_packages" > "$BASELINE_PACKAGES_FILE"
+}
+
+generate_baseline() {
+    print_info "Generating stable API baseline for version ${CURRENT_VERSION}."
+
+    local stable_packages
+    local workspace_packages
+    local exclude_args
+    local baseline_revision
+
+    stable_packages="$(load_stable_packages | sort)"
+    workspace_packages="$(load_workspace_packages | sort)"
+
+    validate_stable_workspace_alignment "$stable_packages" "$workspace_packages"
+
+    baseline_revision="$(cd "$PROJECT_ROOT" && git rev-parse HEAD)"
+    exclude_args="$(build_exclude_args "$workspace_packages" "$stable_packages")"
+
+    print_info "Running baseline check once to ensure stable surface is comparable at ${baseline_revision}..."
+    run_stable_semver_check "$baseline_revision" "$exclude_args"
+
+    record_baseline_state "$stable_packages" "$baseline_revision"
+
+    print_success "Stable API baseline generated for version ${CURRENT_VERSION}"
+    print_info "Baseline metadata stored in ${BASELINE_DIR}"
+}
+
+check_api() {
+    print_info "Checking API compatibility against stable-surface baseline."
+
+    if [[ ! -f "$BASELINE_VERSION_FILE" ]] || [[ ! -f "$BASELINE_REVISION_FILE" ]] || [[ ! -f "$BASELINE_PACKAGES_FILE" ]]; then
         print_error "No baseline found. Run 'just api-baseline' first."
         exit 1
     fi
 
-    BASELINE_VERSION=$(cat "$BASELINE_DIR/version.txt")
-    print_info "Baseline version: $BASELINE_VERSION"
-    print_info "Current version: $CURRENT_VERSION"
+    local baseline_version
+    local baseline_timestamp
+    local baseline_revision
+    local stable_packages
+    local workspace_packages
+    local exclude_args
 
-    cd "$PROJECT_ROOT"
+    baseline_version="$(cat "$BASELINE_VERSION_FILE")"
+    baseline_timestamp="$(cat "$BASELINE_TIMESTAMP_FILE")"
+    baseline_revision="$(cat "$BASELINE_REVISION_FILE")"
+    stable_packages="$(load_stable_packages | sort)"
+    workspace_packages="$(load_workspace_packages | sort)"
 
-    # Run semver checks
-    if cargo semver-checks check-release \
-        --workspace \
-        --baseline-root="$BASELINE_DIR" \
-        --current-root=. \
-        --error-on-missing; then
-        print_success "API compatibility check passed"
-        return 0
-    else
-        print_error "API compatibility check failed"
-        return 1
+    validate_stable_workspace_alignment "$stable_packages" "$workspace_packages"
+
+    if ! (cd "$PROJECT_ROOT" && git cat-file -e "${baseline_revision}^{commit}" >/dev/null 2>&1); then
+        print_error "Baseline commit ${baseline_revision} is unavailable."
+        print_info "Re-run 'just api-baseline' after switching to a reachable commit."
+        exit 1
     fi
+
+    print_info "Baseline version: ${baseline_version}"
+    print_info "Baseline revision: ${baseline_revision}"
+    print_info "Baseline timestamp: ${baseline_timestamp}"
+    print_info "Current version: ${CURRENT_VERSION}"
+
+    exclude_args="$(build_exclude_args "$workspace_packages" "$stable_packages")"
+    if run_stable_semver_check "$baseline_revision" "$exclude_args"; then
+        print_success "Stable API compatibility check passed"
+        return 0
+    fi
+
+    print_error "Stable API compatibility check failed"
+    return 1
 }
 
-# Function to show current baseline info
 show_baseline_info() {
     print_info "API Baseline Information"
 
-    if [ ! -f "$BASELINE_DIR/version.txt" ]; then
+    if [[ ! -f "$BASELINE_VERSION_FILE" ]]; then
         print_warning "No baseline found"
         exit 0
     fi
 
-    BASELINE_VERSION=$(cat "$BASELINE_DIR/version.txt")
-    BASELINE_TIMESTAMP=$(cat "$BASELINE_DIR/timestamp.txt" 2>/dev/null || echo "unknown")
+    local baseline_version
+    local baseline_timestamp
+    local baseline_revision
+    local baseline_tool_version
+    local baseline_scope
+    local baseline_packages_file
+
+    baseline_version="$(cat "$BASELINE_VERSION_FILE")"
+    baseline_timestamp="$(cat "$BASELINE_TIMESTAMP_FILE" 2>/dev/null || echo "unknown")"
+    baseline_revision="$(cat "$BASELINE_REVISION_FILE" 2>/dev/null || echo "unknown")"
+    baseline_tool_version="$(cat "$BASELINE_TOOL_VERSION_FILE" 2>/dev/null || echo "unknown")"
+    baseline_scope="$(cat "$BASELINE_STABILITY_SCOPE_FILE" 2>/dev/null || echo "unknown")"
+    baseline_packages_file="$BASELINE_PACKAGES_FILE"
 
     echo ""
-    echo "Baseline Version: $BASELINE_VERSION"
-    echo "Baseline Timestamp: $BASELINE_TIMESTAMP"
-    echo "Current Version: $CURRENT_VERSION"
-    echo "Baseline Directory: $BASELINE_DIR"
+    echo "Baseline Version: ${baseline_version}"
+    echo "Baseline Timestamp: ${baseline_timestamp}"
+    echo "Baseline Revision: ${baseline_revision}"
+    echo "Baseline Tool: cargo-semver-checks ${baseline_tool_version}"
+    echo "Baseline Scope: ${baseline_scope}"
+    echo "Current Version: ${CURRENT_VERSION}"
+    echo "Baseline Directory: ${BASELINE_DIR}"
+
+    if [[ -f "$baseline_packages_file" ]]; then
+        echo "Stable packages:"
+        while IFS= read -r package; do
+            echo "  - ${package}"
+        done < "$baseline_packages_file"
+    fi
 }
 
-# Function to check if API freeze is active
 check_freeze_status() {
     print_info "Checking API freeze status..."
-
-    if [ -f "$PROJECT_ROOT/.api-freeze" ]; then
+    if [[ -f "$PROJECT_ROOT/.api-freeze" ]]; then
         print_warning "API freeze is ACTIVE"
         echo ""
         cat "$PROJECT_ROOT/.api-freeze"
         return 0
-    else
-        print_success "API freeze is NOT active"
-        return 1
     fi
+
+    print_success "API freeze is NOT active"
+    return 1
 }
 
-# Main function
 main() {
     local command="${1:-help}"
 
-    check_semver_checks
+    require_cargo_semver_checks
 
     case "$command" in
         generate|baseline)
@@ -154,16 +406,16 @@ main() {
             echo "Usage: $0 <command>"
             echo ""
             echo "Commands:"
-            echo "  generate, baseline  Generate API baseline for current version"
-            echo "  check               Check API compatibility against baseline"
+            echo "  generate, baseline  Generate stable API baseline for current version"
+            echo "  check               Check API compatibility against stable baseline"
             echo "  info                Show current baseline information"
             echo "  freeze-status       Check if API freeze is active"
             echo "  help                Show this help message"
             echo ""
             echo "Examples:"
-            echo "  $0 generate    # Generate new baseline"
-            echo "  $0 check       # Check API compatibility"
-            echo "  $0 info        # Show baseline info"
+            echo "  $0 generate   # Generate new stable baseline"
+            echo "  $0 check      # Check stable API compatibility"
+            echo "  $0 info       # Show baseline info"
             ;;
         *)
             print_error "Unknown command: $command"


### PR DESCRIPTION
## Summary

- Reworked scripts/api-baseline.sh to baseline and check only stable-surface crates from docs/stability/surface-registry.json.
- Added deterministic stable-surface metadata recording in .api-baseline.
- Added semver-tool mode detection for standalone vs cargo subcommand usage and required-version check.
- Updated docs/API_FREEZE.md to reference the stability registry as the API-freeze source.

## Verification

- bash scripts/api-baseline.sh help
- bash scripts/api-baseline.sh info
- RUSTUP_TOOLCHAIN=1.92.0 bash scripts/api-baseline.sh generate
- RUSTUP_TOOLCHAIN=1.92.0 bash scripts/api-baseline.sh check
- RUSTUP_TOOLCHAIN=1.92.0 just api-baseline
- RUSTUP_TOOLCHAIN=1.92.0 just api-check
