### PR TITLE
test(core): make feature-gating rejections deterministic

### DIFF
--- a/crates/copybook-core/src/layout.rs
+++ b/crates/copybook-core/src/layout.rs
@@ -71,6 +71,14 @@ impl LayoutContext {
 #[inline]
 #[must_use = "Handle the Result or propagate the error"]
 pub fn resolve_layout(schema: &mut Schema, dialect: Dialect) -> Result<()> {
+    resolve_layout_with_feature_flags(schema, dialect, FeatureFlags::global())
+}
+
+pub(crate) fn resolve_layout_with_feature_flags(
+    schema: &mut Schema,
+    dialect: Dialect,
+    feature_flags: &FeatureFlags,
+) -> Result<()> {
     let mut context = LayoutContext::new();
 
     // First pass: collect all REDEFINES relationships
@@ -91,7 +99,7 @@ pub fn resolve_layout(schema: &mut Schema, dialect: Dialect) -> Result<()> {
     detect_tail_odo(schema, &context, dialect);
 
     // Resolve RENAMES (level-66) aliases
-    resolve_renames_aliases(&mut schema.fields)?;
+    resolve_renames_aliases(&mut schema.fields, feature_flags)?;
 
     // Check for record size overflow
     if context.current_offset > MAX_RECORD_SIZE {
@@ -769,17 +777,20 @@ fn count_redefines_alternatives(
 /// Resolve RENAMES (level-66) aliases (post-order).
 /// Current implementation: same-scope resolution + contiguous slice → (offset, length, members).
 /// Extended to detect and reject R4-R6 patterns unless feature flag is enabled.
-fn resolve_renames_aliases(fields: &mut [crate::schema::Field]) -> Result<()> {
+fn resolve_renames_aliases(
+    fields: &mut [crate::schema::Field],
+    feature_flags: &FeatureFlags,
+) -> Result<()> {
     use crate::error::ErrorCode;
     use crate::schema::{FieldKind, ResolvedRenames};
 
     // Check if R4-R6 feature flag is enabled
-    let r4_r6_enabled = FeatureFlags::global().is_enabled(Feature::RenamesR4R6);
+    let r4_r6_enabled = feature_flags.is_enabled(Feature::RenamesR4R6);
 
     // 1) Recurse first (post-order)
     for f in fields.iter_mut() {
         if !f.children.is_empty() {
-            resolve_renames_aliases(&mut f.children)?;
+            resolve_renames_aliases(&mut f.children, feature_flags)?;
         }
     }
 

--- a/crates/copybook-core/src/lib.rs
+++ b/crates/copybook-core/src/lib.rs
@@ -309,3 +309,29 @@ pub fn parse_copybook(text: &str) -> Result<Schema> {
 pub fn parse_copybook_with_options(text: &str, options: &ParseOptions) -> Result<Schema> {
     parser::parse_with_options(text, options)
 }
+
+/// Parse a COBOL copybook with specific options and feature flags
+///
+/// # Examples
+///
+/// ```
+/// use copybook_core::{parse_copybook_with_feature_flags, ParseOptions, FeatureFlags, Feature};
+///
+/// let options = ParseOptions::default();
+/// let mut feature_flags = FeatureFlags::default();
+/// feature_flags.disable(Feature::SignSeparate);
+/// let source = "01 AMOUNT PIC S9(5) SIGN IS LEADING SEPARATE.";
+/// assert!(parse_copybook_with_feature_flags(source, &options, &feature_flags).is_err());
+/// ```
+///
+/// # Errors
+/// Returns an error if the copybook contains syntax errors or unsupported features.
+#[inline]
+#[must_use = "Handle the Result or propagate the error"]
+pub fn parse_copybook_with_feature_flags(
+    text: &str,
+    options: &ParseOptions,
+    feature_flags: &FeatureFlags,
+) -> Result<Schema> {
+    parser::parse_with_feature_flags(text, options, feature_flags)
+}

--- a/crates/copybook-core/src/parser.rs
+++ b/crates/copybook-core/src/parser.rs
@@ -61,6 +61,10 @@ pub fn parse_with_feature_flags(
     parse_with_options_and_feature_flags(text, options, feature_flags)
 }
 
+/// Parse a COBOL copybook with explicit options and feature flags.
+///
+/// # Errors
+/// Returns an error if the copybook contains syntax errors or unsupported features.
 #[inline]
 #[must_use = "Handle the Result or propagate the error"]
 pub fn parse_with_options_and_feature_flags(

--- a/crates/copybook-core/src/parser.rs
+++ b/crates/copybook-core/src/parser.rs
@@ -53,14 +53,38 @@ pub fn parse(text: &str) -> Result<Schema> {
 /// Returns an error if the copybook contains syntax errors or unsupported features.
 #[inline]
 #[must_use = "Handle the Result or propagate the error"]
-pub fn parse_with_options(text: &str, options: &ParseOptions) -> Result<Schema> {
+pub fn parse_with_feature_flags(
+    text: &str,
+    options: &ParseOptions,
+    feature_flags: &FeatureFlags,
+) -> Result<Schema> {
+    parse_with_options_and_feature_flags(text, options, feature_flags)
+}
+
+#[inline]
+#[must_use = "Handle the Result or propagate the error"]
+pub fn parse_with_options_and_feature_flags(
+    text: &str,
+    options: &ParseOptions,
+    feature_flags: &FeatureFlags,
+) -> Result<Schema> {
     if text.trim().is_empty() {
         return Err(error!(ErrorCode::CBKP001_SYNTAX, "Empty copybook text"));
     }
 
     let tokens = Lexer::new_with_options(text, options).tokenize();
-    let mut parser = Parser::with_options(tokens, options.clone());
+    let mut parser = Parser::with_options(tokens, options.clone(), feature_flags.clone());
     parser.parse_schema()
+}
+
+/// Parse a COBOL copybook text into a schema with specific options
+///
+/// # Errors
+/// Returns an error if the copybook contains syntax errors or unsupported features.
+#[inline]
+#[must_use = "Handle the Result or propagate the error"]
+pub fn parse_with_options(text: &str, options: &ParseOptions) -> Result<Schema> {
+    parse_with_options_and_feature_flags(text, options, FeatureFlags::global())
 }
 
 /// Options for controlling COBOL copybook parsing behavior.
@@ -102,14 +126,20 @@ struct Parser {
     tokens: Vec<TokenPos>,
     current: usize,
     options: ParseOptions,
+    feature_flags: FeatureFlags,
 }
 
 impl Parser {
-    fn with_options(tokens: Vec<TokenPos>, options: ParseOptions) -> Self {
+    fn with_options(
+        tokens: Vec<TokenPos>,
+        options: ParseOptions,
+        feature_flags: FeatureFlags,
+    ) -> Self {
         Self {
             tokens,
             current: 0,
             options,
+            feature_flags,
         }
     }
 
@@ -120,7 +150,7 @@ impl Parser {
         feature_name: &str,
         syntax: &str,
     ) -> Result<()> {
-        if FeatureFlags::global().is_enabled(feature) {
+        if self.feature_flags.is_enabled(feature) {
             return Ok(());
         }
 
@@ -166,7 +196,11 @@ impl Parser {
         let mut schema = Schema::from_fields(hierarchical_fields);
 
         // Resolve field layouts and compute offsets (dialect affects ODO min_count)
-        crate::layout::resolve_layout(&mut schema, self.options.dialect)?;
+        crate::layout::resolve_layout_with_feature_flags(
+            &mut schema,
+            self.options.dialect,
+            &self.feature_flags,
+        )?;
 
         self.calculate_schema_fingerprint(&mut schema);
 

--- a/crates/copybook-core/src/parser/field/clauses.rs
+++ b/crates/copybook-core/src/parser/field/clauses.rs
@@ -1,5 +1,5 @@
 use crate::error::ErrorCode;
-use crate::feature_flags::{Feature, FeatureFlags};
+use crate::feature_flags::Feature;
 use crate::lexer::Token;
 use crate::schema::{Field, FieldKind};
 use crate::{Error, Result};
@@ -96,7 +96,7 @@ impl Parser {
 
     fn parse_sign_field_clause(&mut self, field: &mut Field) -> Result<()> {
         self.advance();
-        if FeatureFlags::global().is_enabled(Feature::SignSeparate) {
+        if self.feature_flags.is_enabled(Feature::SignSeparate) {
             return self.parse_sign_clause(field);
         }
 

--- a/crates/copybook-core/tests/feature_gating_disabled_tests.rs
+++ b/crates/copybook-core/tests/feature_gating_disabled_tests.rs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+use copybook_core::{
+    ErrorCode, ParseOptions, feature_flags::FeatureFlags, parse_copybook_with_feature_flags,
+};
+
+fn ensure_comp_features_disabled() -> FeatureFlags {
+    let mut flags = FeatureFlags::default();
+    flags.disable(copybook_core::feature_flags::Feature::Comp1);
+    flags.disable(copybook_core::feature_flags::Feature::Comp2);
+    flags
+}
+
+#[test]
+fn test_disabled_comp_features_reject_comp1_comp2_clauses() {
+    let flags = ensure_comp_features_disabled();
+    assert!(!flags.is_enabled(copybook_core::feature_flags::Feature::Comp1));
+    assert!(!flags.is_enabled(copybook_core::feature_flags::Feature::Comp2));
+
+    let cases = [
+        (
+            "direct-comp-1",
+            "01 TEMP PIC S9(4) COMP-1.",
+            "COMP-1",
+            "comp_1",
+        ),
+        (
+            "direct-comp-2",
+            "01 TEMP PIC S9(4) COMP-2.",
+            "COMP-2",
+            "comp_2",
+        ),
+        (
+            "usage-comp-1",
+            "01 TEMP PIC 9(4) USAGE COMP-1.",
+            "USAGE COMP-1",
+            "comp_1",
+        ),
+        (
+            "usage-comp-2",
+            "01 TEMP PIC 9(4) USAGE COMP-2.",
+            "USAGE COMP-2",
+            "comp_2",
+        ),
+    ];
+
+    for (_label, source, syntax, token) in cases {
+        let result = parse_copybook_with_feature_flags(source, &ParseOptions::default(), &flags);
+        let error = result.expect_err("expected gated parser to reject disabled COMP features");
+        assert_eq!(error.code, ErrorCode::CBKP011_UNSUPPORTED_CLAUSE);
+        assert!(
+            error.message.contains(syntax),
+            "error message should include disabled syntax '{syntax}', got: {}",
+            error.message
+        );
+        assert!(
+            error.message.contains(token),
+            "error message should include token '{token}', got: {}",
+            error.message
+        );
+    }
+}

--- a/docs/reference/LIBRARY_API.md
+++ b/docs/reference/LIBRARY_API.md
@@ -422,6 +422,36 @@ let schema_custom = parse_copybook_with_options(copybook, &parse_options)?;
 - `strict_comments: bool` - Whether to enforce strict comment parsing rules
 - `dialect: Dialect` - Dialect for ODO `min_count` interpretation
 
+### Parsing with Explicit Feature Flags
+
+```rust
+pub fn parse_copybook_with_feature_flags(
+    text: &str,
+    options: &ParseOptions,
+    feature_flags: &FeatureFlags,
+) -> Result<Schema, Error>
+```
+
+Parse a copybook using an explicit feature-flag snapshot instead of the process-global feature configuration. The supplied flags are used consistently during parser and layout resolution, which makes isolated tests and concurrent callers deterministic.
+
+```rust
+use copybook_core::{
+    parse_copybook_with_feature_flags, Feature, FeatureFlags, ParseOptions,
+};
+
+let mut feature_flags = FeatureFlags::default();
+feature_flags.disable(Feature::Comp1);
+
+let result = parse_copybook_with_feature_flags(
+    "01 VALUE-FIELD PIC S9(4) COMP-1.",
+    &ParseOptions::default(),
+    &feature_flags,
+);
+assert!(result.is_err());
+```
+
+This entry point returns the same structured parse errors as `parse_copybook` and `parse_copybook_with_options`, including stable unsupported-clause errors for disabled features. It does not mutate the global feature configuration.
+
 ### Enhanced Safe Operations Module
 
 The copybook-core crate provides comprehensive panic-safe operations in the `utils::safe_ops` module:


### PR DESCRIPTION
## Summary

Make disabled feature-gating evidence deterministic by parsing and resolving layout with an explicit feature-flag snapshot, then document the new public entry point.

## Scope

- Add `parse_copybook_with_feature_flags` for callers and tests that need isolated feature state.
- Thread the explicit flags through parser feature checks and RENAMES layout resolution.
- Add deterministic rejection coverage for disabled COMP-1/COMP-2 and USAGE COMP-1/COMP-2.
- Document the API in `docs/reference/LIBRARY_API.md`.
- Complete the required `# Errors` rustdoc for the internal explicit-flags parser helper.

## Behavioral contract

- Disabled COMP clauses return `CBKP011_UNSUPPORTED_CLAUSE`.
- Error messages retain the source syntax and feature token.
- Explicit flags do not mutate or depend on process-global feature state.
- Existing `parse_copybook` and `parse_copybook_with_options` behavior remains global-configuration compatible.

## Validation

- `COPYBOOK_RUST_TOOLCHAIN=1.92.0 bash scripts/check-public-result-docs.sh`
- `cargo +1.92.0 fmt --all -- --check`
- `cargo +1.92.0 clippy -p copybook-core --all-features --tests -- -D warnings`
- `cargo +1.92.0 test -p copybook-core --all-features --test feature_gating_disabled_tests`
- `cargo +1.92.0 test -p copybook-core --all-features --doc`
- `git diff --check`

Relates to #551.