### PR TITLE
ci(api): enforce stable surface scope in freeze checks

### DIFF
--- a/.github/workflows/api-freeze.yml
+++ b/.github/workflows/api-freeze.yml
@@ -7,9 +7,9 @@ concurrency:
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [main, develop]
   pull_request:
-    branches: [ main, develop ]
+    branches: [main, develop]
   workflow_dispatch:
 
 env:
@@ -18,117 +18,201 @@ env:
 
 jobs:
   # ============================================================================
-  # API Freeze Check - Detects public API changes during freeze
+  # API Freeze Check - Detects public API and stable-surface contract changes during freeze
   # ============================================================================
   api-freeze:
     name: API Freeze Check
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v7
-      with:
-        fetch-depth: 0
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
-    - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        components: rustfmt
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
 
-    - name: Install cargo-semver-checks
-      run: |
-        cargo install --locked cargo-semver-checks --version 0.46.0
+      - name: Install cargo-semver-checks
+        run: |
+          cargo install --locked cargo-semver-checks --version 0.46.0
 
-    - name: Check if API freeze is active
-      id: freeze-check
-      shell: bash
-      run: |
-        # Check for API freeze indicator file
-        if [ -f ".api-freeze" ]; then
-          echo "freeze_active=true" >> $GITHUB_OUTPUT
-          echo "🔒 API freeze is ACTIVE"
-          cat .api-freeze || echo "No freeze message"
-        else
-          echo "freeze_active=false" >> $GITHUB_OUTPUT
-          echo "✅ API freeze is NOT active"
-        fi
+      - name: Check if API freeze is active
+        id: freeze-check
+        shell: bash
+        run: |
+          if [ -f ".api-freeze" ]; then
+            echo "freeze_active=true" >> "$GITHUB_OUTPUT"
+            echo "API freeze is ACTIVE"
+            cat .api-freeze || echo "No freeze message"
+          else
+            echo "freeze_active=false" >> "$GITHUB_OUTPUT"
+            echo "API freeze is NOT active"
+          fi
 
-    - name: Detect changed paths
-      id: changed-paths
-      shell: bash
-      run: |
-        # Get the base ref for comparison
-        if [ "${{ github.event_name }}" = "pull_request" ]; then
-          BASE_REF="${{ github.base_ref }}"
-        else
-          # For pushes, compare to previous commit
-          BASE_REF="HEAD~1"
-        fi
+      - name: Detect changed paths
+        id: changed-paths
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_REF="origin/${{ github.base_ref }}"
+          else
+            if git rev-parse --verify --quiet HEAD~1 >/dev/null 2>&1; then
+              BASE_REF="HEAD~1"
+            else
+              BASE_REF="$(git rev-list --max-parents=0 HEAD | head -n 1)"
+            fi
+          fi
 
-        echo "Base ref: $BASE_REF"
+          echo "Base ref: $BASE_REF"
+          CHANGED_FILES=$(git diff --name-only "$BASE_REF"...HEAD || true)
 
-        # Detect which paths changed
-        CHANGED_FILES=$(git diff --name-only $BASE_REF...HEAD || echo "")
+          {
+            echo "changed_files<<EOF"
+            echo "$CHANGED_FILES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
-        {
-          echo "changed_files<<EOF"
-          echo "$CHANGED_FILES"
-          echo "EOF"
-        } >> "$GITHUB_OUTPUT"
+          echo "changed_count=$(printf '%s\n' "$CHANGED_FILES" | awk 'NF' | wc -l | tr -d ' ')" >> "$GITHUB_OUTPUT"
 
-        # Check if only docs/bench/tests changed
-        if echo "$CHANGED_FILES" | grep -vE '^(docs/|tools/copybook-bench/|tests/|\.github/|scripts/)' | grep -q .; then
-          echo "api_only_changes=false" >> $GITHUB_OUTPUT
-          echo "📝 Non-docs/bench/tests changes detected"
-        else
-          echo "api_only_changes=true" >> $GITHUB_OUTPUT
-          echo "📚 Only docs/bench/tests changes detected"
-        fi
+      - name: Classify freeze-relevant changes
+        id: freeze-scope
+        shell: bash
+        run: |
+          CHANGED_FILES="${{ steps.changed-paths.outputs.changed_files }}"
+          export CHANGED_FILES
+          CHANGED_FILES="${CHANGED_FILES//$'\r'/}"
+          python - <<'PY'
+          import json
+          import os
+          
+          changed_files = os.environ.get("CHANGED_FILES", "")
+          
+          files = [line.strip() for line in changed_files.splitlines() if line.strip()]
+          
+          stable_packages = []
+          stable_package_file = ".api-baseline/stable-packages.txt"
+          if os.path.exists(stable_package_file):
+              with open(stable_package_file, "r", encoding="utf-8") as handle:
+                  for line in handle:
+                      pkg = line.strip()
+                      if pkg:
+                          stable_packages.append(pkg)
+          else:
+              with open("docs/stability/surface-registry.json", "r", encoding="utf-8") as handle:
+                  registry = json.load(handle)
+              for entry in registry.get("packages", []):
+                  if entry.get("class") == "stable" and entry.get("name"):
+                      stable_packages.append(entry["name"])
+          
+          with open("docs/contracts/stable-surface-contract.json", "r", encoding="utf-8") as handle:
+              manifest = json.load(handle)
+          
+          contract_paths = set(manifest.get("source_paths", []))
+          contract_paths.update(
+              {
+                  "docs/CLI_REFERENCE.md",
+                  "docs/reference/ERROR_CODES.md",
+                  "docs/reference/LIBRARY_API.md",
+                  "docs/reference/COBOL_SUPPORT_MATRIX.md",
+                  "schemas/record-format.json",
+                  "docs/contracts/stable-surface-contract.json",
+                  "scripts/api-baseline.sh",
+                  ".api-baseline/version.txt",
+                  ".api-baseline/revision.txt",
+                  ".api-baseline/stable-packages.txt",
+                  "docs/stability/surface-registry.json",
+                  "Cargo.toml",
+              }
+          )
+          for package in stable_packages:
+              contract_paths.add(f"crates/{package}/")
+              contract_paths.add(f"crates/{package}/src/")
+              contract_paths.add(f"crates/{package}/Cargo.toml")
+          
+          allowed_prefixes = [
+              "docs/",
+              "tests/",
+              ".github/",
+              "scripts/",
+              "tools/",
+              "target/",
+          ]
+          allowed_files = {
+              "README.md",
+              "CHANGELOG.md",
+              "CONTRIBUTING.md",
+              "LICENSE",
+              "AGENTS.md",
+              ".gitignore",
+              "CODEOWNERS",
+          }
+          
+          
+          def is_allowed_non_contract(path: str) -> bool:
+              if path in allowed_files:
+                  return True
+              if any(path.startswith(prefix) for prefix in allowed_prefixes):
+                  return True
+              return False
+          
+          
+          def is_contract_relevant(path: str) -> bool:
+              if path in contract_paths:
+                  return True
+              return any(path.startswith(prefix) for prefix in contract_paths if prefix.endswith("/"))
+          
+          
+          contract_relevant_files = []
+          non_allowed_non_contract = []
+          for path in files:
+              if is_contract_relevant(path):
+                  contract_relevant_files.append(path)
+              elif not is_allowed_non_contract(path):
+                  non_allowed_non_contract.append(path)
+          
+          needs_contract_checks = bool(contract_relevant_files or non_allowed_non_contract)
+          
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
+              out.write(f"needs_contract_checks={'true' if needs_contract_checks else 'false'}\n")
+              out.write(f"has_contract_files={'true' if contract_relevant_files else 'false'}\n")
+              out.write(f"has_non_allowed_non_contract={'true' if non_allowed_non_contract else 'false'}\n")
+              out.write("contract_relevant_files=" + "|".join(contract_relevant_files) + "\n")
+              out.write("non_allowed_non_contract_files=" + "|".join(non_allowed_non_contract) + "\n")
+          PY
+          
+      - name: Generate baseline for current version
+        if: steps.freeze-check.outputs.freeze_active == 'false'
+        run: |
+          bash scripts/api-baseline.sh generate
 
-    - name: Generate baseline for current version
-      if: steps.freeze-check.outputs.freeze_active == 'false'
-      run: |
-        # Generate current API docs for future comparison
-        cargo doc --workspace --no-deps
+      - name: Check stable API + contract surface during freeze
+        if: steps.freeze-check.outputs.freeze_active == 'true' && steps.freeze-scope.outputs.needs_contract_checks == 'true'
+        run: |
+          echo "Running API freeze checks for contract-relevant changes"
+          bash scripts/api-baseline.sh check
+          cargo run -p xtask -- docs freeze contracts
 
-    - name: Check API compatibility
-      if: steps.freeze-check.outputs.freeze_active == 'true'
-      run: |
-        # When API freeze is active, check against baseline
-        # Use the last released version as baseline
-        cargo semver-checks check-release \
-          --workspace \
-          --baseline-rev=origin/main
+      - name: Allow non-contract-only changes during freeze
+        if: steps.freeze-check.outputs.freeze_active == 'true' && steps.freeze-scope.outputs.needs_contract_checks == 'false'
+        run: |
+          echo "API freeze checks skipped: change set is limited to non-contract docs/tests/CI/tooling files"
+          if [[ "${{ steps.changed-paths.outputs.changed_files }}" != "" ]]; then
+            echo "Changed files:"
+            printf '%s\n' "${{ steps.changed-paths.outputs.changed_files }}"
+          fi
 
-    - name: Allow docs/bench/tests only changes during freeze
-      if: steps.freeze-check.outputs.freeze_active == 'true' && steps.changed-paths.outputs.api_only_changes == 'true'
-      run: |
-        echo "✅ Skipping API check - only docs/bench/tests changes detected during freeze"
-
-    - name: Fail on API changes during freeze
-      if: steps.freeze-check.outputs.freeze_active == 'true' && steps.changed-paths.outputs.api_only_changes == 'false'
-      run: |
-        echo "❌ ERROR: API freeze is active but API changes detected!"
-        echo ""
-        echo "During API freeze, only the following changes are allowed:"
-        echo "  - Documentation changes (docs/)"
-        echo "  - Benchmark changes (tools/copybook-bench/)"
-        echo "  - Test changes (tests/)"
-        echo "  - CI/CD changes (.github/, scripts/)"
-        echo ""
-        echo "Changed files:"
-        echo "${{ steps.changed-paths.outputs.changed_files }}"
-        echo ""
-        echo "To make API changes:"
-        echo "  1. Remove the .api-freeze file"
-        echo "  2. Commit and push your changes"
-        echo "  3. After release, re-create .api-freeze for next freeze"
-        exit 1
-
-    - name: Upload API diff
-      if: failure() && steps.freeze-check.outputs.freeze_active == 'true'
-      run: |
-        # Generate detailed API diff for debugging
-        cargo semver-checks check-release \
-          --workspace \
-          --baseline-rev=origin/main \
-          2>&1 || true
+      - name: Upload API diff on freeze failure
+        if: failure() && steps.freeze-check.outputs.freeze_active == 'true'
+        run: |
+          echo "API freeze failed for this change"
+          if [[ -f .api-baseline/version.txt ]]; then
+            bash scripts/api-baseline.sh info || true
+          fi
+          echo ""
+          echo "Contract-relevant files:"
+          echo "${{ steps.freeze-scope.outputs.contract_relevant_files }}"
+          echo ""
+          echo "Non-allowed non-contract files:"
+          echo "${{ steps.freeze-scope.outputs.non_allowed_non_contract_files }}"

--- a/docs/API_FREEZE.md
+++ b/docs/API_FREEZE.md
@@ -41,41 +41,31 @@ The public API includes:
 - All `pub` type aliases
 - All `pub` constants
 
-## Allowed Changes During Freeze
+## Allowed Change Categories During Freeze
 
-### Documentation Changes (docs/)
-- API documentation updates
-- README improvements
-- Example additions
-- Tutorial updates
-- Architecture documentation
+The freeze still allows routine non-contract updates in:
 
-### Benchmark Changes (copybook-bench/)
-- New benchmarks
-- Benchmark infrastructure updates
-- Performance measurement improvements
-- Baseline updates
+- Documentation (`docs/`, selected root docs files)
+- Test-only files (`tests/`)
+- CI/tooling (`.github/`, `scripts/`, `tools/`)
 
-### Test Changes (tests/)
-- New test cases
-- Test infrastructure improvements
-- Bug fixes in tests
-- Test coverage improvements
-
-### CI/CD Changes (.github/, scripts/)
-- Workflow improvements
-- Build script updates
-- Tooling improvements
-- Documentation generation
+Those files are still validated by normal CI, but they do not force API/contract checks when they are the only changed files.
 
 ## Prohibited Changes During Freeze
 
-Any changes that affect the public API are prohibited:
+Changes that affect the stable surface are validated and blocked when incompatible.
+
+- Stable crates listed in `.api-baseline/stable-packages.txt`
+- Stable contract source paths in `docs/contracts/stable-surface-contract.json`
+- Contract reference docs (`docs/CLI_REFERENCE.md`, `docs/reference/ERROR_CODES.md`, `docs/reference/LIBRARY_API.md`, `schemas/record-format.json`)
+- Stability metadata (`docs/stability/surface-registry.json`, `.api-baseline/*`)
+
+Any changes that affect the public API are prohibited without a reviewed exception:
 
 ### Function/Method Changes
 - Adding or removing public functions
 - Changing function signatures (parameters, return types)
-- Changing function visibility (pub → pub(crate))
+- Changing function visibility from `pub` to `pub(crate)`
 
 ### Struct Changes
 - Adding or removing public fields
@@ -123,6 +113,9 @@ bash scripts/api-baseline.sh generate
 # Check API compatibility
 bash scripts/api-baseline.sh check
 
+# Check stable contract invariants (strict freeze contract check)
+cargo run -p xtask -- docs freeze contracts
+
 # Show baseline info
 bash scripts/api-baseline.sh info
 
@@ -136,16 +129,9 @@ bash scripts/api-baseline.sh freeze-status
 # Install cargo-semver-checks
 cargo install --locked cargo-semver-checks --version 0.46.0
 
-# Check API compatibility
-# Optional raw invocation equivalent for this lane:
-# Exclude workspace packages that are not classified `stable`.
-# The repository script computes this exclusion list from
-# `docs/stability/surface-registry.json` automatically.
-cargo semver-checks check-release \
-  --workspace \
-  --baseline-rev=<COMMIT_SHA>
-# (add --exclude <crate-name> for each non-stable package)
-```
+# Check API compatibility via the repository script (stable-surface baseline)
+bash scripts/api-baseline.sh check
+``` 
 
 ## How to Update Baseline
 
@@ -254,41 +240,37 @@ The `.github/workflows/api-freeze.yml` workflow enforces the API freeze:
 1. **Detects freeze status**: Checks for `.api-freeze` file
 2. **Analyzes changes**: Determines which files changed in the PR
 3. **Enforces policy**:
-   - If freeze is active and only docs/bench/tests changed → **PASS**
-   - If freeze is active and API changes detected → **FAIL**
-   - If freeze is not active → **PASS** (generate baseline)
+   - If freeze is active and only non-contract scope changes are detected: **PASS**
+   - If freeze is active and contract-relevant or non-allowed files changed: **FAIL**
+   - If freeze is not active: **PASS** (generate baseline)
 
 ### Example CI Output
 
-**Passing (freeze active, docs only)**:
-```
-🔒 API freeze is ACTIVE
-📚 Only docs/bench/tests changes detected
-✅ Skipping API check - only docs/bench/tests changes detected during freeze
-```
+**Passing (freeze active, non-contract-only changes)**:
+~~~txt
+API freeze is ACTIVE
+Only non-contract files changed
+Skipping API check - no contract-relevant files changed during freeze
+~~~
 
-**Failing (freeze active, API changes)**:
-```
-🔒 API freeze is ACTIVE
-📝 Non-docs/bench/tests changes detected
-❌ ERROR: API freeze is active but API changes detected!
+**Failing (freeze active, contract-sensitive change)**:
+~~~txt
+API freeze is ACTIVE
+Contract-relevant or non-allowed files changed
 
-During API freeze, only the following changes are allowed:
-  - Documentation changes (docs/)
-  - Benchmark changes (copybook-bench/)
-  - Test changes (tests/)
-  - CI/CD changes (.github/, scripts/)
+Allowed auto-pass scope only:
+- Documentation changes (docs/, selected root docs files)
+- Test changes (tests/)
+- CI/tooling files (.github/, scripts/, tools/)
 
 Changed files:
-  copybook-codec/src/lib_api.rs
+  crates/copybook-core/src/lib_api.rs
 
 To make API changes:
   1. Remove the .api-freeze file
-  2. Commit and push your changes
-  3. After release, re-create .api-freeze for next freeze
-```
-
-## Troubleshooting
+  2. Commit and push the change
+  3. Re-establish freeze with updated .api-freeze
+~~~
 
 ### API Check Fails
 
@@ -296,8 +278,8 @@ If `just api-check` fails:
 
 1. **Review the error message** to understand what changed
 2. **Check if the change is intentional**:
-   - If yes → Remove `.api-freeze` and update baseline
-   - If no → Revert the API change
+   - If yes -> Remove `.api-freeze` and update baseline
+   - If no -> Revert the API change
 3. **For breaking changes**: Consider if this is the right time to make them
 
 ### Freeze Status Incorrect

--- a/tools/xtask/src/docs_verify.rs
+++ b/tools/xtask/src/docs_verify.rs
@@ -61,6 +61,93 @@ pub(crate) fn run_contracts_command() -> Result<()> {
         .and_then(|manifest| persist_stable_contract_manifest(&manifest))
 }
 
+pub(crate) fn run_freeze_contract_checks() -> Result<()> {
+    let checks: [Verifier; 3] = [
+        ("error-code-inventory", verify_error_code_inventory),
+        ("cli-inventory", verify_cli_inventory),
+        (
+            "stable-contract-inventory",
+            verify_stable_contract_inventory_strict,
+        ),
+    ];
+    run_checks(&checks)
+}
+
+fn verify_contracts_with_strictness(
+    baseline: &StableSurfaceContractManifest,
+    current: &StableSurfaceContractManifest,
+    fail_on_additions: bool,
+) -> Result<()> {
+    let deltas = diff_contracts(baseline, current);
+
+    if !deltas.removed.is_empty() {
+        let mut lines = Vec::new();
+        for item in deltas.removed {
+            lines.push(format!("- {} {}", item.category, item.item));
+        }
+        lines.sort_unstable();
+        bail!(
+            "stable-contract inventory has breaking changes:\n{}",
+            lines.join("\n")
+        );
+    }
+
+    if !fail_on_additions {
+        if !deltas.added.is_empty() {
+            let mut lines = Vec::new();
+            for item in deltas.added {
+                lines.push(format!("- {} {}", item.category, item.item));
+            }
+            lines.sort_unstable();
+            println!(
+                "stable-contract inventory additions (non-blocking):\n{}",
+                lines.join("\n")
+            );
+        }
+        return Ok(());
+    }
+
+    if !deltas.added.is_empty() {
+        let mut lines = Vec::new();
+        for item in deltas.added {
+            lines.push(format!("- {} {}", item.category, item.item));
+        }
+        lines.sort_unstable();
+        bail!(
+            "stable-contract inventory has incompatible changes:\n{}",
+            lines.join("\n")
+        );
+    }
+
+    Ok(())
+}
+
+fn verify_stable_contract_inventory() -> Result<()> {
+    let baseline = load_stable_contract_manifest()?;
+    if baseline.schema_version != STABLE_CONTRACT_SCHEMA_VERSION {
+        bail!(
+            "stable contract manifest schema mismatch: expected {STABLE_CONTRACT_SCHEMA_VERSION}, found {}",
+            baseline.schema_version
+        );
+    }
+
+    let current = collect_stable_contract_inventory()?;
+    verify_contracts_with_strictness(&baseline, &current, false)
+}
+
+fn verify_stable_contract_inventory_strict() -> Result<()> {
+    let baseline = load_stable_contract_manifest()?;
+    if baseline.schema_version != STABLE_CONTRACT_SCHEMA_VERSION {
+        bail!(
+            "stable contract manifest schema mismatch: expected {STABLE_CONTRACT_SCHEMA_VERSION}, found {}",
+            baseline.schema_version
+        );
+    }
+
+    let current = collect_stable_contract_inventory()?;
+    verify_contracts_with_strictness(&baseline, &current, true)
+}
+
 fn run_checks(checks: &[Verifier]) -> Result<()> {
     for (name, check) in checks {
         check().map_err(|err| anyhow::anyhow!("{name} failed: {err}"))?;
@@ -284,43 +371,6 @@ fn verify_stability_registry() -> Result<()> {
     let registry = load_stability_registry()?;
     let metadata = load_cargo_metadata()?;
     verify_stability_registry_against_metadata(&registry, &metadata)
-}
-
-fn verify_stable_contract_inventory() -> Result<()> {
-    let baseline = load_stable_contract_manifest()?;
-    if baseline.schema_version != STABLE_CONTRACT_SCHEMA_VERSION {
-        bail!(
-            "stable contract manifest schema mismatch: expected {STABLE_CONTRACT_SCHEMA_VERSION}, found {}",
-            baseline.schema_version
-        );
-    }
-
-    let current = collect_stable_contract_inventory()?;
-    let deltas = diff_contracts(&baseline, &current);
-
-    if !deltas.removed.is_empty() {
-        let mut lines = Vec::new();
-        for item in deltas.removed {
-            lines.push(format!("- {} {}", item.category, item.item));
-        }
-        bail!(
-            "stable-contract inventory has breaking changes:\n{}",
-            lines.join("\n")
-        );
-    }
-
-    if !deltas.added.is_empty() {
-        let mut lines = Vec::new();
-        for item in deltas.added {
-            lines.push(format!("- {} {}", item.category, item.item));
-        }
-        println!(
-            "stable-contract inventory additions (non-blocking):\n{}",
-            lines.join("\n")
-        );
-    }
-
-    Ok(())
 }
 
 fn verify_deprecation_audit() -> Result<()> {
@@ -2178,6 +2228,94 @@ mod tests {
         );
         assert!(!deltas.removed.is_empty());
         assert!(!deltas.added.is_empty());
+    }
+
+    fn simple_contract_manifest(
+        commands: &[&str],
+        error_codes: &[&str],
+        exit_variants: &[&str],
+        exit_tags: &[&str],
+    ) -> StableSurfaceContractManifest {
+        StableSurfaceContractManifest {
+            schema_version: "1.0.0".to_string(),
+            generated_at: "current".to_string(),
+            generated_by: "current".to_string(),
+            source_revision: "current".to_string(),
+            source_paths: STABLE_CONTRACT_SOURCE_PATHS
+                .iter()
+                .map(|path| path.to_string())
+                .collect(),
+            cli: ContractCliInventory {
+                commands: commands
+                    .iter()
+                    .map(|command| (*command).to_string())
+                    .collect(),
+                options: vec!["input".to_string()],
+                env_vars: vec!["COPYBOOK_STRICT_POLICY".to_string()],
+            },
+            error: ContractErrorInventory {
+                variants: error_codes
+                    .iter()
+                    .map(|error| (*error).to_string())
+                    .collect(),
+            },
+            exit_code: ContractExitCodeInventory {
+                variants: exit_variants
+                    .iter()
+                    .map(|variant| (*variant).to_string())
+                    .collect(),
+                tags: exit_tags.iter().map(|tag| (*tag).to_string()).collect(),
+            },
+            jsonl: ContractJsonlInventory {
+                schema_keys: vec!["schema".to_string()],
+                required_keys: vec!["schema".to_string()],
+                pattern_properties: vec!["^prefix_".to_string()],
+                compatibility_keys: vec!["raw_b64".to_string()],
+            },
+            raw_capture: ContractRawCaptureInventory {
+                modes: vec!["Off".to_string()],
+                emitted_keys: vec!["__raw_b64".to_string()],
+            },
+        }
+    }
+
+    #[test]
+    fn verify_contracts_with_strictness_allows_added_items_when_non_strict() {
+        let baseline = simple_contract_manifest(&["decode"], &["CBK001"], &["Data"], &["CBKD"]);
+        let current =
+            simple_contract_manifest(&["decode", "parse"], &["CBK001"], &["Data"], &["CBKD"]);
+
+        assert!(verify_contracts_with_strictness(&baseline, &current, false).is_ok());
+    }
+
+    #[test]
+    fn verify_contracts_with_strictness_rejects_added_items_when_strict() {
+        let baseline = simple_contract_manifest(&["decode"], &["CBK001"], &["Data"], &["CBKD"]);
+        let current =
+            simple_contract_manifest(&["decode", "parse"], &["CBK001"], &["Data"], &["CBKD"]);
+
+        let err = verify_contracts_with_strictness(&baseline, &current, true).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("stable-contract inventory has incompatible changes")
+        );
+    }
+
+    #[test]
+    fn verify_contracts_with_strictness_rejects_removed_items_when_non_strict() {
+        let baseline = simple_contract_manifest(
+            &["decode", "parse"],
+            &["CBK001", "CBK002"],
+            &["Data", "Encode"],
+            &["CBKD", "CBKE"],
+        );
+        let current = simple_contract_manifest(&["decode"], &["CBK001"], &["Data"], &["CBKD"]);
+
+        let err = verify_contracts_with_strictness(&baseline, &current, false).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("stable-contract inventory has breaking changes")
+        );
     }
 
     #[test]

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -20,6 +20,7 @@ fn main() -> Result<()> {
         ["docs", "verify-tests"] => verify(),
         ["docs", "verify-all"] => docs_verify::run(),
         ["docs", "verify-support-matrix"] => verify_support_matrix(),
+        ["docs", "freeze", "contracts"] => docs_verify::run_freeze_contract_checks(),
         ["docs", "contracts", "generate"] => docs_verify::run_contracts_command(),
         ["perf"] => perf::run(false, None),
         ["perf", "--enforce"] => perf::run(true, None),
@@ -77,6 +78,7 @@ fn usage() {
          docs sync-tests                     Sync test status from junit.xml\n\
          docs verify-tests                   Verify test status is in sync\n\
          docs verify-all                     Verify all source-of-truth documentation invariants\n\
+         docs freeze contracts               Verify freeze-sensitive contracts (strict, API surface contract guard)\n\
          docs contracts generate             Regenerate stable contract manifest baseline\n\
          docs verify-support-matrix          Verify support matrix registry -> docs\n\
          perf                                Run perf benchmark runner\n\


### PR DESCRIPTION
## Summary

Align API-freeze enforcement with the full stable contract surface for issue #544 by adding a deterministic contract-aware check pipeline.

## Type
- [x] Bugfix
- [x] CI/CD
- [x] Tests

## Summary of changes

- Add docs freeze contracts xtask command for strict freeze contract validation.
- Make stable-contract inventory verification strict when used in freeze mode while preserving additive behavior elsewhere.
- Rework .github/workflows/api-freeze.yml to classify changed paths into:
  - contract-relevant changes (enforce API/contract checks),
  - non-allowed non-contract changes (also enforce checks),
  - allowed non-contract-only changes (skip freeze checks).
- Update docs/API_FREEZE.md to describe the contract-aware scope and enforcement behavior.

## Testing

- cargo check -p xtask
- cargo test -p xtask
- cargo run -p xtask -- docs freeze contracts
- scoped cargo fmt for 	ools/xtask (cargo fmt --check)
- Python parse check for .github/workflows/api-freeze.yml

## Related

Closes #544

## Notes

just recipes and full-workspace cargo fmt are currently unavailable in this environment, and are intentionally not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added enhanced API freeze validation that distinguishes contract-impacting changes from permitted documentation, testing, and tooling updates.
  - Added a dedicated command for checking stable contract compatibility during an API freeze.
  - Added clearer reporting for affected files, baseline details, and freeze-check results.

- **Documentation**
  - Reorganized API freeze guidance, including allowed and prohibited changes, verification commands, release procedures, and troubleshooting steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->