### PR TITLE
fix(core): align SIGN clause contract with accepted/rejected behavior

### DIFF
--- a/crates/copybook-core/src/parser.rs
+++ b/crates/copybook-core/src/parser.rs
@@ -988,7 +988,8 @@ impl Parser {
         // Parse SIGN clause components in either order:
         //   SIGN [IS] [SEPARATE] [LEADING|TRAILING]
         //   SIGN [IS] [LEADING|TRAILING] [SEPARATE]
-        let mut placement = SignPlacement::Leading;
+        // COBOL's standard action for an omitted placement is trailing.
+        let mut placement = SignPlacement::Trailing;
         let mut saw_placement = false;
         let mut saw_separate = false;
 

--- a/crates/copybook-core/tests/bdd_error_handling_scenarios.rs
+++ b/crates/copybook-core/tests/bdd_error_handling_scenarios.rs
@@ -10,7 +10,11 @@
 //! - Enterprise feature workflows
 //! - Performance-related scenarios
 
-use copybook_core::{ErrorCode, FieldKind, parse_copybook};
+use copybook_core::{
+    ErrorCode, FieldKind,
+    feature_flags::{Feature, FeatureFlags},
+    parse_copybook,
+};
 
 #[test]
 fn bdd_scenario_invalid_copybook_syntax() {
@@ -115,6 +119,10 @@ fn bdd_scenario_sign_separate_handling() {
     // Given: A copybook with SIGN SEPARATE
     // When: The copybook is parsed
     // Then: The sign placement should be correctly identified
+
+    if !FeatureFlags::from_env().is_enabled(Feature::SignSeparate) {
+        return;
+    }
 
     let copybook = "01 SIGNED-FIELD PIC S9(5) SIGN IS SEPARATE.";
     let result = parse_copybook(copybook);
@@ -549,6 +557,10 @@ fn bdd_scenario_enterprise_sign_separate() {
     // Given: A copybook with SIGN SEPARATE LEADING/TRAILING
     // When: The copybook is parsed
     // Then: Sign placement should be correctly identified
+
+    if !FeatureFlags::from_env().is_enabled(Feature::SignSeparate) {
+        return;
+    }
 
     let copybook = "01 FIELD PIC S9(5) SIGN IS SEPARATE LEADING.";
     let result = parse_copybook(copybook);

--- a/crates/copybook-core/tests/bdd_error_handling_scenarios.rs
+++ b/crates/copybook-core/tests/bdd_error_handling_scenarios.rs
@@ -118,12 +118,18 @@ fn bdd_scenario_sign_separate_handling() {
 
     let copybook = "01 SIGNED-FIELD PIC S9(5) SIGN IS SEPARATE.";
     let result = parse_copybook(copybook);
-
-    assert!(result.is_err());
-    let err = result.unwrap_err();
+    let schema = result.expect("SIGN IS SEPARATE should parse");
+    let field = schema
+        .all_fields()
+        .into_iter()
+        .find(|field| field.name == "SIGNED-FIELD")
+        .expect("signed field should be present");
     assert!(matches!(
-        err.code(),
-        ErrorCode::CBKP051_UNSUPPORTED_EDITED_PIC
+        field.kind,
+        FieldKind::ZonedDecimal {
+            sign_separate: Some(_),
+            ..
+        }
     ));
 }
 
@@ -547,7 +553,19 @@ fn bdd_scenario_enterprise_sign_separate() {
     let copybook = "01 FIELD PIC S9(5) SIGN IS SEPARATE LEADING.";
     let result = parse_copybook(copybook);
 
-    assert!(result.is_err());
+    let schema = result.expect("enterprise SIGN IS SEPARATE LEADING should parse");
+    let field = schema
+        .all_fields()
+        .into_iter()
+        .find(|field| field.name == "FIELD")
+        .expect("signed field should be present");
+    assert!(matches!(
+        field.kind,
+        FieldKind::ZonedDecimal {
+            sign_separate: Some(_),
+            ..
+        }
+    ));
 }
 
 #[test]

--- a/crates/copybook-core/tests/comprehensive_parser_tests.rs
+++ b/crates/copybook-core/tests/comprehensive_parser_tests.rs
@@ -8,7 +8,9 @@
 //! according to the normative grammar rules specified in the design document.
 
 use copybook_core::{
-    ErrorCode, FieldKind, Occurs, ParseOptions, parse_copybook, parse_copybook_with_options,
+    ErrorCode, FieldKind, Occurs, ParseOptions,
+    feature_flags::{Feature, FeatureFlags},
+    parse_copybook, parse_copybook_with_options,
 };
 
 #[test]
@@ -121,18 +123,15 @@ fn test_edited_pic_error_normative() {
 
 #[test]
 fn test_sign_clause_as_edited_pic_normative() {
-    // NORMATIVE: SIGN LEADING/TRAILING [SEPARATE] treated as edited PIC
+    let flags = FeatureFlags::from_env();
+    if !flags.is_enabled(Feature::SignSeparate) {
+        return;
+    }
+
+    // NORMATIVE: SIGN LEADING/TRAILING are rejected as edited PIC syntax variants.
     let sign_clauses = vec![
         ("01 FIELD1 PIC S999 SIGN LEADING.", "SIGN LEADING"),
         ("01 FIELD2 PIC S999 SIGN TRAILING.", "SIGN TRAILING"),
-        (
-            "01 FIELD3 PIC S999 SIGN LEADING SEPARATE.",
-            "SIGN LEADING SEPARATE",
-        ),
-        (
-            "01 FIELD4 PIC S999 SIGN TRAILING SEPARATE.",
-            "SIGN TRAILING SEPARATE",
-        ),
     ];
 
     for (sign_clause, description) in sign_clauses {
@@ -145,7 +144,22 @@ fn test_sign_clause_as_edited_pic_normative() {
         );
 
         let error = result.unwrap_err();
-        assert_eq!(error.code, ErrorCode::CBKP051_UNSUPPORTED_EDITED_PIC);
+        assert_eq!(error.code, ErrorCode::CBKP001_SYNTAX);
+    }
+
+    let supported_clauses = vec![
+        "01 FIELD3 PIC S999 SIGN LEADING SEPARATE.",
+        "01 FIELD4 PIC S999 SIGN IS LEADING SEPARATE.",
+        "01 FIELD5 PIC S999 SIGN TRAILING SEPARATE.",
+        "01 FIELD6 PIC S999 SIGN IS TRAILING SEPARATE.",
+    ];
+
+    for sign_clause in supported_clauses {
+        let result = parse_copybook(sign_clause);
+        assert!(
+            result.is_ok(),
+            "Should parse supported SIGN SEPARATE clause: {sign_clause}",
+        );
     }
 }
 

--- a/crates/copybook-core/tests/parser_fixtures.rs
+++ b/crates/copybook-core/tests/parser_fixtures.rs
@@ -169,19 +169,27 @@ fn test_edited_pic_error_detection() -> TestResult {
 
 #[test]
 fn test_sign_clause_as_edited_pic() -> TestResult {
-    // NORMATIVE: SIGN LEADING/TRAILING [SEPARATE] treated as edited PIC
+    // NORMATIVE: SIGN LEADING/TRAILING are parse-rejected syntax variants.
+    // SIGN SEPARATE forms are accepted when sign-separate support is enabled.
     let sign_clauses = vec![
         "01 FIELD1 PIC S999 SIGN LEADING.",
         "01 FIELD2 PIC S999 SIGN TRAILING.",
-        "01 FIELD3 PIC S999 SIGN LEADING SEPARATE.",
-        "01 FIELD4 PIC S999 SIGN TRAILING SEPARATE.",
     ];
 
     for sign_clause in sign_clauses {
         let Err(error) = parse_copybook(sign_clause) else {
             bail!("Should fail for: {sign_clause}");
         };
-        assert_eq!(error.code, ErrorCode::CBKP051_UNSUPPORTED_EDITED_PIC);
+        assert_eq!(error.code, ErrorCode::CBKP001_SYNTAX);
+    }
+
+    let supported_clauses = vec![
+        "01 FIELD3 PIC S999 SIGN LEADING SEPARATE.",
+        "01 FIELD4 PIC S999 SIGN TRAILING SEPARATE.",
+    ];
+    for sign_clause in supported_clauses {
+        parse_copybook(sign_clause)
+            .with_context(|| format!("Supported SIGN SEPARATE should parse: {sign_clause}"))?;
     }
     Ok(())
 }

--- a/crates/copybook-core/tests/parser_fixtures.rs
+++ b/crates/copybook-core/tests/parser_fixtures.rs
@@ -8,7 +8,11 @@
 //! and syntax variations according to the normative grammar rules.
 
 use anyhow::{Context as _, Result, bail};
-use copybook_core::{ErrorCode, parse_copybook};
+use copybook_core::{
+    ErrorCode,
+    feature_flags::{Feature, FeatureFlags},
+    parse_copybook,
+};
 
 type TestResult<T = ()> = Result<T>;
 
@@ -169,6 +173,10 @@ fn test_edited_pic_error_detection() -> TestResult {
 
 #[test]
 fn test_sign_clause_as_edited_pic() -> TestResult {
+    if !FeatureFlags::from_env().is_enabled(Feature::SignSeparate) {
+        return Ok(());
+    }
+
     // NORMATIVE: SIGN LEADING/TRAILING are parse-rejected syntax variants.
     // SIGN SEPARATE forms are accepted when sign-separate support is enabled.
     let sign_clauses = vec![

--- a/crates/copybook-core/tests/schema_validation_edge_cases.rs
+++ b/crates/copybook-core/tests/schema_validation_edge_cases.rs
@@ -10,7 +10,11 @@
 //! - Error handling in schema operations
 //! - Boundary conditions
 
-use copybook_core::{FieldKind, SignPlacement, parse_copybook};
+use copybook_core::{
+    FieldKind, SignPlacement,
+    feature_flags::{Feature, FeatureFlags},
+    parse_copybook,
+};
 
 #[test]
 fn test_schema_parse_simple_copybook() {
@@ -101,6 +105,10 @@ fn test_schema_parse_with_odo() {
 
 #[test]
 fn test_schema_parse_with_sign_separate() {
+    if !FeatureFlags::from_env().is_enabled(Feature::SignSeparate) {
+        return;
+    }
+
     // Test parsing with SIGN SEPARATE clause
     let copybook = "01 SIGNED-FIELD PIC S9(5) SIGN IS SEPARATE.";
     let result = parse_copybook(copybook);
@@ -116,7 +124,7 @@ fn test_schema_parse_with_sign_separate() {
             sign_separate: Some(sign),
             ..
         } => {
-            assert_eq!(sign.placement, SignPlacement::Leading);
+            assert_eq!(sign.placement, SignPlacement::Trailing);
         }
         _ => panic!("Expected SIGN SEPARATE zoned decimal field"),
     }

--- a/crates/copybook-core/tests/schema_validation_edge_cases.rs
+++ b/crates/copybook-core/tests/schema_validation_edge_cases.rs
@@ -10,7 +10,7 @@
 //! - Error handling in schema operations
 //! - Boundary conditions
 
-use copybook_core::{ErrorCode, parse_copybook};
+use copybook_core::{FieldKind, SignPlacement, parse_copybook};
 
 #[test]
 fn test_schema_parse_simple_copybook() {
@@ -104,11 +104,22 @@ fn test_schema_parse_with_sign_separate() {
     // Test parsing with SIGN SEPARATE clause
     let copybook = "01 SIGNED-FIELD PIC S9(5) SIGN IS SEPARATE.";
     let result = parse_copybook(copybook);
-    assert!(result.is_err());
-    assert!(matches!(
-        result.unwrap_err().code(),
-        ErrorCode::CBKP051_UNSUPPORTED_EDITED_PIC
-    ));
+    let schema = result.expect("SIGN SEPARATE should parse on stable form");
+
+    let field = schema
+        .all_fields()
+        .into_iter()
+        .find(|field| field.name == "SIGNED-FIELD")
+        .expect("parsed field should exist");
+    match &field.kind {
+        FieldKind::ZonedDecimal {
+            sign_separate: Some(sign),
+            ..
+        } => {
+            assert_eq!(sign.placement, SignPlacement::Leading);
+        }
+        _ => panic!("Expected SIGN SEPARATE zoned decimal field"),
+    }
 }
 
 #[test]

--- a/docs/NORMATIVE_SPEC.md
+++ b/docs/NORMATIVE_SPEC.md
@@ -292,7 +292,7 @@ Becomes: `05 LONG-FIELD-NAME PIC X(100).`
 
 ### 7.5 SIGN Clause Handling
 
-**Rule**: SIGN LEADING/TRAILING [SEPARATE] is fully supported (promoted in v0.4.3).
+**Rule**: SIGN LEADING and SIGN TRAILING without SEPARATE are rejected with `CBKP001_SYNTAX`; SIGN LEADING SEPARATE and SIGN TRAILING SEPARATE are supported (promoted in v0.4.3). When placement is omitted from SIGN SEPARATE, TRAILING is the default.
 
 **Implementation**:
 - Parse SIGN clauses and record sign position (leading/trailing) and encoding (embedded/separate)

--- a/docs/SIGN_SEPARATE.md
+++ b/docs/SIGN_SEPARATE.md
@@ -68,21 +68,21 @@ Digits are stored as standard display characters:
 
 ### IBM Enterprise COBOL
 
-- Default behavior: SIGN SEPARATE uses LEADING placement
+- Omitted placement uses TRAILING, the standard action
 - Supports both LEADING and TRAILING SEPARATE
 - Sign byte uses EBCDIC encoding
 - Unsigned fields may have space (0x40) or zero (0xF0) in sign position
 
 ### Micro Focus COBOL
 
-- Default behavior: SIGN SEPARATE uses LEADING placement
+- copybook-rs uses TRAILING when placement is omitted
 - Supports both LEADING and TRAILING SEPARATE
 - Sign byte uses ASCII encoding
 - Unsigned fields typically use space (0x20) in sign position
 
 ### Fujitsu COBOL
 
-- Default behavior: SIGN SEPARATE uses LEADING placement
+- copybook-rs uses TRAILING when placement is omitted
 - Supports both LEADING and TRAILING SEPARATE
 - Sign byte encoding matches system codepage
 
@@ -101,7 +101,7 @@ If the `sign_separate` feature flag is explicitly disabled (e.g., `COPYBOOK_FF_S
 The following validation rules apply:
 
 1. **Field Type**: SIGN SEPARATE can only be used with numeric display fields (PIC 9 or PIC S9)
-2. **Placement**: Must specify LEADING or TRAILING (defaults to LEADING if omitted)
+2. **Placement**: LEADING or TRAILING may be specified; omitted placement defaults to TRAILING
 3. **Scale**: V (implied decimal) is supported
 4. **Blank When Zero**: Cannot be combined with SIGN SEPARATE
 
@@ -170,7 +170,7 @@ Decoded value: `1234`
 ### Parser Changes
 
 1. When `sign_separate` flag is enabled, accept SIGN SEPARATE clause
-2. Parse placement (LEADING/TRAILING) - default to LEADING
+2. Parse placement (LEADING/TRAILING) - default to TRAILING
 3. Store sign information in field metadata
 
 ### Layout Changes

--- a/docs/reference/COBOL_SUPPORT_MATRIX.md
+++ b/docs/reference/COBOL_SUPPORT_MATRIX.md
@@ -48,9 +48,9 @@
 
 | Feature | Status | Test Evidence | Notes |
 |---------|--------|---------------|-------|
-| SIGN LEADING clause | ✅ Fully Supported | `copybook-core/tests/sign_separate_feature_enabled_tests.rs` | SIGN IS LEADING SEPARATE supported; enabled by default |
-| SIGN TRAILING clause | ✅ Fully Supported | `copybook-core/tests/sign_separate_feature_enabled_tests.rs` | SIGN TRAILING SEPARATE supported; enabled by default |
-| SIGN SEPARATE (`sign-separate`) | ✅ **Fully Supported** | `copybook-core/tests/sign_separate_feature_enabled_tests.rs`, `copybook-core/tests/schema_validation_edge_cases.rs`, `copybook-codec/tests/numeric_sign_separate_comprehensive.rs`, `copybook-codec/tests/sign_separate_golden_tests.rs`, `copybook-codec/tests/sign_separate_tests.rs` | Enabled by default (promoted from experimental); encode + decode + round-trip |
+| SIGN LEADING SEPARATE clause | ✅ Fully Supported | `copybook-core/tests/sign_separate_feature_enabled_tests.rs` | Explicit LEADING SEPARATE is supported; enabled by default |
+| SIGN TRAILING SEPARATE clause | ✅ Fully Supported | `copybook-core/tests/sign_separate_feature_enabled_tests.rs` | Explicit TRAILING SEPARATE is supported; enabled by default |
+| SIGN SEPARATE (`sign-separate`) | ✅ **Fully Supported** | `copybook-core/tests/sign_separate_feature_enabled_tests.rs`, `copybook-core/tests/schema_validation_edge_cases.rs`, `copybook-codec/tests/numeric_sign_separate_comprehensive.rs`, `copybook-codec/tests/sign_separate_golden_tests.rs`, `copybook-codec/tests/sign_separate_tests.rs` | Enabled by default (promoted from experimental); omitted placement defaults to TRAILING; encode + decode + round-trip |
 | Overpunch (EBCDIC/ASCII) | ✅ Fully Supported | `decimal_edge_cases.rs::test_zoned_overpunch_by_codepage`, `decimal_edge_cases.rs::test_zoned_overpunch_comprehensive`, `comprehensive_numeric_tests.rs::test_zoned_decimal_ascii_sign_zones_comprehensive` | Comprehensive overpunch with EBCDIC zones |
 
 ## Record Formats


### PR DESCRIPTION
## Summary

Finalize the SIGN SEPARATE parser, test, and documentation contract for #582.

## Contract

- Bare `SIGN LEADING` and `SIGN TRAILING` remain syntax errors with `CBKP001_SYNTAX`.
- `SIGN [IS] LEADING SEPARATE` and `SIGN [IS] TRAILING SEPARATE` are supported when the feature is enabled.
- `SIGN IS SEPARATE` defaults to `TRAILING`, matching the COBOL standard action.
- SIGN-dependent tests now guard the documented `COPYBOOK_FF_SIGN_SEPARATE=0` compatibility mode.
- The support matrix, normative specification, and SIGN semantics guide now describe the same behavior.

## Scope

- Parser default placement and schema evidence.
- Feature-gated parser, BDD, and schema tests.
- SIGN support documentation.

Disabled-feature error-code changes remain in the separate #587 lane.

## Validation

- `cargo +1.92.0 fmt --all -- --check`
- `cargo +1.92.0 clippy -p copybook-core --all-features --tests -- -D warnings`
- Focused SIGN tests with the feature enabled.
- Focused SIGN tests with `COPYBOOK_FF_SIGN_SEPARATE=0`.
- `cargo +1.92.0 test -p copybook-core --all-features --tests` reaches one pre-existing failure in `test_edited_pic_error_normative` for `PIC ZZ9.99`; that test is unchanged by this PR and should be tracked separately.

Fixes #582.