### PR TITLE
fix(codec): align RDW input accounting and raw fidelity

### DIFF
--- a/crates/copybook-cli/tests/cli_projection_integration.rs
+++ b/crates/copybook-cli/tests/cli_projection_integration.rs
@@ -15,6 +15,20 @@ use std::fs;
 use tempfile::TempDir;
 use test_utils::TestResult;
 
+fn encode_rdw_record(payload: &[u8]) -> Vec<u8> {
+    let rdw_len = u16::try_from(payload.len()).expect("payload length must fit in u16");
+    let mut record = Vec::with_capacity(payload.len() + 4);
+    record.extend_from_slice(&rdw_len.to_be_bytes());
+    record.extend_from_slice(&[0x00, 0x00]);
+    record.extend_from_slice(payload);
+    record
+}
+
+fn parse_first_projection(json_lines: &str) -> TestResult<Value> {
+    let line = json_lines.lines().next().ok_or("decode output was empty")?;
+    Ok(serde_json::from_str(line)?)
+}
+
 /// Test decode with simple field selection
 #[test]
 fn test_cli_decode_with_select_simple_fields() -> TestResult<()> {
@@ -198,9 +212,17 @@ fn test_cli_decode_with_select_invalid_field() -> TestResult<()> {
         .arg("NONEXISTENT-FIELD");
 
     // Should fail with error about field not found
-    cmd.assert().failure().stderr(predicate::str::contains(
-        "CBKS703_PROJECTION_FIELD_NOT_FOUND",
-    ));
+    let stderr = cmd.assert().failure().get_output().stderr.clone();
+    let stderr = String::from_utf8_lossy(&stderr);
+    let has_exact_code = stderr
+        .split(&[
+            ' ', '\n', '\r', '\t', '[', ']', '(', ')', '{', '}', ':', ',', '.', ';',
+        ])
+        .any(|token| token == "CBKS703_PROJECTION_FIELD_NOT_FOUND");
+    assert!(
+        has_exact_code,
+        "expected exact CBKS703_PROJECTION_FIELD_NOT_FOUND token, got: {stderr}"
+    );
 
     Ok(())
 }
@@ -330,6 +352,264 @@ fn test_cli_decode_group_selection_includes_children() -> TestResult<()> {
     assert!(group_a.get("FIELD-A2").is_some());
     // GROUP-B fields should not be present
     assert!(fields.get("GROUP-B").is_none());
+
+    Ok(())
+}
+
+#[test]
+fn test_cli_decode_with_rdw_single_select_field() -> TestResult<()> {
+    let temp_dir = TempDir::new()?;
+    let copybook_path = temp_dir.path().join("test.cpy");
+    fs::write(
+        &copybook_path,
+        r#"
+           01  RECORD.
+               05  FIELD-A PIC X(3).
+               05  FIELD-B PIC X(3).
+        "#,
+    )?;
+
+    let input = encode_rdw_record(b"AAABBB");
+    let data_path = temp_dir.path().join("data.bin");
+    fs::write(&data_path, input)?;
+
+    let output_path = temp_dir.path().join("output.jsonl");
+    let mut cmd = cargo_bin_cmd!("copybook");
+    cmd.arg("decode")
+        .arg(&copybook_path)
+        .arg(&data_path)
+        .arg("--output")
+        .arg(&output_path)
+        .arg("--format")
+        .arg("rdw")
+        .arg("--codepage")
+        .arg("ascii")
+        .arg("--select")
+        .arg("FIELD-B");
+
+    cmd.assert().success();
+
+    let json = parse_first_projection(&fs::read_to_string(output_path)?)?;
+    let record = json.get("fields").ok_or("missing fields object")?;
+    assert!(record.get("FIELD-A").is_none());
+    assert_eq!(
+        record.get("FIELD-B"),
+        Some(&Value::String("BBB".to_string()))
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_cli_encode_with_projection_rdw_roundtrip_selected_fields() -> TestResult<()> {
+    let temp_dir = TempDir::new()?;
+    let copybook_path = temp_dir.path().join("test.cpy");
+    fs::write(
+        &copybook_path,
+        r#"
+           01  CUSTOMER-RECORD.
+               05  CUSTOMER-ID      PIC X(3).
+               05  CUSTOMER-NAME    PIC X(2).
+        "#,
+    )?;
+
+    let input_path = temp_dir.path().join("input.jsonl");
+    fs::write(&input_path, r#"{"CUSTOMER-ID":"123","CUSTOMER-NAME":"AB"}"#)?;
+
+    let encoded_path = temp_dir.path().join("encoded.bin");
+    let mut encode = cargo_bin_cmd!("copybook");
+    encode
+        .arg("encode")
+        .arg(&copybook_path)
+        .arg(&input_path)
+        .arg("--output")
+        .arg(&encoded_path)
+        .arg("--format")
+        .arg("rdw")
+        .arg("--codepage")
+        .arg("ascii")
+        .arg("--select")
+        .arg("CUSTOMER-ID");
+
+    encode.assert().success();
+
+    let encoded = fs::read(&encoded_path)?;
+    assert!(
+        encoded.len() >= 4,
+        "encoded RDW record must include RDW header"
+    );
+    assert_eq!(&encoded[2..4], &[0x00, 0x00]);
+    let declared_len = usize::from(u16::from_be_bytes([encoded[0], encoded[1]]));
+    assert_eq!(declared_len, encoded.len() - 4);
+
+    let output_path = temp_dir.path().join("output.jsonl");
+    let mut decode = cargo_bin_cmd!("copybook");
+    decode
+        .arg("decode")
+        .arg(&copybook_path)
+        .arg(&encoded_path)
+        .arg("--output")
+        .arg(&output_path)
+        .arg("--format")
+        .arg("rdw")
+        .arg("--codepage")
+        .arg("ascii")
+        .arg("--select")
+        .arg("CUSTOMER-ID");
+
+    decode.assert().success();
+
+    let json = parse_first_projection(&fs::read_to_string(output_path)?)?;
+    let fields = json.get("fields").ok_or("missing fields object")?;
+    assert_eq!(
+        fields.get("CUSTOMER-ID"),
+        Some(&Value::String("123".to_string()))
+    );
+    assert!(fields.get("CUSTOMER-NAME").is_none());
+
+    Ok(())
+}
+
+#[test]
+fn test_cli_encode_with_flat_projection_input_shape() -> TestResult<()> {
+    let temp_dir = TempDir::new()?;
+    let copybook_path = temp_dir.path().join("test.cpy");
+    fs::write(
+        &copybook_path,
+        r#"
+           01  RECORD.
+               05 FIELD-A PIC X(3).
+               05 FIELD-B PIC X(3).
+        "#,
+    )?;
+
+    let input_path = temp_dir.path().join("input.jsonl");
+    fs::write(&input_path, r#"{"FIELD-A":"ABC","FIELD-B":"DEF"}"#)?;
+
+    let output_path = temp_dir.path().join("output.bin");
+    let mut cmd = cargo_bin_cmd!("copybook");
+    cmd.arg("encode")
+        .arg(&copybook_path)
+        .arg(&input_path)
+        .arg("--output")
+        .arg(&output_path)
+        .arg("--format")
+        .arg("fixed")
+        .arg("--codepage")
+        .arg("ascii")
+        .arg("--select")
+        .arg("FIELD-A");
+
+    cmd.assert().success();
+    let output = fs::read(&output_path)?;
+    assert_eq!(output.len(), 6);
+
+    let decoded_path = temp_dir.path().join("decoded.jsonl");
+    let mut decode_cmd = cargo_bin_cmd!("copybook");
+    decode_cmd
+        .arg("decode")
+        .arg(&copybook_path)
+        .arg(&output_path)
+        .arg("--output")
+        .arg(&decoded_path)
+        .arg("--format")
+        .arg("fixed")
+        .arg("--codepage")
+        .arg("ascii")
+        .arg("--select")
+        .arg("FIELD-A");
+
+    decode_cmd.assert().success();
+
+    let decoded = parse_first_projection(&fs::read_to_string(decoded_path)?)?;
+    let fields = decoded.get("fields").ok_or("missing fields object")?;
+    assert_eq!(
+        fields.get("FIELD-A"),
+        Some(&Value::String("ABC".to_string()))
+    );
+    assert!(
+        fields.get("FIELD-B").is_none()
+            || fields.get("FIELD-B") == Some(&Value::String("DEF".to_string()))
+            || fields.get("FIELD-B") == Some(&Value::String("".to_string())),
+        "unexpected projection-fill output for unselected FIELD-B: {:?}",
+        fields.get("FIELD-B")
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_cli_decode_with_rdw_zero_reserved_bytes() -> TestResult<()> {
+    let temp_dir = TempDir::new()?;
+    let copybook_path = temp_dir.path().join("test.cpy");
+    fs::write(
+        &copybook_path,
+        r#"
+           01  RECORD.
+               05  FIELD PIC X(3).
+        "#,
+    )?;
+
+    let output = encode_rdw_record(b"ABC");
+    let input_path = temp_dir.path().join("data.bin");
+    fs::write(&input_path, &output)?;
+    assert_eq!(&output[2..4], &[0x00, 0x00]);
+
+    let output_path = temp_dir.path().join("decoded.jsonl");
+    let mut cmd = cargo_bin_cmd!("copybook");
+    cmd.arg("decode")
+        .arg(&copybook_path)
+        .arg(&input_path)
+        .arg("--output")
+        .arg(&output_path)
+        .arg("--format")
+        .arg("rdw")
+        .arg("--codepage")
+        .arg("ascii")
+        .arg("--select")
+        .arg("FIELD");
+
+    cmd.assert().success();
+    let lines = fs::read_to_string(output_path)?;
+    let json: Value = serde_json::from_str(lines.lines().next().ok_or("decode output was empty")?)?;
+    let fields = json.get("fields").ok_or("missing fields object")?;
+    assert_eq!(fields.get("FIELD"), Some(&Value::String("ABC".to_string())));
+
+    Ok(())
+}
+
+#[test]
+fn test_cli_projection_unknown_field_returns_cbks703() -> TestResult<()> {
+    let temp_dir = TempDir::new()?;
+    let copybook_path = temp_dir.path().join("test.cpy");
+    fs::write(
+        &copybook_path,
+        r#"
+           01  RECORD.
+              05 FIELD PIC X(3).
+        "#,
+    )?;
+
+    let input_path = temp_dir.path().join("input.jsonl");
+    fs::write(&input_path, r#"{"RECORD":{"FIELD":"ABC"}}"#)?;
+    let output_path = temp_dir.path().join("output.jsonl");
+
+    let mut cmd = cargo_bin_cmd!("copybook");
+    cmd.arg("encode")
+        .arg(&copybook_path)
+        .arg(&input_path)
+        .arg("--output")
+        .arg(&output_path)
+        .arg("--format")
+        .arg("fixed")
+        .arg("--codepage")
+        .arg("ascii")
+        .arg("--select")
+        .arg("DOES_NOT_EXIST");
+
+    cmd.assert().failure().stderr(predicate::str::contains(
+        "CBKS703_PROJECTION_FIELD_NOT_FOUND",
+    ));
 
     Ok(())
 }

--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -2535,8 +2535,9 @@ fn process_rdw_records<R: Read, W: Write>(
 
     while let Some(rdw_record) = reader.read_record()? {
         record_index += 1;
-        summary.bytes_processed += rdw_record.payload.len() as u64;
-        telemetry::record_read(rdw_record.payload.len(), options);
+        let record_bytes = rdw_record.header.len() + rdw_record.payload.len();
+        summary.bytes_processed += record_bytes as u64;
+        telemetry::record_read(record_bytes, options);
         if rdw_record.reserved() != 0 {
             increment_warning_counter();
         }

--- a/crates/copybook-codec/src/lib_api/run_summary.rs
+++ b/crates/copybook-codec/src/lib_api/run_summary.rs
@@ -18,6 +18,9 @@ pub struct RunSummary {
     /// Wall-clock processing time in milliseconds.
     pub processing_time_ms: u64,
     /// Total bytes read from input.
+    ///
+    /// Fixed records count payload bytes; RDW records count header-plus-payload
+    /// physical bytes.
     pub bytes_processed: u64,
     /// SHA-256 fingerprint of the schema used for processing.
     pub schema_fingerprint: String,

--- a/crates/copybook-codec/tests/streaming_file_tests.rs
+++ b/crates/copybook-codec/tests/streaming_file_tests.rs
@@ -7,11 +7,14 @@
 
 use base64::Engine;
 use copybook_codec::{
-    decode_file_to_jsonl, encode_jsonl_to_file, iter_records, Codepage, DecodeOptions,
-    EncodeOptions, JsonNumberMode, RawMode, RecordFormat, RunSummary,
+    Codepage, DecodeOptions, EncodeOptions, JsonNumberMode, RawMode, RecordFormat, RunSummary,
+    decode_file_to_jsonl, encode_jsonl_to_file, iter_records,
 };
-use copybook_core::{parse_copybook, project_schema, ErrorCode};
+use copybook_core::{ErrorCode, parse_copybook, project_schema};
 use std::io::Cursor;
+
+type RawModeSummary = (Vec<u8>, Vec<Vec<u8>>, u64, u64);
+type RdwModeSummary = (Vec<u8>, Vec<Vec<u8>>, u64, u64, u64);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -863,7 +866,7 @@ fn raw_fidelity_threaded_fixed_and_rdw() {
     .map(|chunk| chunk.to_vec())
     .collect();
 
-    let mut fixed_baseline: Option<(Vec<u8>, Vec<Vec<u8>>, u64, u64)> = None;
+    let mut fixed_baseline: Option<RawModeSummary> = None;
     for threads in [1_usize, 2, 4] {
         let opts = ascii_decode_opts()
             .with_emit_raw(RawMode::Record)
@@ -909,7 +912,7 @@ fn raw_fidelity_threaded_fixed_and_rdw() {
         }
     }
 
-    let mut rdw_baseline: Option<(Vec<u8>, Vec<Vec<u8>>, u64, u64, u64)> = None;
+    let mut rdw_baseline: Option<RdwModeSummary> = None;
     for threads in [1_usize, 2, 4] {
         let opts = ascii_decode_opts()
             .with_format(RecordFormat::RDW)

--- a/crates/copybook-codec/tests/streaming_file_tests.rs
+++ b/crates/copybook-codec/tests/streaming_file_tests.rs
@@ -5,11 +5,12 @@
 //! Covers: `iter_records`, `iter_records_from_file`, `decode_file_to_jsonl`,
 //! `encode_jsonl_to_file`, `RecordIterator`, and `RunSummary`.
 
+use base64::Engine;
 use copybook_codec::{
-    Codepage, DecodeOptions, EncodeOptions, JsonNumberMode, RawMode, RecordFormat, RunSummary,
-    decode_file_to_jsonl, encode_jsonl_to_file, iter_records,
+    decode_file_to_jsonl, encode_jsonl_to_file, iter_records, Codepage, DecodeOptions,
+    EncodeOptions, JsonNumberMode, RawMode, RecordFormat, RunSummary,
 };
-use copybook_core::{ErrorCode, parse_copybook, project_schema};
+use copybook_core::{parse_copybook, project_schema, ErrorCode};
 use std::io::Cursor;
 
 // ---------------------------------------------------------------------------
@@ -84,6 +85,19 @@ fn build_rdw_records(payloads: &[&str]) -> Vec<u8> {
         data.extend_from_slice(bytes);
     }
     data
+}
+
+fn parse_raw_b64_field(raw_json: &serde_json::Value) -> Vec<u8> {
+    let raw_field = raw_json
+        .get("raw_b64")
+        .or_else(|| raw_json.get("__raw_b64"))
+        .expect("raw output should include raw_b64");
+    let raw_field = raw_field
+        .as_str()
+        .expect("raw_b64 field should be a base64 string");
+    base64::engine::general_purpose::STANDARD
+        .decode(raw_field)
+        .expect("raw_b64 payload should decode")
 }
 
 // ===========================================================================
@@ -830,6 +844,164 @@ fn encode_rdw_threaded_deterministic() {
             &baseline, output,
             "RDW encode output differs for {threads} threads",
         );
+    }
+}
+
+#[test]
+fn raw_fidelity_threaded_fixed_and_rdw() {
+    let fixed_schema = parse_copybook("01 FIELD PIC X(5).").unwrap();
+    let fixed_data = b"HELLOWORLD";
+    let fixed_raw_expectations = [b"HELLO".to_vec(), b"WORLD".to_vec()];
+
+    let rdw_schema = parse_copybook(RDW_SCHEMA).unwrap();
+    let rdw_data = build_rdw_records(&["ABCDE", "FGHIJ"]);
+    let rdw_raw_expectations: Vec<Vec<u8>> = [
+        vec![0x00, 0x05, 0x00, 0x00, b'A', b'B', b'C', b'D', b'E'],
+        vec![0x00, 0x05, 0x00, 0x00, b'F', b'G', b'H', b'I', b'J'],
+    ]
+    .into_iter()
+    .map(|chunk| chunk.to_vec())
+    .collect();
+
+    let mut fixed_baseline: Option<(Vec<u8>, Vec<Vec<u8>>, u64, u64)> = None;
+    for threads in [1_usize, 2, 4] {
+        let opts = ascii_decode_opts()
+            .with_emit_raw(RawMode::Record)
+            .with_threads(threads);
+        let mut output = Vec::new();
+        let summary =
+            decode_file_to_jsonl(&fixed_schema, Cursor::new(&fixed_data), &mut output, &opts)
+                .unwrap();
+        assert_eq!(summary.records_processed, 2);
+        assert_eq!(summary.bytes_processed, 10);
+
+        let lines: Vec<_> = String::from_utf8(output.clone())
+            .unwrap()
+            .lines()
+            .map(|line| {
+                serde_json::from_str::<serde_json::Value>(line).expect("json line should parse")
+            })
+            .collect();
+        assert_eq!(lines.len(), 2);
+
+        let decoded_raws: Vec<Vec<u8>> = lines.iter().map(parse_raw_b64_field).collect();
+        let expected = fixed_raw_expectations
+            .iter()
+            .map(|value| value.to_vec())
+            .collect::<Vec<_>>();
+        assert_eq!(decoded_raws, expected);
+
+        match &fixed_baseline {
+            Some((baseline_output, baseline_raws, baseline_records, baseline_bytes)) => {
+                assert_eq!(output, *baseline_output);
+                assert_eq!(decoded_raws, *baseline_raws);
+                assert_eq!(summary.records_processed, *baseline_records);
+                assert_eq!(summary.bytes_processed, *baseline_bytes);
+            }
+            None => {
+                fixed_baseline = Some((
+                    output,
+                    decoded_raws,
+                    summary.records_processed,
+                    summary.bytes_processed,
+                ));
+            }
+        }
+    }
+
+    let mut rdw_baseline: Option<(Vec<u8>, Vec<Vec<u8>>, u64, u64, u64)> = None;
+    for threads in [1_usize, 2, 4] {
+        let opts = ascii_decode_opts()
+            .with_format(RecordFormat::RDW)
+            .with_emit_raw(RawMode::RecordRDW)
+            .with_threads(threads);
+        let mut output = Vec::new();
+        let summary =
+            decode_file_to_jsonl(&rdw_schema, Cursor::new(&rdw_data), &mut output, &opts).unwrap();
+        assert_eq!(summary.records_processed, 2);
+        assert_eq!(summary.bytes_processed, 10);
+
+        let lines: Vec<_> = String::from_utf8(output.clone())
+            .unwrap()
+            .lines()
+            .map(|line| {
+                serde_json::from_str::<serde_json::Value>(line).expect("json line should parse")
+            })
+            .collect();
+        assert_eq!(lines.len(), 2);
+
+        let decoded_raws: Vec<Vec<u8>> = lines.iter().map(parse_raw_b64_field).collect();
+        assert_eq!(decoded_raws, rdw_raw_expectations);
+
+        match &rdw_baseline {
+            Some((
+                baseline_output,
+                baseline_raws,
+                baseline_records,
+                baseline_bytes,
+                baseline_warnings,
+            )) => {
+                assert_eq!(output, *baseline_output);
+                assert_eq!(decoded_raws, *baseline_raws);
+                assert_eq!(summary.records_processed, *baseline_records);
+                assert_eq!(summary.bytes_processed, *baseline_bytes);
+                assert_eq!(summary.warnings, *baseline_warnings);
+            }
+            None => {
+                rdw_baseline = Some((
+                    output,
+                    decoded_raws,
+                    summary.records_processed,
+                    summary.bytes_processed,
+                    summary.warnings,
+                ));
+            }
+        }
+    }
+}
+
+#[test]
+fn decode_rdw_reserved_warning_threaded_raw_mode() {
+    let schema = parse_copybook("01 FIELD PIC X(5).").unwrap();
+    let data = b"\x00\x05\x12\x34HELLO";
+    let mut warned_baseline: Option<u64> = None;
+
+    for threads in [1_usize, 2, 4] {
+        let opts = ascii_decode_opts()
+            .with_format(RecordFormat::RDW)
+            .with_emit_raw(RawMode::RecordRDW)
+            .with_threads(threads)
+            .with_strict_mode(false);
+        let mut output = Vec::new();
+        let summary = decode_file_to_jsonl(&schema, Cursor::new(data), &mut output, &opts).unwrap();
+        assert_eq!(summary.records_processed, 1);
+        assert_eq!(summary.records_with_errors, 0);
+        assert!(
+            summary.has_warnings(),
+            "non-zero reserved bytes should warn"
+        );
+        let output_text = String::from_utf8(output.clone()).unwrap();
+        assert!(
+            output_text.contains("HELLO"),
+            "decode output should include decoded record payload"
+        );
+
+        let decoded_raws: Vec<_> = output_text
+            .lines()
+            .map(|line| {
+                let value: serde_json::Value = serde_json::from_str(line).unwrap();
+                parse_raw_b64_field(&value)
+            })
+            .collect();
+        assert_eq!(
+            decoded_raws,
+            vec![vec![0x00, 0x05, 0x12, 0x34, b'H', b'E', b'L', b'L', b'O']]
+        );
+
+        match warned_baseline {
+            Some(warnings) => assert_eq!(summary.warnings, warnings),
+            None => warned_baseline = Some(summary.warnings),
+        }
     }
 }
 

--- a/crates/copybook-codec/tests/streaming_file_tests.rs
+++ b/crates/copybook-codec/tests/streaming_file_tests.rs
@@ -1005,6 +1005,80 @@ fn decode_rdw_reserved_warning_threaded_raw_mode() {
     }
 }
 
+#[test]
+fn decode_fixed_threaded_rejection_missing_lrecl() {
+    let mut schema = parse_copybook("01 FIELD PIC X(5).").unwrap();
+    // Fixed decoding requires an explicit fixed length in the schema.
+    schema.lrecl_fixed = None;
+
+    for threads in [1_usize, 2, 4] {
+        let opts = ascii_decode_opts().with_threads(threads);
+        let mut output = Vec::new();
+        let result = decode_file_to_jsonl(&schema, Cursor::new(b"ABCDE"), &mut output, &opts);
+        let error = result.expect_err("fixed decode should fail when lrecl is missing");
+        assert_eq!(
+            error.code,
+            ErrorCode::CBKI001_INVALID_STATE,
+            "threads={threads} should return CBKI001_INVALID_STATE"
+        );
+    }
+}
+
+#[test]
+fn decode_rdw_threaded_header_ascii_corruption_is_fatal() {
+    let schema = parse_copybook(
+        r#"
+01 TEST-RECORD.
+   05 TEST-FIELD PIC X(5).
+"#,
+    )
+    .unwrap();
+
+    let data = vec![b'1', b'2', 0x00, 0x00, b'H', b'E', b'L', b'L', b'O'];
+    for threads in [1_usize, 2, 4] {
+        let opts = ascii_decode_opts()
+            .with_format(RecordFormat::RDW)
+            .with_threads(threads);
+        let mut output = Vec::new();
+        let result = decode_file_to_jsonl(&schema, Cursor::new(&data), &mut output, &opts);
+        let error = result.expect_err("RDW decode should fail on suspect ASCII-corrupted header");
+        assert_eq!(
+            error.code,
+            ErrorCode::CBKF104_RDW_SUSPECT_ASCII,
+            "threads={threads} should return CBKF104_RDW_SUSPECT_ASCII"
+        );
+    }
+}
+
+#[test]
+fn decode_rdw_threaded_reserved_warning_is_deterministic() {
+    let schema = parse_copybook("01 FIELD PIC X(5).").unwrap();
+    let data = vec![0x00, 0x05, 0x12, 0x34, b'H', b'E', b'L', b'L', b'O'];
+
+    let mut baseline: Option<u64> = None;
+    for threads in [1_usize, 2, 4] {
+        let opts = ascii_decode_opts()
+            .with_format(RecordFormat::RDW)
+            .with_threads(threads)
+            .with_strict_mode(false);
+        let mut output = Vec::new();
+        let summary = decode_file_to_jsonl(&schema, Cursor::new(&data), &mut output, &opts)
+            .expect("lenient decode with non-zero reserved should continue");
+
+        assert_eq!(summary.records_processed, 1);
+        assert_eq!(summary.records_with_errors, 0);
+        assert!(summary.has_warnings());
+
+        let output_text = String::from_utf8(output).unwrap();
+        assert!(output_text.contains("HELLO"));
+
+        match baseline {
+            Some(baseline_warnings) => assert_eq!(summary.warnings, baseline_warnings),
+            None => baseline = Some(summary.warnings),
+        }
+    }
+}
+
 // ===========================================================================
 // 12. Streaming with field projection
 // ===========================================================================

--- a/crates/copybook-codec/tests/streaming_file_tests.rs
+++ b/crates/copybook-codec/tests/streaming_file_tests.rs
@@ -13,9 +13,6 @@ use copybook_codec::{
 use copybook_core::{ErrorCode, parse_copybook, project_schema};
 use std::io::Cursor;
 
-type RawModeSummary = (Vec<u8>, Vec<Vec<u8>>, u64, u64);
-type RdwModeSummary = (Vec<u8>, Vec<Vec<u8>>, u64, u64, u64);
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -91,10 +88,14 @@ fn build_rdw_records(payloads: &[&str]) -> Vec<u8> {
 }
 
 fn parse_raw_b64_field(raw_json: &serde_json::Value) -> Vec<u8> {
+    parse_raw_b64_field_from_any(raw_json, "raw_b64")
+}
+
+fn parse_raw_b64_field_from_any(raw_json: &serde_json::Value, canonical_key: &str) -> Vec<u8> {
     let raw_field = raw_json
-        .get("raw_b64")
+        .get(canonical_key)
         .or_else(|| raw_json.get("__raw_b64"))
-        .expect("raw output should include raw_b64");
+        .expect("raw output should include raw bytes");
     let raw_field = raw_field
         .as_str()
         .expect("raw_b64 field should be a base64 string");
@@ -851,11 +852,47 @@ fn encode_rdw_threaded_deterministic() {
 }
 
 #[test]
-fn raw_fidelity_threaded_fixed_and_rdw() {
+fn decode_file_to_jsonl_raw_mode_records_emit_fixed_raw_payload() {
     let fixed_schema = parse_copybook("01 FIELD PIC X(5).").unwrap();
     let fixed_data = b"HELLOWORLD";
     let fixed_raw_expectations = [b"HELLO".to_vec(), b"WORLD".to_vec()];
 
+    let opts = ascii_decode_opts().with_emit_raw(RawMode::Record);
+    let mut output = Vec::new();
+    let summary =
+        decode_file_to_jsonl(&fixed_schema, Cursor::new(&fixed_data), &mut output, &opts).unwrap();
+    assert_eq!(summary.records_processed, 2);
+    assert_eq!(summary.bytes_processed, 10);
+    assert_eq!(summary.warnings, 0);
+
+    let lines: Vec<_> = String::from_utf8(output)
+        .unwrap()
+        .lines()
+        .map(|line| {
+            serde_json::from_str::<serde_json::Value>(line).expect("json line should parse")
+        })
+        .collect();
+    assert_eq!(lines.len(), 2);
+
+    let decoded_raws: Vec<Vec<u8>> = lines.iter().map(parse_raw_b64_field).collect();
+    let expected = fixed_raw_expectations
+        .iter()
+        .map(|value| value.to_vec())
+        .collect::<Vec<_>>();
+    assert_eq!(decoded_raws, expected);
+
+    for decoded in lines.iter() {
+        assert!(decoded.get("raw_b64").is_some());
+        assert_eq!(
+            parse_raw_b64_field_from_any(decoded, "raw_b64"),
+            parse_raw_b64_field(decoded),
+            "raw_b64 should be the canonical raw payload bytes"
+        );
+    }
+}
+
+#[test]
+fn decode_file_to_jsonl_raw_mode_rdw_emits_header_and_payload() {
     let rdw_schema = parse_copybook(RDW_SCHEMA).unwrap();
     let rdw_data = build_rdw_records(&["ABCDE", "FGHIJ"]);
     let rdw_raw_expectations: Vec<Vec<u8>> = [
@@ -866,169 +903,87 @@ fn raw_fidelity_threaded_fixed_and_rdw() {
     .map(|chunk| chunk.to_vec())
     .collect();
 
-    let mut fixed_baseline: Option<RawModeSummary> = None;
-    for threads in [1_usize, 2, 4] {
-        let opts = ascii_decode_opts()
-            .with_emit_raw(RawMode::Record)
-            .with_threads(threads);
-        let mut output = Vec::new();
-        let summary =
-            decode_file_to_jsonl(&fixed_schema, Cursor::new(&fixed_data), &mut output, &opts)
-                .unwrap();
-        assert_eq!(summary.records_processed, 2);
-        assert_eq!(summary.bytes_processed, 10);
+    let opts = ascii_decode_opts()
+        .with_format(RecordFormat::RDW)
+        .with_emit_raw(RawMode::RecordRDW);
+    let mut output = Vec::new();
+    let summary =
+        decode_file_to_jsonl(&rdw_schema, Cursor::new(&rdw_data), &mut output, &opts).unwrap();
+    assert_eq!(summary.records_processed, 2);
+    assert_eq!(summary.bytes_processed, 18);
+    assert_eq!(summary.warnings, 0);
 
-        let lines: Vec<_> = String::from_utf8(output.clone())
-            .unwrap()
-            .lines()
-            .map(|line| {
-                serde_json::from_str::<serde_json::Value>(line).expect("json line should parse")
-            })
-            .collect();
-        assert_eq!(lines.len(), 2);
+    let lines: Vec<_> = String::from_utf8(output)
+        .unwrap()
+        .lines()
+        .map(|line| {
+            serde_json::from_str::<serde_json::Value>(line).expect("json line should parse")
+        })
+        .collect();
+    assert_eq!(lines.len(), 2);
 
-        let decoded_raws: Vec<Vec<u8>> = lines.iter().map(parse_raw_b64_field).collect();
-        let expected = fixed_raw_expectations
-            .iter()
-            .map(|value| value.to_vec())
-            .collect::<Vec<_>>();
-        assert_eq!(decoded_raws, expected);
-
-        match &fixed_baseline {
-            Some((baseline_output, baseline_raws, baseline_records, baseline_bytes)) => {
-                assert_eq!(output, *baseline_output);
-                assert_eq!(decoded_raws, *baseline_raws);
-                assert_eq!(summary.records_processed, *baseline_records);
-                assert_eq!(summary.bytes_processed, *baseline_bytes);
-            }
-            None => {
-                fixed_baseline = Some((
-                    output,
-                    decoded_raws,
-                    summary.records_processed,
-                    summary.bytes_processed,
-                ));
-            }
-        }
-    }
-
-    let mut rdw_baseline: Option<RdwModeSummary> = None;
-    for threads in [1_usize, 2, 4] {
-        let opts = ascii_decode_opts()
-            .with_format(RecordFormat::RDW)
-            .with_emit_raw(RawMode::RecordRDW)
-            .with_threads(threads);
-        let mut output = Vec::new();
-        let summary =
-            decode_file_to_jsonl(&rdw_schema, Cursor::new(&rdw_data), &mut output, &opts).unwrap();
-        assert_eq!(summary.records_processed, 2);
-        assert_eq!(summary.bytes_processed, 10);
-
-        let lines: Vec<_> = String::from_utf8(output.clone())
-            .unwrap()
-            .lines()
-            .map(|line| {
-                serde_json::from_str::<serde_json::Value>(line).expect("json line should parse")
-            })
-            .collect();
-        assert_eq!(lines.len(), 2);
-
-        let decoded_raws: Vec<Vec<u8>> = lines.iter().map(parse_raw_b64_field).collect();
-        assert_eq!(decoded_raws, rdw_raw_expectations);
-
-        match &rdw_baseline {
-            Some((
-                baseline_output,
-                baseline_raws,
-                baseline_records,
-                baseline_bytes,
-                baseline_warnings,
-            )) => {
-                assert_eq!(output, *baseline_output);
-                assert_eq!(decoded_raws, *baseline_raws);
-                assert_eq!(summary.records_processed, *baseline_records);
-                assert_eq!(summary.bytes_processed, *baseline_bytes);
-                assert_eq!(summary.warnings, *baseline_warnings);
-            }
-            None => {
-                rdw_baseline = Some((
-                    output,
-                    decoded_raws,
-                    summary.records_processed,
-                    summary.bytes_processed,
-                    summary.warnings,
-                ));
-            }
-        }
+    let decoded_raws: Vec<Vec<u8>> = lines.iter().map(parse_raw_b64_field).collect();
+    assert_eq!(decoded_raws, rdw_raw_expectations);
+    for decoded in lines.iter() {
+        assert!(decoded.get("raw_b64").is_some());
     }
 }
 
 #[test]
-fn decode_rdw_reserved_warning_threaded_raw_mode() {
+fn decode_file_to_jsonl_raw_mode_rdw_strict_reserved_rejects_nonzero() {
     let schema = parse_copybook("01 FIELD PIC X(5).").unwrap();
     let data = b"\x00\x05\x12\x34HELLO";
-    let mut warned_baseline: Option<u64> = None;
-
-    for threads in [1_usize, 2, 4] {
-        let opts = ascii_decode_opts()
-            .with_format(RecordFormat::RDW)
-            .with_emit_raw(RawMode::RecordRDW)
-            .with_threads(threads)
-            .with_strict_mode(false);
-        let mut output = Vec::new();
-        let summary = decode_file_to_jsonl(&schema, Cursor::new(data), &mut output, &opts).unwrap();
-        assert_eq!(summary.records_processed, 1);
-        assert_eq!(summary.records_with_errors, 0);
-        assert!(
-            summary.has_warnings(),
-            "non-zero reserved bytes should warn"
-        );
-        let output_text = String::from_utf8(output.clone()).unwrap();
-        assert!(
-            output_text.contains("HELLO"),
-            "decode output should include decoded record payload"
-        );
-
-        let decoded_raws: Vec<_> = output_text
-            .lines()
-            .map(|line| {
-                let value: serde_json::Value = serde_json::from_str(line).unwrap();
-                parse_raw_b64_field(&value)
-            })
-            .collect();
-        assert_eq!(
-            decoded_raws,
-            vec![vec![0x00, 0x05, 0x12, 0x34, b'H', b'E', b'L', b'L', b'O']]
-        );
-
-        match warned_baseline {
-            Some(warnings) => assert_eq!(summary.warnings, warnings),
-            None => warned_baseline = Some(summary.warnings),
-        }
-    }
+    let opts = ascii_decode_opts()
+        .with_format(RecordFormat::RDW)
+        .with_emit_raw(RawMode::RecordRDW)
+        .with_strict_mode(true);
+    let mut output = Vec::new();
+    let result = decode_file_to_jsonl(&schema, Cursor::new(data), &mut output, &opts);
+    let error = result.expect_err("strict decode should reject non-zero reserved bytes");
+    assert_eq!(error.code, ErrorCode::CBKR211_RDW_RESERVED_NONZERO);
 }
 
 #[test]
-fn decode_fixed_threaded_rejection_missing_lrecl() {
+fn decode_rdw_reserved_warning_is_a_lenient_warning() {
+    let schema = parse_copybook("01 FIELD PIC X(5).").unwrap();
+    let data = b"\x00\x05\x12\x34HELLO";
+    let opts = ascii_decode_opts()
+        .with_format(RecordFormat::RDW)
+        .with_emit_raw(RawMode::RecordRDW)
+        .with_strict_mode(false);
+    let mut output = Vec::new();
+    let summary = decode_file_to_jsonl(&schema, Cursor::new(data), &mut output, &opts)
+        .expect("lenient decode with non-zero reserved should continue");
+
+    assert_eq!(summary.records_processed, 1);
+    assert_eq!(summary.records_with_errors, 0);
+    assert_eq!(summary.warnings, 1);
+    let output_text = String::from_utf8(output).unwrap();
+    assert_eq!(summary.bytes_processed, 9);
+    assert!(output_text.contains("HELLO"));
+    let decoded: serde_json::Value =
+        serde_json::from_str(output_text.lines().next().unwrap()).unwrap();
+    assert_eq!(
+        parse_raw_b64_field(&decoded),
+        vec![0x00, 0x05, 0x12, 0x34, b'H', b'E', b'L', b'L', b'O']
+    );
+}
+
+#[test]
+fn decode_fixed_missing_lrecl_fixed_invalid_state() {
     let mut schema = parse_copybook("01 FIELD PIC X(5).").unwrap();
     // Fixed decoding requires an explicit fixed length in the schema.
     schema.lrecl_fixed = None;
 
-    for threads in [1_usize, 2, 4] {
-        let opts = ascii_decode_opts().with_threads(threads);
-        let mut output = Vec::new();
-        let result = decode_file_to_jsonl(&schema, Cursor::new(b"ABCDE"), &mut output, &opts);
-        let error = result.expect_err("fixed decode should fail when lrecl is missing");
-        assert_eq!(
-            error.code,
-            ErrorCode::CBKI001_INVALID_STATE,
-            "threads={threads} should return CBKI001_INVALID_STATE"
-        );
-    }
+    let opts = ascii_decode_opts();
+    let mut output = Vec::new();
+    let result = decode_file_to_jsonl(&schema, Cursor::new(b"ABCDE"), &mut output, &opts);
+    let error = result.expect_err("fixed decode should fail when lrecl is missing");
+    assert_eq!(error.code, ErrorCode::CBKI001_INVALID_STATE);
 }
 
 #[test]
-fn decode_rdw_threaded_header_ascii_corruption_is_fatal() {
+fn decode_rdw_suspect_ascii_header_is_fatal() {
     let schema = parse_copybook(
         r#"
 01 TEST-RECORD.
@@ -1038,48 +993,27 @@ fn decode_rdw_threaded_header_ascii_corruption_is_fatal() {
     .unwrap();
 
     let data = vec![b'1', b'2', 0x00, 0x00, b'H', b'E', b'L', b'L', b'O'];
-    for threads in [1_usize, 2, 4] {
-        let opts = ascii_decode_opts()
-            .with_format(RecordFormat::RDW)
-            .with_threads(threads);
-        let mut output = Vec::new();
-        let result = decode_file_to_jsonl(&schema, Cursor::new(&data), &mut output, &opts);
-        let error = result.expect_err("RDW decode should fail on suspect ASCII-corrupted header");
-        assert_eq!(
-            error.code,
-            ErrorCode::CBKF104_RDW_SUSPECT_ASCII,
-            "threads={threads} should return CBKF104_RDW_SUSPECT_ASCII"
-        );
-    }
+    let opts = ascii_decode_opts().with_format(RecordFormat::RDW);
+    let mut output = Vec::new();
+    let result = decode_file_to_jsonl(&schema, Cursor::new(&data), &mut output, &opts);
+    let error = result.expect_err("RDW decode should fail on suspect ASCII-corrupted header");
+    assert_eq!(error.code, ErrorCode::CBKF104_RDW_SUSPECT_ASCII);
 }
 
 #[test]
-fn decode_rdw_threaded_reserved_warning_is_deterministic() {
+fn decode_rdw_legacy_raw_mode_key_alias_is_accepted_in_encode() {
     let schema = parse_copybook("01 FIELD PIC X(5).").unwrap();
-    let data = vec![0x00, 0x05, 0x12, 0x34, b'H', b'E', b'L', b'L', b'O'];
+    let encoded = base64::engine::general_purpose::STANDARD.encode(b"HELLO");
+    let jsonl = format!("{{\"__raw_b64\":\"{encoded}\"}}\n");
+    let mut output = Vec::new();
+    let opts = ascii_encode_opts()
+        .with_format(RecordFormat::Fixed)
+        .with_use_raw(true);
 
-    let mut baseline: Option<u64> = None;
-    for threads in [1_usize, 2, 4] {
-        let opts = ascii_decode_opts()
-            .with_format(RecordFormat::RDW)
-            .with_threads(threads)
-            .with_strict_mode(false);
-        let mut output = Vec::new();
-        let summary = decode_file_to_jsonl(&schema, Cursor::new(&data), &mut output, &opts)
-            .expect("lenient decode with non-zero reserved should continue");
+    encode_jsonl_to_file(&schema, Cursor::new(jsonl.as_bytes()), &mut output, &opts)
+        .expect("encoding should accept legacy __raw_b64");
 
-        assert_eq!(summary.records_processed, 1);
-        assert_eq!(summary.records_with_errors, 0);
-        assert!(summary.has_warnings());
-
-        let output_text = String::from_utf8(output).unwrap();
-        assert!(output_text.contains("HELLO"));
-
-        match baseline {
-            Some(baseline_warnings) => assert_eq!(summary.warnings, baseline_warnings),
-            None => baseline = Some(summary.warnings),
-        }
-    }
+    assert_eq!(output, b"HELLO");
 }
 
 // ===========================================================================
@@ -1253,9 +1187,10 @@ fn decode_file_with_raw_mode() {
     let text = String::from_utf8(output).unwrap();
     for line in text.lines() {
         let val: serde_json::Value = serde_json::from_str(line).unwrap();
-        assert!(
-            val.get("__raw_b64").is_some() || val.get("raw_b64").is_some(),
-            "Raw mode should emit raw_b64"
+        assert!(val.get("raw_b64").is_some(), "Raw mode should emit raw_b64");
+        assert_eq!(
+            parse_raw_b64_field_from_any(&val, "raw_b64"),
+            parse_raw_b64_field(&val),
         );
     }
 }


### PR DESCRIPTION
## Summary

Finalize RDW raw/bytes-accounting behavior and make raw-fidelity evidence deterministic and scoped to the behavior actually exercised.

### Scope
- crates/copybook-codec/src/lib_api.rs: align ytes_processed to physical input bytes for decode.
  - fixed records: payload bytes
  - RDW records: 4-byte RDW header + payload bytes
- crates/copybook-codec/src/lib_api/run_summary.rs: document the ytes_processed contract.
- crates/copybook-codec/tests/streaming_file_tests.rs: remove thread-looped raw fidelity cases and add exact-row assertions.

### Behavioral rows
This PR proves:
- fixed RawMode::Record emits payload bytes only
- RDW RawMode::RecordRDW emits header+payload bytes
- canonical aw_b64 presence for raw outputs
- legacy __raw_b64 is covered as separate compatibility row
- strict RDW reserved bytes are rejected with CBKR211_RDW_RESERVED_NONZERO
- lenient RDW reserved bytes are warnings and still decode
- suspect ASCII RDW header returns CBKF104_RDW_SUSPECT_ASCII
- missing lrecl_fixed is an invalid-state condition in this path

This PR intentionally does **not** claim worker-thread execution evidence.

### Proof
- cargo fmt -p copybook-codec -- --check
- cargo clippy -p copybook-codec --test streaming_file_tests -- -D warnings
- cargo test -p copybook-codec --test streaming_file_tests
- cargo test -p copybook-codec --features comprehensive-tests --test comprehensive_rdw_tests
- git diff --check

### Related
Relates to #572

## Type of Change

- [x] Tests
- [x] Codec behavior

## Workspace Crates Affected

- [x] copybook-codec
