### PR TITLE
docs(api): add surface deprecation audit coverage for #543

### DIFF
--- a/docs/API_FREEZE_AUDIT.md
+++ b/docs/API_FREEZE_AUDIT.md
@@ -33,10 +33,11 @@ Before freeze closure, confirm these items are completed and evidenced in reposi
 rg "#\\[deprecated" copybook-* -g "*.rs"
 ```
 
-- Keep the canonical machine-readable deprecation inventory in:
+- Keep the canonical machine-readable deprecation inventories in:
 
 ```bash
 docs/reports/deprecation-audit.json
+docs/reports/surface-deprecation-audit.json
 ```
 
 - Validate the file is complete and consistent by running:

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -112,7 +112,7 @@ copybook decode <COPYBOOK> <DATA> [OPTIONS]
 **Output Control:**
 - `--emit-filler` - Include FILLER fields in output
 - `--emit-meta` - Add metadata keys (`schema_fingerprint`, `record_index`, `offset`, `length`)
-- `--emit-raw <MODE>` - Capture raw bytes (`__raw_b64`): off, record, field, record+rdw (default: off)
+- `--emit-raw <MODE>` - Capture raw bytes (`raw_b64`): off, record, field, record+rdw (default: off)
 - `--json-number <MODE>` - JSON number format: lossless, native (default: lossless)
 
 **Performance:**
@@ -190,7 +190,7 @@ copybook encode <COPYBOOK> <JSONL> [OPTIONS]
 - `--codepage <CP>` - Character encoding: cp037, cp273, cp500, cp1047, cp1140, ascii (default: cp037)
 
 **Encoding Options:**
-- `--use-raw` - Use raw bytes from `__raw_b64` (or legacy `raw_b64`) when available
+- `--use-raw` - Use raw bytes from `raw_b64` (or legacy `__raw_b64`) when available
 - `--bwz-encode` - Encode zero values as spaces for BLANK WHEN ZERO fields
 - `--coerce-numbers` - Coerce non-string JSON numbers to strings before encoding
 
@@ -645,7 +645,7 @@ Binary field sizes are determined by PIC digits: ≤4→16b, 5–9→32b, 10–1
 - `length` - Record length in bytes
 
 **Raw Bytes (--emit-raw):**
-- `__raw_b64` - Canonical base64-encoded raw record bytes (record/record+rdw modes); a legacy `raw_b64` key is also emitted for backward compatibility
+- `raw_b64` - Canonical base64-encoded raw record bytes (record/record+rdw modes); legacy `__raw_b64` is also emitted for backward compatibility
 - `<FIELD>__raw_b64` - Base64 payload for individual fields (field mode)
 - Enables byte-perfect round trips when re-encoding
 

--- a/docs/reports/surface-deprecation-audit.json
+++ b/docs/reports/surface-deprecation-audit.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "1.0.0",
+  "generated_at": "2026-07-11T00:00:00Z",
+  "generated_by": "docs/contracts-deprecation-audit",
+  "entries": [
+    {
+      "surface": "cli",
+      "state": "none",
+      "path": "docs/CLI_REFERENCE.md",
+      "symbol": "stable-cli-contract",
+      "kind": "cli-contract",
+      "note": "No stable CLI commands, options, defaults, or environment-variable behaviors are currently marked deprecated. Existing legacy compatibility behavior is explicitly documented in the CLI reference and is not planned for removal in the pre-v1 freeze."
+    },
+    {
+      "surface": "schema",
+      "state": "none",
+      "path": "schemas/record-format.json",
+      "symbol": "stable-jsonl-schema",
+      "kind": "schema",
+      "note": "No schema-key removals are currently scheduled before the v1 freeze."
+    },
+    {
+      "surface": "error",
+      "state": "none",
+      "path": "crates/copybook-error/src/lib.rs",
+      "symbol": "stable-error-codes",
+      "kind": "error-codes",
+      "note": "No new stable error-code retirements are planned before v1; migration notes are only required for breaking renames, which are not currently proposed."
+    },
+    {
+      "surface": "config",
+      "state": "none",
+      "path": "docs/FEATURE_FLAGS.md",
+      "symbol": "stable-feature-flags",
+      "kind": "feature-flags",
+      "note": "No config flags are currently deprecated for stable users; staged flag deprecations must be added as explicit entries in this audit before implementation."
+    },
+    {
+      "surface": "output",
+      "state": "deprecated",
+      "path": "crates/copybook-codec/src/lib_api/envelope.rs",
+      "symbol": "__schema_id",
+      "kind": "json-key",
+      "deprecated_since": "0.5.0",
+      "replacement": "schema_fingerprint",
+      "migration_example": "Prefer the stable `schema_fingerprint` JSON key when reading decoded records from CLI or library output.",
+      "planned_removal": "No pre-v1 removal is planned; retained until the v1 migration decision approved by #543.",
+      "compatibility_impact": "Existing JSON consumers that read `__schema_id` must fall back to `schema_fingerprint` for forward compatibility.",
+      "note": "This key is retained for pre-v1 compatibility while the migration toward a single schema identifier key is completed."
+    },
+    {
+      "surface": "output",
+      "state": "deprecated",
+      "path": "crates/copybook-codec/src/lib_api/envelope.rs",
+      "symbol": "__raw_b64",
+      "kind": "json-key",
+      "deprecated_since": "0.5.0",
+      "replacement": "raw_b64",
+      "migration_example": "Use `raw_b64` as the primary raw payload field and accept `__raw_b64` only as compatibility input.",
+      "planned_removal": "No pre-v1 removal is planned; retained until the v1 migration decision approved by #543.",
+      "compatibility_impact": "Legacy consumers relying only on `__raw_b64` must add `raw_b64` handling before v1 migration decisions.",
+      "note": "Dual emission of both keys is intentional for migration; output docs now call `raw_b64` canonical."
+    }
+  ]
+}

--- a/tools/xtask/src/docs_verify.rs
+++ b/tools/xtask/src/docs_verify.rs
@@ -19,7 +19,7 @@ use xtask::perf;
 type Verifier = (&'static str, fn() -> Result<()>);
 
 pub(crate) fn run() -> Result<()> {
-    let checks: [Verifier; 13] = [
+    let checks: [Verifier; 14] = [
         (
             "workspace-version-and-msrv",
             verify_workspace_version_and_msrv,
@@ -47,6 +47,10 @@ pub(crate) fn run() -> Result<()> {
             verify_stable_contract_inventory,
         ),
         ("deprecation-audit", verify_deprecation_audit),
+        (
+            "surface-deprecation-audit",
+            verify_surface_deprecation_audit,
+        ),
         ("quick-start-versioning", verify_quick_start_versioning),
     ];
     run_checks(&checks)
@@ -88,6 +92,9 @@ const STABLE_CONTRACT_SOURCE_PATHS: [&str; 6] = [
     "docs/CLI_REFERENCE.md",
 ];
 const DEPRECATION_AUDIT_PATH: &str = "docs/reports/deprecation-audit.json";
+const SURFACE_DEPRECATION_AUDIT_PATH: &str = "docs/reports/surface-deprecation-audit.json";
+const SURFACE_DEPRECATION_SURFACES: [&str; 5] = ["cli", "schema", "error", "config", "output"];
+const SURFACE_DEPRECATION_STATES: [&str; 2] = ["deprecated", "none"];
 const STABILITY_MANUAL_REVIEW_PLACEHOLDERS: [&str; 2] = ["tbd", "set during manual review"];
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -154,6 +161,29 @@ struct DeprecatedApiItem {
     migration_example: String,
     planned_removal: String,
     compatibility_impact: String,
+    note: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct SurfaceDeprecationAuditReport {
+    schema_version: String,
+    generated_at: String,
+    generated_by: String,
+    entries: Vec<SurfaceDeprecationAuditEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct SurfaceDeprecationAuditEntry {
+    surface: String,
+    state: String,
+    path: String,
+    symbol: String,
+    kind: String,
+    deprecated_since: Option<String>,
+    replacement: Option<String>,
+    migration_example: Option<String>,
+    planned_removal: Option<String>,
+    compatibility_impact: Option<String>,
     note: String,
 }
 
@@ -394,6 +424,153 @@ fn verify_deprecation_audit() -> Result<()> {
         "\u{2713} Deprecation audit inventory coverage verified ({} entries)",
         audit.items.len()
     );
+    Ok(())
+}
+
+fn verify_surface_deprecation_audit() -> Result<()> {
+    let audit = load_surface_deprecation_audit_report()?;
+
+    if audit.entries.is_empty() {
+        bail!("surface deprecation audit is empty");
+    }
+
+    let mut by_surface: BTreeMap<&str, Vec<&SurfaceDeprecationAuditEntry>> = BTreeMap::new();
+    for entry in &audit.entries {
+        validate_surface_deprecation_audit_entry(entry)?;
+
+        by_surface
+            .entry(entry.surface.as_str())
+            .or_default()
+            .push(entry);
+    }
+
+    validate_surface_deprecation_audit_output(&by_surface)?;
+
+    println!(
+        "\u{2713} Surface deprecation audit coverage verified ({} entries)",
+        audit.entries.len()
+    );
+    Ok(())
+}
+
+fn validate_surface_deprecation_audit_entry(entry: &SurfaceDeprecationAuditEntry) -> Result<()> {
+    if !SURFACE_DEPRECATION_SURFACES.contains(&entry.surface.as_str()) {
+        bail!(
+            "surface deprecation audit contains unknown surface `{}` in entry `{}`",
+            entry.surface,
+            entry.symbol
+        );
+    }
+    if !SURFACE_DEPRECATION_STATES.contains(&entry.state.as_str()) {
+        bail!(
+            "surface deprecation audit has invalid state `{}` for `{}`",
+            entry.state,
+            entry.symbol
+        );
+    }
+
+    let resolved_entry_path = resolve_workspace_file(&entry.path).ok_or_else(|| {
+        anyhow::anyhow!(
+            "surface deprecation audit entry `{}` references unresolved path `{}`",
+            entry.symbol,
+            entry.path
+        )
+    })?;
+    if !resolved_entry_path.exists() {
+        bail!(
+            "surface deprecation audit entry `{}` references missing path `{}`",
+            entry.symbol,
+            entry.path
+        );
+    }
+
+    if entry.symbol.trim().is_empty()
+        || entry.kind.trim().is_empty()
+        || entry.note.trim().is_empty()
+    {
+        bail!("surface deprecation audit entry has empty `symbol`, `kind`, or `note`");
+    }
+
+    if entry.state == "deprecated" {
+        validate_surface_deprecated_entry(entry)?;
+    } else if entry.deprecated_since.is_some()
+        || entry.replacement.is_some()
+        || entry.migration_example.is_some()
+        || entry.planned_removal.is_some()
+        || entry.compatibility_impact.is_some()
+    {
+        bail!(
+            "surface deprecation audit entry `{}` has `state: none` but migration fields",
+            entry.symbol
+        );
+    }
+
+    Ok(())
+}
+
+fn validate_surface_deprecated_entry(entry: &SurfaceDeprecationAuditEntry) -> Result<()> {
+    let required = [
+        (&entry.deprecated_since, "deprecated_since"),
+        (&entry.replacement, "replacement"),
+        (&entry.migration_example, "migration_example"),
+        (&entry.planned_removal, "planned_removal"),
+        (&entry.compatibility_impact, "compatibility_impact"),
+    ];
+    for (value, field_name) in required {
+        let Some(value) = value.as_ref().map(|value| value.trim()) else {
+            bail!(
+                "surface deprecation audit deprecated entry `{}` missing required field `{field_name}`",
+                entry.symbol
+            );
+        };
+        if value.is_empty() {
+            bail!(
+                "surface deprecation audit deprecated entry `{}` has empty required field `{field_name}`",
+                entry.symbol
+            );
+        }
+    }
+
+    let known_output_symbols = ["__schema_id", "__raw_b64"];
+    if entry.surface == "output" && !known_output_symbols.contains(&entry.symbol.as_str()) {
+        bail!(
+            "surface deprecation audit has unexpected deprecated output symbol `{}`",
+            entry.symbol
+        );
+    }
+
+    Ok(())
+}
+
+fn validate_surface_deprecation_audit_output(
+    by_surface: &BTreeMap<&str, Vec<&SurfaceDeprecationAuditEntry>>,
+) -> Result<()> {
+    for surface in SURFACE_DEPRECATION_SURFACES {
+        if !by_surface.contains_key(surface) {
+            bail!(
+                "surface deprecation audit missing required surface `{surface}` in {SURFACE_DEPRECATION_AUDIT_PATH}"
+            );
+        }
+    }
+
+    let output_entries: &[&SurfaceDeprecationAuditEntry] = by_surface
+        .get("output")
+        .map_or(&[], |entries| entries.as_slice());
+    let has_schema_id = output_entries
+        .iter()
+        .any(|entry| entry.symbol == "__schema_id" && entry.state == "deprecated");
+    let has_raw_b64 = output_entries
+        .iter()
+        .any(|entry| entry.symbol == "__raw_b64" && entry.state == "deprecated");
+    if !has_schema_id || !has_raw_b64 {
+        bail!(
+            "surface deprecation audit output surface must include deprecated `__schema_id` and `__raw_b64`; found {:?}",
+            output_entries
+                .iter()
+                .map(|entry| &entry.symbol)
+                .collect::<Vec<_>>()
+        );
+    }
     Ok(())
 }
 
@@ -1418,6 +1595,24 @@ fn load_deprecation_audit_report() -> Result<DeprecatedAuditReport> {
     Ok(audit)
 }
 
+fn load_surface_deprecation_audit_report() -> Result<SurfaceDeprecationAuditReport> {
+    let path = resolve_workspace_file(SURFACE_DEPRECATION_AUDIT_PATH)
+        .ok_or_else(|| anyhow::anyhow!("loading docs/reports/surface-deprecation-audit.json"))?;
+    let source = fs::read_to_string(&path)
+        .with_context(|| format!("loading surface deprecation audit {}", path.display()))?;
+
+    let audit: SurfaceDeprecationAuditReport = serde_json::from_str(&source)
+        .context("parsing docs/reports/surface-deprecation-audit.json")?;
+    if audit.schema_version != STABILITY_SCHEMA_VERSION {
+        bail!(
+            "surface deprecation audit schema version mismatch: expected {STABILITY_SCHEMA_VERSION}, found {}",
+            audit.schema_version
+        );
+    }
+
+    Ok(audit)
+}
+
 fn collect_deprecated_api_inventory() -> Result<Vec<DiscoveredDeprecatedItem>> {
     let mut files = Vec::new();
     let crates_dir = workspace_root().join("crates");
@@ -2415,5 +2610,64 @@ mod tests {
             assert!(!item.compatibility_impact.trim().is_empty());
             assert!(!item.note.trim().is_empty());
         }
+    }
+
+    #[test]
+    fn verify_surface_deprecation_audit_required_surfaces_are_present() {
+        let report =
+            load_surface_deprecation_audit_report().expect("load surface deprecation audit report");
+        assert!(
+            !report.entries.is_empty(),
+            "surface deprecation audit report is empty"
+        );
+
+        let mut seen = BTreeSet::new();
+        for entry in report.entries {
+            assert!(
+                SURFACE_DEPRECATION_SURFACES.contains(&entry.surface.as_str()),
+                "unexpected surface `{}` in surface deprecation audit",
+                entry.surface
+            );
+            seen.insert(entry.surface.clone());
+            assert!(
+                SURFACE_DEPRECATION_STATES.contains(&entry.state.as_str()),
+                "unexpected state `{}` for surface `{}`",
+                entry.state,
+                entry.surface
+            );
+        }
+
+        for surface in SURFACE_DEPRECATION_SURFACES {
+            assert!(
+                seen.contains(surface),
+                "missing required surface `{surface}` from surface deprecation audit"
+            );
+        }
+    }
+
+    #[test]
+    fn verify_surface_deprecation_audit_output_keys_are_included() {
+        let report =
+            load_surface_deprecation_audit_report().expect("load surface deprecation audit report");
+        let output_deprecated_keys: BTreeSet<String> = report
+            .entries
+            .into_iter()
+            .filter(|entry| entry.surface == "output" && entry.state == "deprecated")
+            .map(|entry| entry.symbol)
+            .collect();
+
+        assert!(
+            output_deprecated_keys.contains("__schema_id"),
+            "surface deprecation audit missing deprecated output key `__schema_id`"
+        );
+        assert!(
+            output_deprecated_keys.contains("__raw_b64"),
+            "surface deprecation audit missing deprecated output key `__raw_b64`"
+        );
+    }
+
+    #[test]
+    fn verify_surface_deprecation_audit_check_passes() {
+        verify_surface_deprecation_audit().expect("surface deprecation audit check failed");
     }
 }


### PR DESCRIPTION
## Why
Closes the remaining #543 follow-up surface-audit gap (CLI/schema/error/output/config deprecations) after PR #562.

## What changed
- Add erify_surface_deprecation_audit to cargo run -p xtask -- docs verify-all.
- Add machine-readable docs/reports/surface-deprecation-audit.json with required surfaces.
- Load/validate the new surface audit in 	ools/xtask/src/docs_verify.rs with invariants for surface/state/path/key presence.
- Add focused tests for surface audit presence, output key assertions, and end-to-end verifier behavior.
- Update docs/API_FREEZE_AUDIT.md to include both deprecation inventories.
- Align CLI docs (docs/CLI_REFERENCE.md) around canonical raw naming: aw_b64 primary, __raw_b64 legacy.

## Evidence
- tk cargo test -p xtask verify_ -- --test-threads=1 --nocapture (20 passed, 75 filtered out)
- tk cargo fmt -p xtask --check

## Known gap
- cargo run -p xtask -- docs verify-all still fails at test-status check (No junit.xml found...) due pre-existing repo debt unrelated to this change.

## Linkage
- Issue: https://github.com/EffortlessMetrics/copybook-rs/issues/543
- Depends on prior PR: #562