### PR TITLE
test(codec): cover missing CBKR101 and CBKR201 record-format errors

### DIFF
--- a/crates/copybook-codec/src/iterator.rs
+++ b/crates/copybook-codec/src/iterator.rs
@@ -402,7 +402,7 @@ impl<R: Read> RecordIterator<R> {
                     }
                     Err(e) => {
                         return Err(Error::new(
-                            ErrorCode::CBKD301_RECORD_TOO_SHORT,
+                            ErrorCode::CBKR101_FIXED_RECORD_ERROR,
                             format!("Failed to read fixed record: {e}"),
                         ));
                     }
@@ -689,7 +689,7 @@ mod tests {
     use super::*;
     use crate::Codepage;
     use copybook_core::parse_copybook;
-    use std::io::Cursor;
+    use std::io::{self, Cursor, Read};
 
     #[test]
     fn test_record_iterator_basic() {
@@ -1077,5 +1077,42 @@ mod tests {
 
         // Second call should return None (EOF)
         assert!(iterator.next().is_none());
+    }
+
+    #[derive(Default)]
+    struct FailingReader {
+        fail: bool,
+    }
+
+    impl Read for FailingReader {
+        fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+            if self.fail {
+                Ok(0)
+            } else {
+                self.fail = true;
+                Err(io::Error::other("forced read error"))
+            }
+        }
+    }
+
+    #[test]
+    fn test_iterator_fixed_format_read_error_code() {
+        let copybook_text = r"
+            01 RECORD.
+               05 ID PIC 9(3).
+               05 NAME PIC X(5).
+        ";
+
+        let schema = parse_copybook(copybook_text).unwrap();
+
+        let mut schema = schema;
+        schema.lrecl_fixed = Some(8);
+
+        let mut iterator =
+            RecordIterator::new(FailingReader::default(), &schema, &DecodeOptions::default())
+                .unwrap();
+
+        let error = iterator.read_raw_record().unwrap_err();
+        assert_eq!(error.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
     }
 }

--- a/crates/copybook-codec/tests/streaming_file_tests.rs
+++ b/crates/copybook-codec/tests/streaming_file_tests.rs
@@ -9,7 +9,7 @@ use copybook_codec::{
     Codepage, DecodeOptions, EncodeOptions, JsonNumberMode, RawMode, RecordFormat, RunSummary,
     decode_file_to_jsonl, encode_jsonl_to_file, iter_records,
 };
-use copybook_core::{parse_copybook, project_schema};
+use copybook_core::{ErrorCode, parse_copybook, project_schema};
 use std::io::Cursor;
 
 // ---------------------------------------------------------------------------
@@ -715,7 +715,15 @@ fn iter_records_from_file_nonexistent() {
     let schema = parse_copybook(SIMPLE_SCHEMA).unwrap();
     let opts = ascii_decode_opts();
     let result = iter_records_from_file("nonexistent_file_12345.bin", &schema, &opts);
-    assert!(result.is_err(), "Should error on nonexistent file");
+    match result {
+        Ok(iterator) => {
+            let _ = iterator;
+            panic!("Should error on nonexistent file");
+        }
+        Err(err) => {
+            assert_eq!(err.code, ErrorCode::CBKR201_RDW_READ_ERROR);
+        }
+    }
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Why
Complete one missing slice from [#551](https://github.com/EffortlessMetrics/copybook-rs/issues/551): dedicated stable error-code coverage for record-format errors.

## What changed
- Map fixed-format raw-read I/O failures in RecordIterator::read_raw_record to CBKR101_FIXED_RECORD_ERROR (was previously CBKD301_RECORD_TOO_SHORT).
- Add unit coverage in crates/copybook-codec/src/iterator.rs with a dedicated failure reader for fixed-format read errors.
- Add explicit assertion in crates/copybook-codec/tests/streaming_file_tests.rs that iter_records_from_file returns CBKR201_RDW_READ_ERROR for missing input file.

## Evidence
- tk cargo fmt -p copybook-codec
- tk cargo clippy -p copybook-codec --all-targets --all-features --tests -- -D warnings
- tk cargo test -p copybook-codec test_iterator_fixed_format_read_error_code -- --test-threads=1 --nocapture
- tk cargo test -p copybook-codec iter_records_from_file_nonexistent -- --test-threads=1 --nocapture
- tk cargo test -p copybook-codec --lib -- --test-threads=1
- tk cargo test -p copybook-codec --test streaming_file_tests -- --test-threads=1
