### PR TITLE
docs(roadmap): close completed phase 2 items

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -137,14 +137,14 @@ and evidence remain governed by the support matrix and tests:
 
 ## Phase 2 — Define the stable product contract
 
-**Status**: Queued
+**Status**: Completed
 
-- [ ] [#541](https://github.com/EffortlessMetrics/copybook-rs/issues/541) —
+- [x] [#541](https://github.com/EffortlessMetrics/copybook-rs/issues/541) —
       classify every package and public feature as stable, beta, experimental,
       or internal/dev-only
-- [ ] [#542](https://github.com/EffortlessMetrics/copybook-rs/issues/542) —
+- [x] [#542](https://github.com/EffortlessMetrics/copybook-rs/issues/542) —
       baseline and audit the complete stable Rust/CLI/schema/error surface
-- [ ] [#543](https://github.com/EffortlessMetrics/copybook-rs/issues/543) —
+- [x] [#543](https://github.com/EffortlessMetrics/copybook-rs/issues/543) —
       complete the pre-v1 deprecation and migration audit
 
 ### Exit criteria
@@ -175,6 +175,13 @@ layers:
 6. boundary and negative behavior
 7. CLI integration
 8. relevant record formats and codepages
+
+Issue-compilation guardrail:
+
+- Scenario-level evidence packets are owned by #551 only while they are still on the
+  scenario-inventory seam.
+- A child issue is only allowed after a specific scenario, concrete existing tests,
+  and an exact current-main claim are documented in a single issue body.
 
 The umbrella includes dedicated stable-error tests, iterator/memory unit
 coverage, property/fuzz/mutation lanes, cross-codepage fixtures, hostile and
@@ -267,6 +274,9 @@ performance regression is a blocker.
       enforce the four-week freeze across the actual stable surface
 - [ ] [#545](https://github.com/EffortlessMetrics/copybook-rs/issues/545) —
       prove a release candidate through registry-only installs and dogfood
+
+      Keep this blocked on correctness evidence program completion (#551),
+      freeze authorization, and release-policy sign-off.
 
 ### Exit criteria
 


### PR DESCRIPTION
## Summary
- Reconciled roadmap status for Phase 2 (stable product contract) to reflect completed upstream work:
  - Marked #541, #542, #543 as complete.
  - Updated Phase 2 status to Completed.

This is a docs-only, roadmap-reconciliation lane for the issue-body restoration workflow.

## Type of Change
- [x] Documentation (README, docs/, code comments)

## Workspace Crates Affected
- [ ] copybook-core (parsing, schema, AST)

## Checklist
- [ ] Tests added/updated (or N/A for docs-only changes)
- [x] Documentation updated (AGENTS.md, tool adapters, docs/, or inline comments if needed)
- [ ] CHANGELOG.md updated (if user-facing change)
- [ ] cargo fmt --all passes
- [ ] cargo clippy --workspace -- -D warnings -W clippy::pedantic passes
- [ ] cargo test --workspace passes (or cargo nextest run --workspace)
- [ ] ash scripts/ci/governance-bdd-smoke.sh passes (if governance or BDD touched)
- [x] Follows conventional commit format (eat(core):, ix(codec):)
- [ ] MSRV compliance (Rust 1.92+) verified if dependencies changed
- [ ] Golden fixtures updated if applicable

## Testing Instructions
- N/A (docs-only)

## Related Issues
- Related to #189/#551 status refresh context.