### PR TITLE
chore(devex): add one-shot dev toolchain bootstrap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,19 @@ Thank you for your interest in contributing to copybook-rs. This guide will help
 - **Rust 1.92+** (MSRV enforced at workspace level)
 - **Git** for version control
 - **Cargo** (comes with Rust)
-- **[just](https://github.com/casey/just)** task runner (for `just ci-quick`, `just pr`)
-- **[cargo-nextest](https://nexte.st/)** — `cargo install cargo-nextest`
-- **[cargo-deny](https://github.com/EmbarkStudios/cargo-deny)** — `cargo install cargo-deny`
+- **[just](https://github.com/casey/just)** task runner (for `just ci-quick`, `just pr`) — `cargo install just`
+
+The remaining dev-only cargo subcommands used by the justfile
+(`cargo-nextest`, `cargo-deny`, `cargo-watch`, `cargo-llvm-cov`,
+`cargo-mutants`) can be installed one at a time, or all at once with:
+
+```bash
+just setup
+```
+
+`just setup` skips any tool that is already installed, and uses
+[`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall) for faster
+installs when it's available on your `PATH`.
 
 ### Setting Up Your Development Environment
 
@@ -20,6 +30,9 @@ Thank you for your interest in contributing to copybook-rs. This guide will help
 # Fork the repository on GitHub, then clone your fork
 git clone https://github.com/YOUR_USERNAME/copybook-rs.git
 cd copybook-rs
+
+# Install the dev toolchain (nextest, cargo-deny, cargo-watch, ...)
+just setup
 
 # Build the workspace
 cargo build --workspace

--- a/justfile
+++ b/justfile
@@ -8,6 +8,10 @@ set dotenv-load := true
 default:
     @just --list
 
+# One-shot dev environment bootstrap (installs nextest, cargo-deny, etc.)
+setup:
+    bash scripts/setup-dev.sh
+
 # Build all workspace crates
 build:
     cargo build --workspace

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,6 +14,7 @@ Automation and utility scripts for copybook-rs development and CI/CD.
 - **guard-hotpaths.sh** - Rust-backed hot-path allocation guard
 
 ## Development Automation
+- **setup-dev.sh** - One-shot bootstrap that installs the cargo subcommands the justfile expects (cargo-nextest, cargo-deny, cargo-watch, cargo-llvm-cov, cargo-mutants); also runnable as `just setup`
 - **copybook-scripts adapt-review-agents** - Native Rust agent configuration adaptation utility
 - **copybook-scripts final-cleanup-agents** - Native Rust agent cleanup and finalization
 - **copybook-scripts fix-agent-issues** - Native Rust agent configuration repair tool

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# One-shot bootstrap for local copybook-rs development.
+# Installs the cargo subcommands referenced by the justfile so `just <recipe>`
+# works out of the box after a fresh clone.
+set -euo pipefail
+
+if command -v cargo.exe >/dev/null 2>&1; then
+  CARGO_BIN="cargo.exe"
+else
+  CARGO_BIN="cargo"
+fi
+
+# name -> crate name (kept separate in case they ever diverge)
+TOOLS=(
+  "cargo-nextest:cargo-nextest"
+  "cargo-deny:cargo-deny"
+  "cargo-watch:cargo-watch"
+  "cargo-llvm-cov:cargo-llvm-cov"
+  "cargo-mutants:cargo-mutants"
+)
+
+install_one() {
+  local bin_name="$1" crate="$2"
+  if command -v "$bin_name" >/dev/null 2>&1; then
+    echo "==> $bin_name already installed, skipping"
+    return
+  fi
+  echo "==> Installing $crate"
+  if command -v cargo-binstall >/dev/null 2>&1; then
+    "$CARGO_BIN" binstall --no-confirm "$crate"
+  else
+    "$CARGO_BIN" install --locked "$crate"
+  fi
+}
+
+echo "==> copybook-rs dev environment setup"
+for entry in "${TOOLS[@]}"; do
+  install_one "${entry%%:*}" "${entry##*:}"
+done
+
+if ! command -v just >/dev/null 2>&1; then
+  echo "NOTE: 'just' is not installed. Install it from https://github.com/casey/just"
+  echo "      or run: cargo install just"
+fi
+
+echo "==> Done. Try 'just ci-quick' to validate your setup."


### PR DESCRIPTION
## Summary

- Add `scripts/setup-dev.sh`, a one-shot bootstrap that installs the cargo subcommands the justfile expects (`cargo-nextest`, `cargo-deny`, `cargo-watch`, `cargo-llvm-cov`, `cargo-mutants`), skipping any already installed and preferring `cargo-binstall` when available.
- Add a `just setup` recipe that runs the script.
- Update `CONTRIBUTING.md` prerequisites to point new contributors at `just setup` instead of a partial, manually-installed tool list (it previously only mentioned `cargo-nextest` and `cargo-deny`, while the justfile also depends on `cargo-watch`, `cargo-llvm-cov`, and `cargo-mutants`).
- List the new script in `scripts/README.md`.

## Type of Change

- [ ] Feature (new functionality)
- [ ] Bugfix (fixes an issue)
- [ ] Refactor (code improvement without behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (README, docs/, code comments)
- [ ] Tests (test additions or improvements)
- [ ] CI/CD (workflow or tooling changes)
- [x] Chore (dependencies, formatting, etc.)

## Workspace Crates Affected

None — this change only touches contributor tooling/docs (`justfile`, `scripts/`, `CONTRIBUTING.md`), no crate source.

## Checklist

- [ ] Tests added/updated — N/A, shell/docs-only change
- [x] Documentation updated (CONTRIBUTING.md, scripts/README.md)
- [ ] CHANGELOG.md updated — not user-facing (dev tooling only)
- [x] Follows conventional commit format (`chore(devex):`)
- N/A `cargo fmt`/`cargo clippy`/`cargo test` — no Rust source changed

## Testing Instructions

```bash
# Validate the justfile still parses and the new recipe resolves
just --list
just --show setup

# Exercise the script (safe to re-run; skips already-installed tools)
bash scripts/setup-dev.sh
```

## Breaking Changes

- [x] No breaking changes

## Additional Notes

Motivated by a DevEx audit of this repo: the justfile references five dev-only cargo subcommands (`cargo-nextest`, `cargo-deny`, `cargo-watch`, `cargo-llvm-cov`, `cargo-mutants`), but `CONTRIBUTING.md` only documented two of them, and install instructions for the rest were scattered across `scripts/ci/README.md` and various docs. This consolidates first-time setup into a single command.


---
_Generated by [Claude Code](https://claude.ai/code/session_013wX8qfpv9B8sfUNZK8TfNp)_