### PR TITLE
fix(codec): reject ODO encode when JSON counter disagrees with array length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **codec**: Reject ODO (OCCURS DEPENDING ON) encode input where the JSON counter value disagrees with the array length instead of silently writing extra elements that are unrecoverable on decode (`CBKE521_ARRAY_LEN_OOB`)
 - **codec**: Keep `RawMode::Field` output scoped to `<field>_raw_b64` values instead of also emitting whole-record `raw_b64` and `__raw_b64` payloads
 - Release prep: resolve clippy/rustdoc gate failures across core, codec, arrow examples, and test suites
 - Release prep: stabilize enterprise throughput assertions in `enterprise_mainframe_production_scenarios` for CI-consistent performance checks

--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -1622,10 +1622,9 @@ fn validate_lib_api_odo_encoding(
     if let Some(array) = json_lookup_array(fields_value, &array_field.path)
         .or_else(|| json_lookup_array(fields_value, &tail_odo.array_path))
     {
-        if json_lookup_value(fields_value, &counter_field.path)
+        let Some(counter_json_value) = json_lookup_value(fields_value, &counter_field.path)
             .or_else(|| json_lookup_value(fields_value, &tail_odo.counter_path))
-            .is_none()
-        {
+        else {
             return Err(crate::odo_redefines::handle_missing_counter_field(
                 &counter_field.path,
                 &array_field.path,
@@ -1633,6 +1632,35 @@ fn validate_lib_api_odo_encoding(
                 0,
                 u64::from(counter_field.offset),
             ));
+        };
+
+        // The counter field is encoded independently as a scalar, and the array
+        // is written using its own length. If the two disagree, whichever value
+        // wins at encode time makes the other one wrong on decode - silently
+        // dropping array elements or leaving a stale counter. Reject the
+        // inconsistent input instead of guessing which side is authoritative.
+        if let Some(counter_count) = json_counter_value_as_usize(counter_json_value)
+            && counter_count != array.len()
+        {
+            return Err(Error::new(
+                ErrorCode::CBKE521_ARRAY_LEN_OOB,
+                format!(
+                    "ODO counter '{}' value ({counter_count}) does not match array '{}' length ({})",
+                    counter_field.path,
+                    array_field.path,
+                    array.len()
+                ),
+            )
+            .with_context(crate::odo_redefines::create_comprehensive_error_context(
+                0,
+                &array_field.path,
+                u64::from(array_field.offset),
+                Some(format!(
+                    "counter_field={}, counter_value={counter_count}, array_length={}",
+                    counter_field.path,
+                    array.len()
+                )),
+            )));
         }
 
         let context = crate::odo_redefines::OdoValidationContext {
@@ -1652,6 +1680,15 @@ fn validate_lib_api_odo_encoding(
     }
 
     Ok(())
+}
+
+/// Parse a JSON counter field value (string or number) into an element count.
+fn json_counter_value_as_usize(value: &Value) -> Option<usize> {
+    match value {
+        Value::Number(n) => n.as_u64().and_then(|v| usize::try_from(v).ok()),
+        Value::String(s) => s.trim().parse::<usize>().ok(),
+        _ => None,
+    }
 }
 
 fn json_lookup_value<'a>(value: &'a Value, field_path: &str) -> Option<&'a Value> {

--- a/crates/copybook-codec/tests/comprehensive_redefines_odo_tests.rs
+++ b/crates/copybook-codec/tests/comprehensive_redefines_odo_tests.rs
@@ -359,7 +359,7 @@ fn test_odo_decode_clamp_vs_strict() {
 }
 
 #[test]
-fn test_odo_encode_counter_update() {
+fn test_odo_encode_counter_array_mismatch_rejected() {
     let copybook = r#"
 01 ODO-RECORD.
    05 COUNTER PIC 9(2).
@@ -369,22 +369,50 @@ fn test_odo_encode_counter_update() {
     let schema = parse_copybook(copybook).unwrap();
     let options = create_test_encode_options(false);
 
-    // Test encoding with array length different from counter
+    // The counter is encoded independently as a scalar and the array is
+    // written using its own length, so a mismatch between the two must be
+    // rejected rather than silently writing elements the counter doesn't
+    // account for (which would make them unrecoverable on decode).
     let json_data = json!({
         "COUNTER": "02",
         "VARIABLE-ARRAY": ["ABC", "DEF", "GHI"] // 3 elements, counter says 2
     });
 
     let result = copybook_codec::encode_record(&schema, &json_data, &options);
-    assert!(result.is_ok(), "Should succeed and update counter");
+    assert!(
+        result.is_err(),
+        "Counter/array length mismatch must be rejected"
+    );
+    assert_eq!(result.unwrap_err().code, ErrorCode::CBKE521_ARRAY_LEN_OOB);
+}
+
+#[test]
+fn test_odo_encode_counter_array_match_succeeds() {
+    let copybook = r#"
+01 ODO-RECORD.
+   05 COUNTER PIC 9(2).
+   05 VARIABLE-ARRAY OCCURS 1 TO 5 TIMES DEPENDING ON COUNTER PIC X(3).
+"#;
+
+    let schema = parse_copybook(copybook).unwrap();
+    let options = create_test_encode_options(false);
+
+    let json_data = json!({
+        "COUNTER": "03",
+        "VARIABLE-ARRAY": ["ABC", "DEF", "GHI"]
+    });
+
+    let result = copybook_codec::encode_record(&schema, &json_data, &options);
+    assert!(
+        result.is_ok(),
+        "Matching counter/array length should succeed"
+    );
 
     let encoded_data = result.unwrap();
-
-    // Counter is encoded from the provided JSON and array elements are encoded in order.
-    assert_eq!(&encoded_data[0..2], b"02"); // Counter remains as provided
-    assert_eq!(&encoded_data[2..5], [0, 0, 0]); // Array elements are not encoded yet in this path
-    assert_eq!(&encoded_data[5..8], [0, 0, 0]);
-    assert_eq!(&encoded_data[8..11], [0, 0, 0]);
+    assert_eq!(&encoded_data[0..2], b"03");
+    assert_eq!(&encoded_data[2..5], b"ABC");
+    assert_eq!(&encoded_data[5..8], b"DEF");
+    assert_eq!(&encoded_data[8..11], b"GHI");
 }
 
 #[test]

--- a/crates/copybook-codec/tests/odo_comprehensive.rs
+++ b/crates/copybook-codec/tests/odo_comprehensive.rs
@@ -317,7 +317,7 @@ fn test_odo_payload_length_correctness() {
 }
 
 #[test]
-fn test_odo_encode_counter_update() {
+fn test_odo_encode_counter_array_mismatch_rejected() {
     let copybook = r#"
 01 RECORD-LAYOUT.
    05 ITEM-COUNT PIC 9(3).
@@ -326,7 +326,11 @@ fn test_odo_encode_counter_update() {
 
     let schema = parse_copybook(copybook).unwrap();
 
-    // JSON with array length different from counter
+    // JSON with array length different from counter. The counter is encoded
+    // independently as a scalar, and the array is written using its own
+    // length - if the two disagree, the mismatch must be rejected up front
+    // rather than silently writing more elements than the counter says are
+    // present (which would make them unrecoverable on decode).
     let json_data = json!({
         "ITEM-COUNT": "002", // Counter says 2
         "ITEMS": ["ITEM1     ", "ITEM2     ", "ITEM3     "] // But array has 3 items
@@ -344,12 +348,44 @@ fn test_odo_encode_counter_update() {
     let input = Cursor::new(jsonl_data.as_bytes());
     let mut output = Vec::new();
 
-    // Should succeed but does not update counter in current lib_api encoder path
+    let summary =
+        copybook_codec::encode_jsonl_to_file(&schema, input, &mut output, &options).unwrap();
+    assert_eq!(summary.records_with_errors, 1);
+    assert!(output.is_empty());
+}
+
+#[test]
+fn test_odo_encode_counter_array_match_accepted() {
+    let copybook = r#"
+01 RECORD-LAYOUT.
+   05 ITEM-COUNT PIC 9(3).
+   05 ITEMS PIC X(10) OCCURS 0 TO 5 TIMES DEPENDING ON ITEM-COUNT.
+"#;
+
+    let schema = parse_copybook(copybook).unwrap();
+
+    // Counter and array length agree - this must still succeed.
+    let json_data = json!({
+        "ITEM-COUNT": "003",
+        "ITEMS": ["ITEM1     ", "ITEM2     ", "ITEM3     "]
+    });
+
+    let jsonl_data = format!("{json_data}\n");
+
+    let options = EncodeOptions {
+        codepage: Codepage::ASCII,
+        preferred_zoned_encoding: ZonedEncodingFormat::Auto,
+        float_format: copybook_codec::FloatFormat::IeeeBigEndian,
+        ..EncodeOptions::default()
+    };
+
+    let input = Cursor::new(jsonl_data.as_bytes());
+    let mut output = Vec::new();
+
     let summary =
         copybook_codec::encode_jsonl_to_file(&schema, input, &mut output, &options).unwrap();
     assert_eq!(summary.records_with_errors, 0);
 
-    // Decode back to verify counter was updated
     let decode_options = DecodeOptions {
         format: RecordFormat::Fixed,
         codepage: Codepage::ASCII,
@@ -368,11 +404,10 @@ fn test_odo_encode_counter_update() {
 
     let json_record = copybook_codec::decode_record(&schema, &output, &decode_options).unwrap();
 
-    // Counter remains as provided in JSON
-    assert_eq!(json_record["ITEM-COUNT"], "002");
+    assert_eq!(json_record["ITEM-COUNT"], "003");
 
     let items = json_record["ITEMS"].as_array().unwrap();
-    assert_eq!(items.len(), 2);
+    assert_eq!(items.len(), 3);
 }
 
 #[test]

--- a/docs/reference/ERROR_CODES.md
+++ b/docs/reference/ERROR_CODES.md
@@ -576,10 +576,10 @@ String length: 27 exceeds field size 20
 ```
 
 #### CBKE521_ARRAY_LEN_OOB
-**Description**: JSON array length out of bounds for OCCURS
+**Description**: JSON array length out of bounds for OCCURS. Also raised for OCCURS DEPENDING ON (ODO) fields when the JSON counter field's value does not equal the JSON array's length, since the two are encoded independently and a mismatch would silently drop or fabricate elements on decode.
 **Severity**: Fatal
-**Context**: Record number, field path, array length, min/max bounds
-**Resolution**: Adjust array length or OCCURS bounds
+**Context**: Record number, field path, array length, min/max bounds (or counter field, counter value, array length for an ODO counter/array mismatch)
+**Resolution**: Adjust array length or OCCURS bounds, or make the ODO counter value match the array length
 
 ```
 Error: CBKE521_ARRAY_LEN_OOB at record 800


### PR DESCRIPTION
&#60;!-- SPDX-License-Identifier: AGPL-3.0-or-later --&#62;
## Summary

The ODO (`OCCURS ... DEPENDING ON`) encoder wrote the counter field and the variable-length array completely independently: the counter came straight from the JSON value, and the array was written using its own `array.len()`, with no check that the two agreed. If a caller supplied a counter and an array of different lengths, encoding silently succeeded and the "extra" array elements were written to the record but became **unrecoverable on decode**, since decode trusts the counter field to know how many elements to read back. This violated the project's round-trip determinism invariant with no error or warning surfaced — the existing test even had a comment noting the silent-drop behavior instead of flagging it as a bug.

`validate_lib_api_odo_encoding` (`crates/copybook-codec/src/lib_api.rs`) now parses the JSON counter value and rejects the record with `CBKE521_ARRAY_LEN_OOB` when it doesn't match the array length, instead of guessing which side is authoritative.

## Type of Change

- [ ] Feature (new functionality)
- [x] Bugfix (fixes an issue)
- [ ] Refactor (code improvement without behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (README, docs/, code comments)
- [ ] Tests (test additions or improvements)
- [ ] CI/CD (workflow or tooling changes)
- [ ] Chore (dependencies, formatting, etc.)

## COBOL/Mainframe Context

- **COBOL features affected**: ODO (OCCURS DEPENDING ON)
- **Data processing impact**: encoding (JSON -> binary record)
- **Mainframe compatibility**: N/A (encoder-side input validation, not a dialect-specific behavior)

## Workspace Crates Affected

- [ ] copybook-core (parsing, schema, AST)
- [x] copybook-codec (encoding, decoding, character conversion)
- [ ] copybook-codec-memory (shared memory primitives for codec hot paths)
- [ ] copybook-cli (CLI commands and options)
- [ ] copybook-gen (test fixture generation)
- [ ] copybook-bench (performance benchmarks)
- [ ] copybook-contracts (feature flag contracts)
- [ ] copybook-support-matrix (COBOL support contract data)
- [ ] copybook-governance-contracts (contracts + support matrix facade)
- [ ] copybook-governance-grid (support-to-flag mapping)
- [ ] copybook-governance-runtime (runtime governance state evaluation)
- [ ] copybook-governance (governance compatibility facade)
- [ ] copybook-bdd (BDD smoke/exploratory runners)

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (`docs/reference/ERROR_CODES.md`)
- [x] CHANGELOG.md updated
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace --lib --bins --examples --all-features -- -D warnings -W clippy::pedantic` passes
- [x] `cargo test --workspace` passes (pre-existing unrelated failures noted below)
- [ ] `bash scripts/ci/governance-bdd-smoke.sh` passes (governance/BDD not touched)
- [x] Follows conventional commit format (`fix(codec):`)
- [x] MSRV compliance (Rust 1.92+) verified — no dependency changes
- [ ] Golden fixtures updated (none affected)

## Testing Instructions

```bash
cargo test -p copybook-codec --features comprehensive-tests --test odo_comprehensive
cargo test -p copybook-codec --features comprehensive-tests --test comprehensive_redefines_odo_tests
cargo clippy -p copybook-codec --lib -- -D warnings -W clippy::pedantic
cargo fmt --all --check
```

A full `cargo test --workspace --all-features --no-fail-fast` run was performed before and after this change. Two pre-existing failure groups are unrelated to this fix and reproduce identically on `main`:
- `copybook-codec::comprehensive_rdw_tests` (`test_rdw_length_recomputation`, `test_rdw_with_odo_variable_length`) — decode-only RDW handling, no ODO-encode path involved.
- `copybook-codec::comprehensive_redefines_odo_tests` (`test_redefines_decode_all_views`, `test_redefines_declaration_order`) and `copybook-codec::integration_odo_redefines` (`test_odo_redefines_integration`, `test_missing_counter_field_error`) — REDEFINES decode/schema issues unrelated to the counter/array-length check.
- `copybook-core` (`bdd_error_handling_scenarios`, `comprehensive_parser_tests`, `parser_fixtures`, `schema_validation_edge_cases`) — SIGN SEPARATE / edited-PIC parser tests, unrelated to `copybook-codec`.

Both were verified to fail identically with this branch's changes stashed out, confirming they predate this fix.

## Performance Impact

- [x] No performance impact expected (one extra JSON value parse + integer comparison on the ODO tail-array encode path only)

## Breaking Changes

- [x] No breaking changes to the public API surface or error taxonomy (reuses the existing `CBKE521_ARRAY_LEN_OOB` code).
- Note: input that previously encoded "successfully" while silently dropping array elements (counter/array length mismatch) will now return `CBKE521_ARRAY_LEN_OOB` instead. This is the intended fix — the old behavior was silent data loss.

## Related Issues

N/A — found via proactive codebase review, not tied to a filed issue.

## Additional Notes

Root cause: `validate_lib_api_odo_encoding` validated that the counter field was *present* in the JSON and that `array.len()` itself fell within the schema's min/max bounds, but never checked that the counter's *value* equaled `array.len()`. Since the counter is encoded independently as a scalar field via the normal field-encode path, and the array is encoded separately using `array.len()`, the two could silently diverge in the emitted binary record.