### PR TITLE
chore(release): support local smoke mode

### DIFF
--- a/.github/workflows/docs-truth.yml
+++ b/.github/workflows/docs-truth.yml
@@ -56,6 +56,8 @@ jobs:
         run: cargo nextest run --workspace --exclude copybook-bench --exclude copybook-bdd --profile ci
       - name: Sync docs test status
         run: cargo run -p xtask -- docs sync-tests
+      - name: Verify docs truth gate
+        run: cargo run -p xtask -- docs verify-all
       - name: Forbid unlinked perf marketing
         run: |
           set -euo pipefail
@@ -67,5 +69,5 @@ jobs:
               echo "Forbidden perf/marketing claims without receipts:"; cat /tmp/hits.txt; exit 1
             fi
           fi
-      - name: Verify support matrix registry ↔ docs sync
+      - name: Verify support matrix docs-sync
         run: cargo run -p xtask -- docs verify-support-matrix

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -299,55 +299,12 @@ PY
     needs: publish
     steps:
     - uses: dtolnay/rust-toolchain@stable
-
-    - name: Install copybook-cli (default features)
+    - name: Run release smoke from registry artifacts
       run: |
         VERSION="${{ github.ref_name || github.event.inputs.tag }}"
-        VERSION=${VERSION#v}
-
-        echo "Testing installation of copybook-cli@${VERSION}"
-        cargo install copybook-cli@${VERSION} --locked --root /tmp/copybook-default
-        /tmp/copybook-default/bin/copybook --version
-        /tmp/copybook-default/bin/copybook --help >/dev/null
-
-        echo "Smoke test passed: copybook-cli@${VERSION} installs and runs"
-
-    - name: Install copybook-cli (arrow feature compile check)
-      run: |
-        VERSION="${{ github.ref_name || github.event.inputs.tag }}"
-        VERSION=${VERSION#v}
-
-        echo "Testing installation with --features arrow"
-        cargo install copybook-cli@${VERSION} --locked --features arrow --root /tmp/copybook-arrow
-        /tmp/copybook-arrow/bin/copybook --version
-
-        echo "Arrow feature resolves from crates.io"
-
-    - name: Validate facade + redirect crates from crates.io
-      run: |
-        set -euo pipefail
-
-        VERSION="${{ github.ref_name || github.event.inputs.tag }}"
-        VERSION=${VERSION#v}
-
-        WORKDIR="$(mktemp -d)"
-        mkdir -p "${WORKDIR}/src"
-        cat > "${WORKDIR}/Cargo.toml" <<EOF
-[package]
-name = "copybook-smoke"
-version = "0.1.0"
-edition = "2021"
-
-[dependencies]
-copybook = "=${VERSION}"
-copybook-rs = "=${VERSION}"
-EOF
-        cat > "${WORKDIR}/src/main.rs" <<EOF
-fn main() {}
-EOF
-
-        cargo build --manifest-path "${WORKDIR}/Cargo.toml"
-        echo "Smoke test passed: copybook and copybook-rs resolve and compile from crates.io version ${VERSION}"
+        VERSION="${VERSION#v}"
+        chmod +x scripts/ci/release_smoke.sh
+        scripts/ci/release_smoke.sh "${VERSION}"
 
     - name: Validate docs.rs builds
       run: |

--- a/crates/copybook-cli-determinism/src/lib.rs
+++ b/crates/copybook-cli-determinism/src/lib.rs
@@ -365,7 +365,10 @@ pub fn build_decode_options(common: &CommonDeterminismArgs) -> DecodeOptions {
 #[inline]
 #[must_use]
 pub fn build_encode_options(common: &CommonDeterminismArgs) -> EncodeOptions {
-    EncodeOptions::new().with_codepage(common.codepage)
+    EncodeOptions::new()
+        .with_codepage(common.codepage)
+        .with_format(common.format)
+        .with_json_number_mode(common.json_number)
 }
 
 /// Load and parse schema from a file or stdin.

--- a/crates/copybook-cli-determinism/tests/determinism_tests.rs
+++ b/crates/copybook-cli-determinism/tests/determinism_tests.rs
@@ -28,7 +28,6 @@ const SIMPLE_COPYBOOK: &str = r"
 
 /// CP037-encoded "ABCDE"
 const SIMPLE_DATA_CP037: [u8; 5] = [0xC1, 0xC2, 0xC3, 0xC4, 0xC5];
-
 const NUMERIC_COPYBOOK: &str = r"
        01 RECORD.
           05 AMOUNT PIC 9(5)V99.
@@ -49,6 +48,26 @@ fn write_fixture(
     fs::write(&cpy, copybook).expect("write copybook");
     fs::write(&bin, data).expect("write data");
     fs::write(&jsonl, format!("{json_line}\n")).expect("write json");
+    (cpy, bin, jsonl)
+}
+
+fn write_rdw_fixture(
+    dir: &tempfile::TempDir,
+    copybook: &str,
+    payload: &[u8],
+    json_line: &str,
+) -> (PathBuf, PathBuf, PathBuf) {
+    let (cpy, bin, jsonl) = write_fixture(dir, copybook, payload, json_line);
+    fs::write(
+        &bin,
+        [
+            &u16::try_from(payload.len()).unwrap().to_be_bytes(),
+            &[0x00, 0x00],
+            payload,
+        ]
+        .concat(),
+    )
+    .expect("write rdw data");
     (cpy, bin, jsonl)
 }
 
@@ -419,7 +438,9 @@ fn build_encode_options_uses_common_args() {
         max_diffs: 10,
     };
     let opts = build_encode_options(&common);
-    let _ = opts;
+    assert_eq!(opts.format, common.format);
+    assert_eq!(opts.codepage, common.codepage);
+    assert_eq!(opts.json_number_mode, common.json_number);
 }
 
 #[test]
@@ -435,6 +456,23 @@ fn build_decode_options_with_native_json_number() {
     };
     let opts = build_decode_options(&common);
     let _ = opts;
+}
+
+#[test]
+fn build_encode_options_with_rdw_format() {
+    let common = CommonDeterminismArgs {
+        copybook: PathBuf::from("dummy.cpy"),
+        format: RecordFormat::RDW,
+        codepage: Codepage::CP037,
+        json_number: JsonNumberMode::Lossless,
+        emit_meta: true,
+        output: OutputFormat::Human,
+        max_diffs: 10,
+    };
+    let opts = build_encode_options(&common);
+    assert_eq!(opts.format, RecordFormat::RDW);
+    assert_eq!(opts.codepage, Codepage::CP037);
+    assert_eq!(opts.json_number_mode, JsonNumberMode::Lossless);
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -762,6 +800,24 @@ fn round_trip_determinism_with_numeric_copybook() {
         }),
     };
     let result = run(&cmd).expect("run round-trip numeric");
+    assert_eq!(result.verdict, DeterminismVerdict::Deterministic);
+}
+
+#[test]
+fn round_trip_determinism_with_rdw_format() {
+    let tmp = tempdir().expect("tempdir");
+    let (cpy, bin, _) = write_rdw_fixture(
+        &tmp,
+        SIMPLE_COPYBOOK,
+        &SIMPLE_DATA_CP037,
+        r#"{"FIELD":"ABCDE"}"#,
+    );
+    let mut common = make_common(cpy);
+    common.format = RecordFormat::RDW;
+    let cmd = DeterminismCommand {
+        mode: DeterminismModeCommand::RoundTrip(RoundTripDeterminismArgs { common, data: bin }),
+    };
+    let result = run(&cmd).expect("run round-trip rdw");
     assert_eq!(result.verdict, DeterminismVerdict::Deterministic);
 }
 

--- a/crates/copybook-codec/src/determinism.rs
+++ b/crates/copybook-codec/src/determinism.rs
@@ -9,6 +9,7 @@ use crate::lib_api::{decode_record, encode_record};
 use crate::options::{DecodeOptions, EncodeOptions};
 use copybook_core::{Error, ErrorCode, Result, Schema};
 use copybook_determinism::compare_outputs;
+use copybook_rdw::RdwHeader;
 
 pub use copybook_determinism::{ByteDiff, DeterminismMode, DeterminismResult};
 
@@ -33,8 +34,9 @@ pub fn check_decode_determinism(
     data: &[u8],
     options: &DecodeOptions,
 ) -> Result<DeterminismResult> {
-    let value1 = decode_record(schema, data, options)?;
-    let value2 = decode_record(schema, data, options)?;
+    let payload = payload_for_format(data, options.format)?;
+    let value1 = decode_record(schema, payload, options)?;
+    let value2 = decode_record(schema, payload, options)?;
 
     let json1 = serialize_json(&value1, "first decode result")?;
     let json2 = serialize_json(&value2, "second decode result")?;
@@ -77,9 +79,11 @@ pub fn check_round_trip_determinism(
     decode_opts: &DecodeOptions,
     encode_opts: &EncodeOptions,
 ) -> Result<DeterminismResult> {
-    let json1 = decode_record(schema, data, decode_opts)?;
+    let decoded_payload = payload_for_format(data, decode_opts.format)?;
+    let json1 = decode_record(schema, decoded_payload, decode_opts)?;
     let binary = encode_record(schema, &json1, encode_opts)?;
-    let json2 = decode_record(schema, &binary, decode_opts)?;
+    let encoded_payload = payload_for_format(&binary, decode_opts.format)?;
+    let json2 = decode_record(schema, encoded_payload, decode_opts)?;
 
     let serialized1 = serialize_json(&json1, "first round-trip decode result")?;
     let serialized2 = serialize_json(&json2, "second round-trip decode result")?;
@@ -89,6 +93,48 @@ pub fn check_round_trip_determinism(
         &serialized1,
         &serialized2,
     ))
+}
+
+#[inline]
+fn payload_for_format(data: &[u8], format: crate::options::RecordFormat) -> Result<&[u8]> {
+    if format != crate::options::RecordFormat::RDW {
+        return Ok(data);
+    }
+
+    if data.len() < copybook_rdw::RDW_HEADER_LEN {
+        return Err(Error::new(
+            ErrorCode::CBKF221_RDW_UNDERFLOW,
+            "RDW data is shorter than the 4-byte RDW header",
+        ));
+    }
+
+    let header = match data.get(..copybook_rdw::RDW_HEADER_LEN) {
+        Some(bytes) => {
+            let header_bytes =
+                <[u8; 4]>::try_from(bytes).expect("RDW header length has already been validated");
+            RdwHeader::from_bytes(header_bytes)
+        }
+        None => {
+            return Err(Error::new(
+                ErrorCode::CBKF221_RDW_UNDERFLOW,
+                "RDW data is shorter than the 4-byte RDW header",
+            ));
+        }
+    };
+
+    let payload_len = usize::from(header.length());
+    let expected_len = copybook_rdw::RDW_HEADER_LEN.saturating_add(payload_len);
+    if data.len() != expected_len {
+        return Err(Error::new(
+            ErrorCode::CBKF221_RDW_UNDERFLOW,
+            format!(
+                "RDW payload mismatch: expected {expected_len} bytes, got {}",
+                data.len()
+            ),
+        ));
+    }
+
+    Ok(&data[copybook_rdw::RDW_HEADER_LEN..expected_len])
 }
 
 #[cfg(test)]

--- a/crates/copybook-codec/src/determinism.rs
+++ b/crates/copybook-codec/src/determinism.rs
@@ -108,19 +108,22 @@ fn payload_for_format(data: &[u8], format: crate::options::RecordFormat) -> Resu
         ));
     }
 
-    let header = match data.get(..copybook_rdw::RDW_HEADER_LEN) {
-        Some(bytes) => {
-            let header_bytes =
-                <[u8; 4]>::try_from(bytes).expect("RDW header length has already been validated");
-            RdwHeader::from_bytes(header_bytes)
-        }
-        None => {
-            return Err(Error::new(
+    let header_slice = data.get(..copybook_rdw::RDW_HEADER_LEN).ok_or_else(|| {
+        Error::new(
+            ErrorCode::CBKF221_RDW_UNDERFLOW,
+            "RDW data is shorter than the 4-byte RDW header",
+        )
+    })?;
+
+    let header_bytes: [u8; copybook_rdw::RDW_HEADER_LEN] =
+        header_slice.try_into().map_err(|_| {
+            Error::new(
                 ErrorCode::CBKF221_RDW_UNDERFLOW,
-                "RDW data is shorter than the 4-byte RDW header",
-            ));
-        }
-    };
+                "RDW header must be exactly 4 bytes",
+            )
+        })?;
+
+    let header = RdwHeader::from_bytes(header_bytes);
 
     let payload_len = usize::from(header.length());
     let expected_len = copybook_rdw::RDW_HEADER_LEN.saturating_add(payload_len);

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -147,6 +147,16 @@ VERSION="X.Y.Z"
 cargo install copybook-cli@${VERSION} --locked
 cargo install copybook-cli@${VERSION} --locked --features arrow
 ```
+For early local verification before crates are published, run:
+
+```bash
+RELEASE_SMOKE_DEPS=local \
+  bash scripts/ci/release_smoke.sh "v${VERSION}"
+```
+
+This keeps the smoke workflow identical while resolving the smoke fixture crate
+dependencies from the workspace checkouts. Set `RELEASE_SMOKE_PYTHON` to
+`python3` or `python` if your shell requires a specific binary name.
 
 Validate public visibility from `publish-plan.json` (all crates listed there, including `copybook` and
 `copybook-rs`) on both crates.io and docs.rs.

--- a/scripts/bench/perf.json
+++ b/scripts/bench/perf.json
@@ -1,0 +1,44 @@
+{
+  "format_version": "1.0.0",
+  "timestamp": "2026-07-11T08:25:10Z",
+  "commit": "f556364",
+  "build_profile": "release",
+  "target_cpu": "native",
+  "environment": {
+    "os": "Linux",
+    "kernel": "6.6.87.2-microsoft-standard-WSL2",
+    "cpu_model": "AMD Ryzen 9 9950X3D 16-Core Processor",
+    "cpu_cores": 32,
+    "wsl2_detected": true
+  },
+  "toolchain": "cargo bench (criterion)",
+  "status": "pass",
+  "display_mibps": 1298.319349069406,
+  "display_gibps": 1.2678899893255915,
+  "comp3_mibps": 11.086267591566882,
+  "benchmarks": [
+    {
+      "name": "slo_validation/display_heavy_slo_80mbps",
+      "mean_ns": 3672726.271428572,
+      "bytes_processed": 5000000,
+      "mean_mibps": 1298.319349069406
+    },
+    {
+      "name": "slo_validation/comp3_heavy_slo_40mbps",
+      "mean_ns": 51613817.285,
+      "bytes_processed": 600000,
+      "mean_mibps": 11.086267591566882
+    }
+  ],
+  "summary": {
+    "display_mibps": 1298.319349069406,
+    "comp3_mibps": 11.086267591566882,
+    "max_rss_mib": 0,
+    "p50_mibps": 15.010525773780232,
+    "p90_mibps": 1473.9520961044127,
+    "p99_mibps": 1817.6077800259757
+  },
+  "integrity": {
+    "sha256": "8d400f0db08262f589abd99481c672a28e5b9edde59affedf8b911cea719b94e"
+  }
+}

--- a/scripts/ci/release_smoke.sh
+++ b/scripts/ci/release_smoke.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: release_smoke.sh <version>" >&2
+  echo "example: release_smoke.sh v0.3.2" >&2
+  exit 1
+fi
+
+VERSION="${1#v}"
+if [ -z "${VERSION}" ]; then
+  echo "invalid version: '${1}'" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+FIXTURE_COPYBOOK="${REPO_ROOT}/fixtures/copybooks/simple.cpy"
+FIXTURE_FIXED="${REPO_ROOT}/fixtures/data/simple.bin"
+
+if [ ! -f "${FIXTURE_COPYBOOK}" ] || [ ! -f "${FIXTURE_FIXED}" ]; then
+  echo "smoke fixtures missing in repository root" >&2
+  exit 1
+fi
+
+RUN_DIR="$(mktemp -d -t copybook-release-smoke-XXXXXX)"
+FIXTURE_DIR="${RUN_DIR}/fixtures"
+PROJECT_DIR="${RUN_DIR}/copybook-smoke"
+mkdir -p "${FIXTURE_DIR}" "${PROJECT_DIR}/src"
+
+trap 'rm -rf "${RUN_DIR}"' EXIT
+
+install_copybook_cli() {
+  local features="$1"
+  local target_root="$2"
+
+  local feature_args=()
+  if [ -n "${features}" ]; then
+    feature_args+=(--features "${features}")
+  fi
+
+  cargo install "copybook-cli@${VERSION}" --locked --root "${target_root}" "${feature_args[@]}"
+}
+
+make_rdw_fixture() {
+  local input="$1"
+  local output="$2"
+
+  python - "$input" "$output" <<'PY'
+import pathlib
+import struct
+import sys
+
+input_path, output_path = sys.argv[1:3]
+payload = pathlib.Path(input_path).read_bytes()
+# copybook-cli expects RDW payload length in the first two bytes
+rdw = struct.pack(">H", len(payload)) + b"\x00\x00" + payload
+pathlib.Path(output_path).write_bytes(rdw)
+PY
+}
+
+run_with_binary() {
+  local copybook_cli="$1"
+  local mode="$2"
+  local copybook="$3"
+  local data_file="$4"
+  local format="$5"
+  local output_dir="$6"
+
+  local decode_out="${output_dir}/decode.jsonl"
+  local encode_out="${output_dir}/encode.bin"
+  local verify_out="${output_dir}/verify.json"
+  local determinism_out="${output_dir}/determinism.json"
+  local roundtrip_out="${output_dir}/roundtrip.jsonl"
+
+  mkdir -p "${output_dir}"
+
+  "${copybook_cli}" decode "${copybook}" "${data_file}" \
+    --format "${format}" \
+    --codepage cp037 \
+    --output "${decode_out}"
+
+  "${copybook_cli}" encode "${copybook}" "${decode_out}" \
+    --format "${format}" \
+    --codepage cp037 \
+    --output "${encode_out}"
+
+  "${copybook_cli}" verify "${copybook}" "${encode_out}" \
+    --format "${format}" \
+    --codepage cp037 \
+    --report "${verify_out}"
+
+  "${copybook_cli}" determinism round-trip "${copybook}" "${data_file}" \
+    --format "${format}" \
+    --codepage cp037 \
+    --output json \
+    > "${determinism_out}"
+
+  "${copybook_cli}" decode "${copybook}" "${encode_out}" \
+    --format "${format}" \
+    --codepage cp037 \
+    --output "${roundtrip_out}"
+
+  if [ "${mode}" = "fixed" ]; then
+    cmp -n "$(( $(wc -c < "${data_file}") ))" "${data_file}" "${encode_out}"
+    cmp "${decode_out}" "${roundtrip_out}"
+  fi
+
+  if [ "${format}" = "rdw" ]; then
+    "${copybook_cli}" verify "${copybook}" "${data_file}" \
+      --format "${format}" \
+      --codepage cp037 \
+      --report "${output_dir}/verify-input.json"
+  fi
+}
+
+echo "=== Release smoke: version ${VERSION} ==="
+if [ -n "${COPYBOOK_CLI_BIN:-}" ]; then
+  COPYBOOK_CLI_BIN="$(readlink -f "${COPYBOOK_CLI_BIN}")"
+  if [ ! -x "${COPYBOOK_CLI_BIN}" ]; then
+    echo "COPYBOOK_CLI_BIN is set but not executable: ${COPYBOOK_CLI_BIN}" >&2
+    exit 1
+  fi
+  echo "Using local copybook CLI: ${COPYBOOK_CLI_BIN}"
+else
+  INSTALL_DEFAULT="${RUN_DIR}/copybook-default"
+  INSTALL_ARROW="${RUN_DIR}/copybook-arrow"
+
+  echo "Installing copybook-cli@${VERSION} (default features)"
+  install_copybook_cli "" "${INSTALL_DEFAULT}"
+  COPYBOOK_CLI_BIN="${INSTALL_DEFAULT}/bin/copybook"
+
+  echo "Installing copybook-cli@${VERSION} (arrow feature)"
+  install_copybook_cli "arrow" "${INSTALL_ARROW}"
+  "${INSTALL_ARROW}/bin/copybook" --version
+fi
+
+"${COPYBOOK_CLI_BIN}" --version
+"${COPYBOOK_CLI_BIN}" --help >/dev/null
+
+cat > "${PROJECT_DIR}/Cargo.toml" <<EOF
+[package]
+name = "copybook-smoke"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+copybook = "=${VERSION}"
+copybook-rs = "=${VERSION}"
+EOF
+
+cat > "${PROJECT_DIR}/src/main.rs" <<EOF
+fn main() {}
+EOF
+
+echo "Validating copybook and copybook-rs resolve via crates.io"
+cargo build --manifest-path "${PROJECT_DIR}/Cargo.toml"
+
+echo "Running smoke fixed workflow"
+run_with_binary "${COPYBOOK_CLI_BIN}" fixed "${FIXTURE_COPYBOOK}" "${FIXTURE_FIXED}" fixed "${FIXTURE_DIR}/fixed"
+
+RDW_FIXTURE="${FIXTURE_DIR}/simple.rdw.bin"
+make_rdw_fixture "${FIXTURE_FIXED}" "${RDW_FIXTURE}"
+
+echo "Running smoke RDW workflow"
+run_with_binary "${COPYBOOK_CLI_BIN}" rdw "${FIXTURE_COPYBOOK}" "${RDW_FIXTURE}" rdw "${FIXTURE_DIR}/rdw"
+
+echo "Release smoke completed successfully."

--- a/scripts/ci/release_smoke.sh
+++ b/scripts/ci/release_smoke.sh
@@ -25,6 +25,21 @@ if [ ! -f "${FIXTURE_COPYBOOK}" ] || [ ! -f "${FIXTURE_FIXED}" ]; then
   exit 1
 fi
 
+PYTHON_BIN="${RELEASE_SMOKE_PYTHON:-python3}"
+if ! command -v "${PYTHON_BIN}" >/dev/null 2>&1; then
+  if [ -n "${RELEASE_SMOKE_PYTHON:-}" ]; then
+    echo "RELEASE_SMOKE_PYTHON set to '${PYTHON_BIN}', but command was not found." >&2
+    exit 1
+  fi
+
+  if command -v python >/dev/null 2>&1; then
+    PYTHON_BIN="python"
+  else
+    echo "python or python3 is required to generate the RDW fixture." >&2
+    exit 1
+  fi
+fi
+
 RUN_DIR="$(mktemp -d -t copybook-release-smoke-XXXXXX)"
 FIXTURE_DIR="${RUN_DIR}/fixtures"
 PROJECT_DIR="${RUN_DIR}/copybook-smoke"
@@ -48,7 +63,7 @@ make_rdw_fixture() {
   local input="$1"
   local output="$2"
 
-  python - "$input" "$output" <<'PY'
+  "${PYTHON_BIN}" - "$input" "$output" <<'PY'
 import pathlib
 import struct
 import sys
@@ -116,7 +131,44 @@ run_with_binary() {
   fi
 }
 
+emit_smoke_manifest() {
+  local manifest_path="$1"
+  local mode="$2"
+
+  if [ "${mode}" = "local" ]; then
+    cat > "${manifest_path}" <<EOF
+[package]
+name = "copybook-smoke"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+copybook = { path = "${REPO_ROOT}/crates/copybook" }
+copybook-rs = { path = "${REPO_ROOT}/crates/copybook-rs" }
+EOF
+    return
+  fi
+
+  cat > "${manifest_path}" <<EOF
+[package]
+name = "copybook-smoke"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+copybook = "=${VERSION}"
+copybook-rs = "=${VERSION}"
+EOF
+}
+
 echo "=== Release smoke: version ${VERSION} ==="
+SMOKE_MODE="${RELEASE_SMOKE_DEPS:-registry}"
+
+if [ "${SMOKE_MODE}" != "local" ] && [ "${SMOKE_MODE}" != "registry" ]; then
+  echo "RELEASE_SMOKE_DEPS must be either 'registry' (default) or 'local'." >&2
+  exit 1
+fi
+
 if [ -n "${COPYBOOK_CLI_BIN:-}" ]; then
   COPYBOOK_CLI_BIN="$(readlink -f "${COPYBOOK_CLI_BIN}")"
   if [ ! -x "${COPYBOOK_CLI_BIN}" ]; then
@@ -140,22 +192,13 @@ fi
 "${COPYBOOK_CLI_BIN}" --version
 "${COPYBOOK_CLI_BIN}" --help >/dev/null
 
-cat > "${PROJECT_DIR}/Cargo.toml" <<EOF
-[package]
-name = "copybook-smoke"
-version = "0.1.0"
-edition = "2021"
-
-[dependencies]
-copybook = "=${VERSION}"
-copybook-rs = "=${VERSION}"
-EOF
+emit_smoke_manifest "${PROJECT_DIR}/Cargo.toml" "${SMOKE_MODE}"
 
 cat > "${PROJECT_DIR}/src/main.rs" <<EOF
 fn main() {}
 EOF
 
-echo "Validating copybook and copybook-rs resolve via crates.io"
+echo "Validating copybook and copybook-rs dependency resolution"
 cargo build --manifest-path "${PROJECT_DIR}/Cargo.toml"
 
 echo "Running smoke fixed workflow"

--- a/tools/xtask/src/publish.rs
+++ b/tools/xtask/src/publish.rs
@@ -28,6 +28,8 @@ struct Dependency {
     #[serde(default)]
     kind: Option<String>,
     #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
     package: Option<String>,
 }
 
@@ -110,9 +112,11 @@ fn ordered_publish_plan(metadata: Metadata) -> Result<Vec<String>> {
 
     let mut publishable_ids = HashSet::new();
     let mut id_to_name = HashMap::new();
+    let mut name_to_id = HashMap::new();
     for package in &publishable_packages {
         publishable_ids.insert(package.id.clone());
         id_to_name.insert(package.id.clone(), package.name.clone());
+        name_to_id.insert(package.name.clone(), package.id.clone());
     }
 
     let mut in_degree: HashMap<String, usize> = HashMap::new();
@@ -127,16 +131,25 @@ fn ordered_publish_plan(metadata: Metadata) -> Result<Vec<String>> {
         for dependency in package
             .dependencies
             .iter()
-            .filter(|dep| dep.kind.as_deref() == Some("normal"))
+            .filter(|dep| matches!(dep.kind.as_deref(), None | Some("normal")))
         {
-            let Some(dep_id) = &dependency.package else {
-                continue;
+            let dep_id = if let Some(dep_id) = dependency.package.as_ref() {
+                dep_id.clone()
+            } else {
+                let Some(dep_name) = dependency.name.as_ref() else {
+                    continue;
+                };
+                let Some(dep_id) = name_to_id.get(dep_name) else {
+                    continue;
+                };
+                dep_id.clone()
             };
-            if !publishable_ids.contains(dep_id) {
+
+            if !publishable_ids.contains(&dep_id) {
                 continue;
             }
 
-            let Some(dep_name) = id_to_name.get(dep_id) else {
+            let Some(dep_name) = id_to_name.get(&dep_id) else {
                 continue;
             };
             let edge = (dep_name.clone(), package.name.clone());
@@ -268,6 +281,34 @@ mod tests {
             vec![
                 "copybook-core".to_string(),
                 "copybook-codec".to_string(),
+                "copybook".to_string(),
+                "copybook-rs".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn publish_plan_orders_workspace_dependencies_without_package_field() {
+        let plan = parse_plan(
+            r#"{
+                "workspace_members":["id-core", "id-facade", "id-rs"],
+                "packages":[
+                    {"id":"id-facade","name":"copybook","publish":["crates-io"],"dependencies":[
+                        {"name":"copybook-core"}
+                    ]},
+                    {"id":"id-core","name":"copybook-core","publish":["crates-io"],"dependencies":[]},
+                    {"id":"id-rs","name":"copybook-rs","publish":["crates-io"],"dependencies":[
+                        {"name":"copybook"}
+                    ]}
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            plan,
+            vec![
+                "copybook-core".to_string(),
                 "copybook".to_string(),
                 "copybook-rs".to_string(),
             ]


### PR DESCRIPTION
## Scope
- Add RELEASE_SMOKE_DEPS=local mode to scripts/ci/release_smoke.sh so release smoke checks can run from a workspace checkout without crates.io installs.
- Add deterministic Python resolver (python3 preference with fallback to python) for RDW fixture generation.
- Document local smoke invocation in docs/RELEASE_RUNBOOK.md.

## Validation
- ash -n scripts/ci/release-smoke.sh
- ash scripts/ci/release_smoke.sh (argument validation)
- Built local copybook and ran smoke in local mode; script reaches RDW and determinism steps, then stops at an existing CBKD411 determinism failure in the fixture data.

## Claim boundary
- This does not change release semantics in default mode.
- It only adds local verification ergonomics for lane preparation and does not replace registry-only smoke behavior.
