### PR TITLE
test(codepage): consolidate per-codepage evidence plane (#573)

### DIFF
--- a/crates/copybook-cli/tests/codepage_precedence.rs
+++ b/crates/copybook-cli/tests/codepage_precedence.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! CLI-level per-codepage decode evidence and codepage precedence (issue #573).
+//!
+//! Before this suite only CP037 was exercised through the compiled `copybook`
+//! binary (`cli_args.rs`). Here we drive `copybook decode` for every supported
+//! EBCDIC codepage and prove the `--codepage` flag — not a silent default —
+//! governs the conversion. Each codepage decodes a single "signature" byte to a
+//! character that is unique to (or distinctly placed in) that codepage.
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::unwrap_used)]
+
+mod common;
+
+use assert_fs::prelude::*;
+use common::bin;
+
+/// One-field copybook: a single alphanumeric byte (LRECL = 1).
+const SIG_CPY: &str = "01 REC.\n   05 SIG PIC X(1).\n";
+
+fn path_str(p: &std::path::Path) -> String {
+    p.to_string_lossy().into_owned()
+}
+
+/// Decode a single `byte` through `copybook decode`, optionally passing
+/// `--codepage`, and return the JSONL written to `--output`.
+fn decode_single_byte(byte: u8, codepage: Option<&str>) -> String {
+    let dir = assert_fs::TempDir::new().unwrap();
+    let cpy = dir.child("sig.cpy");
+    cpy.write_str(SIG_CPY).unwrap();
+    let data = dir.child("sig.bin");
+    data.write_binary(&[byte]).unwrap();
+    let out = dir.child("out.jsonl");
+
+    let mut cmd = bin();
+    cmd.args([
+        "decode",
+        &path_str(cpy.path()),
+        &path_str(data.path()),
+        "--output",
+        &path_str(out.path()),
+        "--format",
+        "fixed",
+    ]);
+    if let Some(cp) = codepage {
+        cmd.args(["--codepage", cp]);
+    }
+    cmd.assert().success();
+
+    std::fs::read_to_string(out.path()).unwrap()
+}
+
+// ====================================================================
+// Per-codepage decode evidence (CP273/CP500/CP1047/CP1140 previously
+// untested through the compiled binary).
+// ====================================================================
+
+#[test]
+fn cli_decode_cp273_signature() {
+    // CP273 0x4A = Ä (German A-umlaut).
+    let out = decode_single_byte(0x4A, Some("cp273"));
+    assert!(out.contains('Ä'), "CP273 decode should yield Ä, got: {out}");
+}
+
+#[test]
+fn cli_decode_cp500_signature() {
+    // CP500 0x4F = ! (where CP037 has |).
+    let out = decode_single_byte(0x4F, Some("cp500"));
+    assert!(out.contains('!'), "CP500 decode should yield !, got: {out}");
+}
+
+#[test]
+fn cli_decode_cp1047_signature() {
+    // CP1047 0xBA = Ý (where CP037 has [) — the z/OS-Unix bracket swap.
+    let out = decode_single_byte(0xBA, Some("cp1047"));
+    assert!(
+        out.contains('Ý'),
+        "CP1047 decode should yield Ý, got: {out}"
+    );
+}
+
+#[test]
+fn cli_decode_cp1140_signature() {
+    // CP1140 0xFF = € (Euro), the single byte that differs from CP037.
+    let out = decode_single_byte(0xFF, Some("cp1140"));
+    assert!(
+        out.contains('€'),
+        "CP1140 decode should yield €, got: {out}"
+    );
+}
+
+// ====================================================================
+// Codepage precedence: the same input byte decodes differently
+// depending on --codepage, and an explicit flag overrides the CP037
+// default.
+// ====================================================================
+
+#[test]
+fn cli_codepage_flag_changes_decoded_character() {
+    // Byte 0x4A is ¢ in CP037 but Ä in CP273 — same bytes, different flag.
+    let as_cp037 = decode_single_byte(0x4A, Some("cp037"));
+    let as_cp273 = decode_single_byte(0x4A, Some("cp273"));
+
+    assert!(as_cp037.contains('¢'), "CP037 should decode 0x4A as ¢");
+    assert!(as_cp273.contains('Ä'), "CP273 should decode 0x4A as Ä");
+    assert!(
+        !as_cp037.contains('Ä'),
+        "CP037 output must not contain the CP273 character"
+    );
+}
+
+#[test]
+fn cli_explicit_codepage_overrides_default() {
+    // With no --codepage the CP037 default applies (0x4A → ¢); an explicit
+    // --codepage cp273 overrides that default (0x4A → Ä).
+    let default_out = decode_single_byte(0x4A, None);
+    let explicit_out = decode_single_byte(0x4A, Some("cp273"));
+
+    assert!(
+        default_out.contains('¢'),
+        "default codepage (CP037) should decode 0x4A as ¢, got: {default_out}"
+    );
+    assert!(
+        explicit_out.contains('Ä'),
+        "explicit CP273 should decode 0x4A as Ä, got: {explicit_out}"
+    );
+}

--- a/crates/copybook-cli/tests/codepage_precedence.rs
+++ b/crates/copybook-cli/tests/codepage_precedence.rs
@@ -23,8 +23,10 @@ fn path_str(p: &std::path::Path) -> String {
 }
 
 /// Decode a single `byte` through `copybook decode`, optionally passing
-/// `--codepage`, and return the JSONL written to `--output`.
-fn decode_single_byte(byte: u8, codepage: Option<&str>) -> String {
+/// `--codepage`, then parse the JSONL output and return the decoded `SIG` field.
+/// Parsing (rather than a substring match) keeps the assertion exact and robust
+/// to any future change in the JSONL envelope.
+fn decode_sig(byte: u8, codepage: Option<&str>) -> String {
     let dir = assert_fs::TempDir::new().unwrap();
     let cpy = dir.child("sig.cpy");
     cpy.write_str(SIG_CPY).unwrap();
@@ -47,7 +49,14 @@ fn decode_single_byte(byte: u8, codepage: Option<&str>) -> String {
     }
     cmd.assert().success();
 
-    std::fs::read_to_string(out.path()).unwrap()
+    let contents = std::fs::read_to_string(out.path()).unwrap();
+    let line = contents.lines().next().expect("at least one JSONL record");
+    let value: serde_json::Value = serde_json::from_str(line).expect("valid JSON line");
+    value
+        .get("SIG")
+        .and_then(serde_json::Value::as_str)
+        .expect("SIG field present")
+        .to_owned()
 }
 
 // ====================================================================
@@ -58,35 +67,25 @@ fn decode_single_byte(byte: u8, codepage: Option<&str>) -> String {
 #[test]
 fn cli_decode_cp273_signature() {
     // CP273 0x4A = Ä (German A-umlaut).
-    let out = decode_single_byte(0x4A, Some("cp273"));
-    assert!(out.contains('Ä'), "CP273 decode should yield Ä, got: {out}");
+    assert_eq!(decode_sig(0x4A, Some("cp273")), "Ä");
 }
 
 #[test]
 fn cli_decode_cp500_signature() {
     // CP500 0x4F = ! (where CP037 has |).
-    let out = decode_single_byte(0x4F, Some("cp500"));
-    assert!(out.contains('!'), "CP500 decode should yield !, got: {out}");
+    assert_eq!(decode_sig(0x4F, Some("cp500")), "!");
 }
 
 #[test]
 fn cli_decode_cp1047_signature() {
     // CP1047 0xBA = Ý (where CP037 has [) — the z/OS-Unix bracket swap.
-    let out = decode_single_byte(0xBA, Some("cp1047"));
-    assert!(
-        out.contains('Ý'),
-        "CP1047 decode should yield Ý, got: {out}"
-    );
+    assert_eq!(decode_sig(0xBA, Some("cp1047")), "Ý");
 }
 
 #[test]
 fn cli_decode_cp1140_signature() {
     // CP1140 0xFF = € (Euro), the single byte that differs from CP037.
-    let out = decode_single_byte(0xFF, Some("cp1140"));
-    assert!(
-        out.contains('€'),
-        "CP1140 decode should yield €, got: {out}"
-    );
+    assert_eq!(decode_sig(0xFF, Some("cp1140")), "€");
 }
 
 // ====================================================================
@@ -98,30 +97,14 @@ fn cli_decode_cp1140_signature() {
 #[test]
 fn cli_codepage_flag_changes_decoded_character() {
     // Byte 0x4A is ¢ in CP037 but Ä in CP273 — same bytes, different flag.
-    let as_cp037 = decode_single_byte(0x4A, Some("cp037"));
-    let as_cp273 = decode_single_byte(0x4A, Some("cp273"));
-
-    assert!(as_cp037.contains('¢'), "CP037 should decode 0x4A as ¢");
-    assert!(as_cp273.contains('Ä'), "CP273 should decode 0x4A as Ä");
-    assert!(
-        !as_cp037.contains('Ä'),
-        "CP037 output must not contain the CP273 character"
-    );
+    assert_eq!(decode_sig(0x4A, Some("cp037")), "¢");
+    assert_eq!(decode_sig(0x4A, Some("cp273")), "Ä");
 }
 
 #[test]
 fn cli_explicit_codepage_overrides_default() {
     // With no --codepage the CP037 default applies (0x4A → ¢); an explicit
     // --codepage cp273 overrides that default (0x4A → Ä).
-    let default_out = decode_single_byte(0x4A, None);
-    let explicit_out = decode_single_byte(0x4A, Some("cp273"));
-
-    assert!(
-        default_out.contains('¢'),
-        "default codepage (CP037) should decode 0x4A as ¢, got: {default_out}"
-    );
-    assert!(
-        explicit_out.contains('Ä'),
-        "explicit CP273 should decode 0x4A as Ä, got: {explicit_out}"
-    );
+    assert_eq!(decode_sig(0x4A, None), "¢");
+    assert_eq!(decode_sig(0x4A, Some("cp273")), "Ä");
 }

--- a/crates/copybook-codec/tests/codepage_evidence_matrix.rs
+++ b/crates/copybook-codec/tests/codepage_evidence_matrix.rs
@@ -1,0 +1,446 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+//! Consolidated per-codepage evidence matrix (issue #573).
+//!
+//! Prior coverage already exercises the charset byte tables
+//! (`crates/copybook-charset/tests/*`), fixed-format single-record decode/encode
+//! (`codepage_comprehensive.rs`), and zoned-overpunch behavior by codepage
+//! (`decimal_edge_cases.rs`). The remaining evidence plane called out in #573 is
+//! a single per-codepage scenario table that links
+//! **parse → layout → decode → encode → rejection** across *both* `Fixed` and
+//! `RDW` record framing, driven through the streaming `decode_file_to_jsonl` /
+//! `encode_jsonl_to_file` entry points as well as the single-record API.
+//!
+//! Two orthogonal discriminators pin down "the requested codepage really
+//! governed the conversion":
+//!
+//! * **Decode discriminator** — one raw EBCDIC byte (`probe_byte`) that decodes
+//!   to a *different* character (`probe_ch`) under each codepage (e.g. byte
+//!   `0x4A` is `¢` in CP037 but `Ä` in CP273 and `[` in CP500).
+//! * **Round-trip discriminator** — the ASCII character `[` (`RT_CH`), which
+//!   maps to a *different* EBCDIC byte (`rt_byte`) under each codepage. `[` is a
+//!   single UTF-8 byte, so it also round-trips cleanly through the encode
+//!   capacity check for a one-byte `PIC X(1)` field (unlike a national
+//!   character such as `¢`, which is two UTF-8 bytes — see
+//!   `encode_capacity_is_measured_in_utf8_bytes`).
+
+use copybook_codec::charset::{ebcdic_to_utf8, utf8_to_ebcdic};
+use copybook_codec::{
+    Codepage, DecodeOptions, EncodeOptions, JsonNumberMode, RecordFormat, UnmappablePolicy,
+    decode_file_to_jsonl, decode_record, encode_jsonl_to_file, encode_record,
+};
+use copybook_core::{ErrorCode, parse_copybook};
+use std::io::Cursor;
+
+/// One-field copybook used across the matrix: a single alphanumeric byte, so the
+/// record LRECL is exactly one byte regardless of codepage.
+const SIG_COPYBOOK: &str = "01 REC.\n   05 SIG PIC X(1).";
+
+/// The ASCII round-trip character shared by every row (see module docs).
+const RT_CH: &str = "[";
+
+/// Per-codepage signature row.
+struct Signature {
+    cp: Codepage,
+    /// Raw byte whose decoded character discriminates this codepage.
+    probe_byte: u8,
+    /// Expected decode of `probe_byte` under `cp`.
+    probe_ch: &'static str,
+    /// EBCDIC byte that `RT_CH` (`[`) maps to under `cp`.
+    rt_byte: u8,
+}
+
+const SIGNATURES: &[Signature] = &[
+    // CP037: 0x4A = ¢, and `[` lives at 0xBA.
+    Signature {
+        cp: Codepage::CP037,
+        probe_byte: 0x4A,
+        probe_ch: "¢",
+        rt_byte: 0xBA,
+    },
+    // CP273: 0x4A = Ä (German A-umlaut), and `[` lives at 0x63.
+    Signature {
+        cp: Codepage::CP273,
+        probe_byte: 0x4A,
+        probe_ch: "Ä",
+        rt_byte: 0x63,
+    },
+    // CP500: 0x4A = [ itself (so `[` maps back to 0x4A).
+    Signature {
+        cp: Codepage::CP500,
+        probe_byte: 0x4A,
+        probe_ch: "[",
+        rt_byte: 0x4A,
+    },
+    // CP1047: 0xBA = Ý (where CP037 has [), and `[` lives at 0xAD.
+    Signature {
+        cp: Codepage::CP1047,
+        probe_byte: 0xBA,
+        probe_ch: "Ý",
+        rt_byte: 0xAD,
+    },
+    // CP1140: 0xFF = € (the single byte differing from CP037); `[` at 0xBA.
+    Signature {
+        cp: Codepage::CP1140,
+        probe_byte: 0xFF,
+        probe_ch: "€",
+        rt_byte: 0xBA,
+    },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn decode_opts(cp: Codepage, format: RecordFormat) -> DecodeOptions {
+    DecodeOptions::new()
+        .with_format(format)
+        .with_codepage(cp)
+        .with_json_number_mode(JsonNumberMode::Lossless)
+        .with_emit_meta(false)
+}
+
+fn encode_opts(cp: Codepage, format: RecordFormat) -> EncodeOptions {
+    EncodeOptions::new().with_format(format).with_codepage(cp)
+}
+
+/// Wrap a payload in a canonical RDW frame: 2-byte big-endian length, 2 reserved
+/// bytes (zero), then the payload.
+fn rdw_frame(payload: &[u8]) -> Vec<u8> {
+    let len = u16::try_from(payload.len()).expect("payload fits in u16");
+    let mut framed = Vec::with_capacity(payload.len() + 4);
+    framed.extend_from_slice(&len.to_be_bytes());
+    framed.extend_from_slice(&[0x00, 0x00]);
+    framed.extend_from_slice(payload);
+    framed
+}
+
+/// Extract the `SIG` field value from the first JSONL record line. Handles both
+/// the flat envelope (`emit_meta(false)`) and a nested `fields` envelope.
+fn sig_from_jsonl(jsonl: &[u8]) -> String {
+    let text = String::from_utf8(jsonl.to_vec()).expect("jsonl output is valid UTF-8");
+    let line = text.lines().next().expect("at least one JSONL record");
+    let value: serde_json::Value = serde_json::from_str(line).expect("valid JSON line");
+    let field = value
+        .get("SIG")
+        .or_else(|| value.get("fields").and_then(|fields| fields.get("SIG")))
+        .and_then(serde_json::Value::as_str);
+    match field {
+        Some(text) => text.to_owned(),
+        None => panic!("SIG field missing in JSONL line: {line}"),
+    }
+}
+
+// ===========================================================================
+// Charset plane: the signature invariants the rest of the matrix relies on.
+// ===========================================================================
+
+#[test]
+fn charset_signatures_hold() {
+    for sig in SIGNATURES {
+        // Decode discriminator.
+        let decoded = ebcdic_to_utf8(&[sig.probe_byte], sig.cp, UnmappablePolicy::Error)
+            .unwrap_or_else(|e| {
+                panic!(
+                    "decode 0x{:02X} under {} failed: {e}",
+                    sig.probe_byte, sig.cp
+                )
+            });
+        assert_eq!(
+            decoded, sig.probe_ch,
+            "byte 0x{:02X} must decode to {:?} under {}",
+            sig.probe_byte, sig.probe_ch, sig.cp
+        );
+
+        // Round-trip discriminator: `[` maps to rt_byte, and back.
+        let encoded = utf8_to_ebcdic(RT_CH, sig.cp)
+            .unwrap_or_else(|e| panic!("encode {RT_CH:?} under {} failed: {e}", sig.cp));
+        assert_eq!(
+            encoded,
+            vec![sig.rt_byte],
+            "{RT_CH:?} must encode to 0x{:02X} under {}",
+            sig.rt_byte,
+            sig.cp
+        );
+        let back =
+            ebcdic_to_utf8(&[sig.rt_byte], sig.cp, UnmappablePolicy::Error).unwrap_or_else(|e| {
+                panic!("decode 0x{:02X} under {} failed: {e}", sig.rt_byte, sig.cp)
+            });
+        assert_eq!(
+            back, RT_CH,
+            "0x{:02X} must decode to {RT_CH:?} under {}",
+            sig.rt_byte, sig.cp
+        );
+    }
+}
+
+// ===========================================================================
+// Parse / layout plane: the schema (and thus LRECL/layout) is codepage-
+// independent, so a fixed stream of N probe bytes yields exactly N records
+// under every codepage, each decoding to that codepage's probe character.
+// ===========================================================================
+
+#[test]
+fn parse_layout_stable_across_codepages() {
+    let schema = parse_copybook(SIG_COPYBOOK).expect("copybook parses");
+
+    for sig in SIGNATURES {
+        let payload = vec![sig.probe_byte; 3];
+        let mut output = Vec::new();
+        let summary = decode_file_to_jsonl(
+            &schema,
+            Cursor::new(payload),
+            &mut output,
+            &decode_opts(sig.cp, RecordFormat::Fixed),
+        )
+        .unwrap_or_else(|e| panic!("fixed decode under {} failed: {e}", sig.cp));
+
+        assert_eq!(
+            summary.records_processed, 3,
+            "1-byte LRECL layout must yield 3 records under {}",
+            sig.cp
+        );
+
+        let text = String::from_utf8(output).expect("jsonl utf-8");
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(lines.len(), 3, "expected 3 JSONL lines under {}", sig.cp);
+        for line in lines {
+            assert_eq!(
+                sig_from_jsonl(line.as_bytes()),
+                sig.probe_ch,
+                "each record must decode to {:?} under {}",
+                sig.probe_ch,
+                sig.cp
+            );
+        }
+    }
+}
+
+// ===========================================================================
+// Single-record decode/encode plane (Fixed), using the ASCII round-trip char.
+// ===========================================================================
+
+#[test]
+fn single_record_decode_encode_fixed() {
+    let schema = parse_copybook(SIG_COPYBOOK).expect("copybook parses");
+
+    for sig in SIGNATURES {
+        let json = decode_record(
+            &schema,
+            &[sig.rt_byte],
+            &decode_opts(sig.cp, RecordFormat::Fixed),
+        )
+        .unwrap_or_else(|e| panic!("decode_record under {} failed: {e}", sig.cp));
+        assert_eq!(
+            json.get("SIG").and_then(serde_json::Value::as_str),
+            Some(RT_CH),
+            "single-record decode of 0x{:02X} must yield {RT_CH:?} under {}",
+            sig.rt_byte,
+            sig.cp
+        );
+
+        let encoded = encode_record(&schema, &json, &encode_opts(sig.cp, RecordFormat::Fixed))
+            .unwrap_or_else(|e| panic!("encode_record under {} failed: {e}", sig.cp));
+        assert_eq!(
+            encoded,
+            vec![sig.rt_byte],
+            "single-record encode of {RT_CH:?} must reproduce 0x{:02X} under {}",
+            sig.rt_byte,
+            sig.cp
+        );
+    }
+}
+
+// ===========================================================================
+// Streaming decode → encode round-trip plane (Fixed).
+// ===========================================================================
+
+#[test]
+fn streaming_roundtrip_fixed() {
+    let schema = parse_copybook(SIG_COPYBOOK).expect("copybook parses");
+
+    for sig in SIGNATURES {
+        let original = vec![sig.rt_byte];
+
+        let mut jsonl = Vec::new();
+        decode_file_to_jsonl(
+            &schema,
+            Cursor::new(original.clone()),
+            &mut jsonl,
+            &decode_opts(sig.cp, RecordFormat::Fixed),
+        )
+        .unwrap_or_else(|e| panic!("fixed decode under {} failed: {e}", sig.cp));
+        assert_eq!(
+            sig_from_jsonl(&jsonl),
+            RT_CH,
+            "fixed decode under {}",
+            sig.cp
+        );
+
+        let mut reencoded = Vec::new();
+        encode_jsonl_to_file(
+            &schema,
+            Cursor::new(jsonl),
+            &mut reencoded,
+            &encode_opts(sig.cp, RecordFormat::Fixed),
+        )
+        .unwrap_or_else(|e| panic!("fixed encode under {} failed: {e}", sig.cp));
+        assert_eq!(
+            reencoded, original,
+            "fixed streaming round-trip must be byte-identical under {}",
+            sig.cp
+        );
+    }
+}
+
+// ===========================================================================
+// Streaming decode → encode round-trip plane (RDW) — the primary #573 gap.
+// ===========================================================================
+
+#[test]
+fn streaming_roundtrip_rdw() {
+    let schema = parse_copybook(SIG_COPYBOOK).expect("copybook parses");
+
+    for sig in SIGNATURES {
+        let framed = rdw_frame(&[sig.rt_byte]);
+
+        let mut jsonl = Vec::new();
+        decode_file_to_jsonl(
+            &schema,
+            Cursor::new(framed.clone()),
+            &mut jsonl,
+            &decode_opts(sig.cp, RecordFormat::RDW),
+        )
+        .unwrap_or_else(|e| panic!("RDW decode under {} failed: {e}", sig.cp));
+        assert_eq!(sig_from_jsonl(&jsonl), RT_CH, "RDW decode under {}", sig.cp);
+
+        let mut reencoded = Vec::new();
+        encode_jsonl_to_file(
+            &schema,
+            Cursor::new(jsonl),
+            &mut reencoded,
+            &encode_opts(sig.cp, RecordFormat::RDW),
+        )
+        .unwrap_or_else(|e| panic!("RDW encode under {} failed: {e}", sig.cp));
+        assert_eq!(
+            reencoded, framed,
+            "RDW streaming round-trip must reproduce header+payload under {}",
+            sig.cp
+        );
+    }
+}
+
+// ===========================================================================
+// Fixed-vs-RDW linkage: the same payload byte decodes to the same character
+// regardless of framing, for every codepage.
+// ===========================================================================
+
+#[test]
+fn fixed_and_rdw_decode_agree() {
+    let schema = parse_copybook(SIG_COPYBOOK).expect("copybook parses");
+
+    for sig in SIGNATURES {
+        let mut fixed_out = Vec::new();
+        decode_file_to_jsonl(
+            &schema,
+            Cursor::new(vec![sig.probe_byte]),
+            &mut fixed_out,
+            &decode_opts(sig.cp, RecordFormat::Fixed),
+        )
+        .unwrap_or_else(|e| panic!("fixed decode under {} failed: {e}", sig.cp));
+
+        let mut rdw_out = Vec::new();
+        decode_file_to_jsonl(
+            &schema,
+            Cursor::new(rdw_frame(&[sig.probe_byte])),
+            &mut rdw_out,
+            &decode_opts(sig.cp, RecordFormat::RDW),
+        )
+        .unwrap_or_else(|e| panic!("RDW decode under {} failed: {e}", sig.cp));
+
+        assert_eq!(
+            sig_from_jsonl(&fixed_out),
+            sig_from_jsonl(&rdw_out),
+            "Fixed and RDW framing must decode identically under {}",
+            sig.cp
+        );
+        assert_eq!(
+            sig_from_jsonl(&fixed_out),
+            sig.probe_ch,
+            "framing-agnostic decode must yield {:?} under {}",
+            sig.probe_ch,
+            sig.cp
+        );
+    }
+}
+
+// ===========================================================================
+// Rejection plane: deliberate, stable rejections.
+// ===========================================================================
+
+#[test]
+fn decode_rejects_unmappable_byte_all_codepages() {
+    let schema = parse_copybook(SIG_COPYBOOK).expect("copybook parses");
+
+    for sig in SIGNATURES {
+        // 0x00 (EBCDIC NUL / U+0000) is an unmappable control byte in every
+        // supported codepage; with the Error policy the decode must reject it.
+        let opts = decode_opts(sig.cp, RecordFormat::Fixed)
+            .with_unmappable_policy(UnmappablePolicy::Error);
+        let err = decode_record(&schema, &[0x00], &opts)
+            .expect_err("unmappable NUL byte must be rejected under Error policy");
+        assert_eq!(
+            err.code,
+            ErrorCode::CBKC301_INVALID_EBCDIC_BYTE,
+            "unmappable decode must surface CBKC301 under {}",
+            sig.cp
+        );
+    }
+}
+
+#[test]
+fn encode_euro_is_specific_to_cp1140() {
+    // The Euro sign is representable only in CP1140 among the supported EBCDIC
+    // codepages. Encoding it into a field wide enough to pass the (UTF-8-byte)
+    // length check therefore succeeds under CP1140 and is rejected as an
+    // unmappable character (CBKC301) under every other codepage.
+    let schema = parse_copybook("01 REC.\n   05 EU PIC X(4).").expect("copybook parses");
+    let json = serde_json::json!({ "EU": "€" });
+
+    for sig in SIGNATURES {
+        let result = encode_record(&schema, &json, &encode_opts(sig.cp, RecordFormat::Fixed));
+        if sig.cp == Codepage::CP1140 {
+            let encoded = result.unwrap_or_else(|e| panic!("CP1140 must encode €: {e}"));
+            assert_eq!(encoded[0], 0xFF, "€ must encode to 0xFF under CP1140");
+        } else {
+            let err = result.expect_err("€ must be rejected outside CP1140");
+            assert_eq!(
+                err.code,
+                ErrorCode::CBKC301_INVALID_EBCDIC_BYTE,
+                "unmappable € must surface CBKC301 under {}",
+                sig.cp
+            );
+        }
+    }
+}
+
+// ===========================================================================
+// Documented asymmetry: the encode capacity check counts UTF-8 bytes, not
+// characters, so a single-byte alphanumeric field cannot hold a national
+// character that occupies more than one UTF-8 byte even though it maps to a
+// single EBCDIC byte. This pins the current, observed contract.
+// ===========================================================================
+
+#[test]
+fn encode_capacity_is_measured_in_utf8_bytes() {
+    let schema = parse_copybook(SIG_COPYBOOK).expect("copybook parses");
+    // "¢" is one character but two UTF-8 bytes; PIC X(1) has capacity one byte.
+    let json = serde_json::json!({ "SIG": "¢" });
+    let err = encode_record(
+        &schema,
+        &json,
+        &encode_opts(Codepage::CP037, RecordFormat::Fixed),
+    )
+    .expect_err("2-byte UTF-8 char must not fit a 1-byte field");
+    assert_eq!(err.code, ErrorCode::CBKE515_STRING_LENGTH_VIOLATION);
+}

--- a/docs/reference/COBOL_SUPPORT_MATRIX.md
+++ b/docs/reference/COBOL_SUPPORT_MATRIX.md
@@ -64,11 +64,11 @@
 
 | Feature | Status | Test Evidence | Notes |
 |---------|--------|---------------|-------|
-| CP037 (US/Canada) | ✅ Fully Supported | Primary codepage across 35+ test files, `comprehensive_numeric_tests.rs::test_codepage_specific_behavior` | Default EBCDIC codepage |
-| CP273 (German) | ✅ Fully Supported | `prop_codepage_parity_extra.rs`, `decimal_edge_cases.rs::test_zoned_overpunch_by_codepage` | Full character conversion support |
-| CP500 (International) | ✅ Fully Supported | `prop_codepage_parity_extra.rs`, `decimal_edge_cases.rs::test_zoned_overpunch_by_codepage` | International variant support |
-| CP1047 (Latinized) | ✅ Fully Supported | `prop_codepage_parity_extra.rs`, `decimal_edge_cases.rs::test_zoned_overpunch_by_codepage` | Latin-1 based EBCDIC |
-| CP1140 (Euro) | ✅ Fully Supported | `prop_codepage_parity_extra.rs`, `decimal_edge_cases.rs::test_zoned_overpunch_by_codepage` | Euro currency support |
+| CP037 (US/Canada) | ✅ Fully Supported | Primary codepage across 35+ test files, `comprehensive_numeric_tests.rs::test_codepage_specific_behavior`, `codepage_evidence_matrix.rs` | Default EBCDIC codepage |
+| CP273 (German) | ✅ Fully Supported | `prop_codepage_parity_extra.rs`, `decimal_edge_cases.rs::test_zoned_overpunch_by_codepage`, `codepage_evidence_matrix.rs`, `codepage_precedence.rs::cli_decode_cp273_signature` | Full character conversion support |
+| CP500 (International) | ✅ Fully Supported | `prop_codepage_parity_extra.rs`, `decimal_edge_cases.rs::test_zoned_overpunch_by_codepage`, `codepage_evidence_matrix.rs`, `codepage_precedence.rs::cli_decode_cp500_signature` | International variant support |
+| CP1047 (Latinized) | ✅ Fully Supported | `prop_codepage_parity_extra.rs`, `decimal_edge_cases.rs::test_zoned_overpunch_by_codepage`, `codepage_evidence_matrix.rs`, `codepage_precedence.rs::cli_decode_cp1047_signature` | Latin-1 based EBCDIC |
+| CP1140 (Euro) | ✅ Fully Supported | `prop_codepage_parity_extra.rs`, `decimal_edge_cases.rs::test_zoned_overpunch_by_codepage`, `codepage_evidence_matrix.rs::encode_euro_is_specific_to_cp1140`, `codepage_precedence.rs::cli_decode_cp1140_signature` | Euro currency support |
 | ASCII (supplementary) | ✅ Fully Supported | `binary_roundtrip_fidelity_tests.rs::test_ascii_zoned_roundtrip_byte_identical`, `encode_options_zoned_encoding_tests.rs::test_encode_preserves_ascii_format` | For comparison/testing purposes |
 
 ## Edited PIC Clauses


### PR DESCRIPTION
## Summary

Closes the "missing evidence plane" called out in #573: a **consolidated per-codepage** scenario matrix that links **parse → layout → decode → encode → rejection** across *both* `Fixed` and `RDW` record framing, plus CLI-level coverage.

Prior coverage already exercised the charset byte tables (`copybook-charset` tests), fixed-format single-record decode/encode (`codepage_comprehensive.rs`), and zoned-overpunch by codepage (`decimal_edge_cases.rs`). The gaps this PR fills:

- **RDW-framed per-codepage** streaming decode/encode round-trips (existing RDW tests only used `ASCII`).
- **Streaming `decode_file_to_jsonl` / `encode_jsonl_to_file`** coverage per non-CP037 EBCDIC codepage, in both framing modes.
- **CLI (`copybook decode`) coverage for CP273/CP500/CP1047/CP1140** — before this, only CP037 was exercised through the compiled binary — plus `--codepage` precedence over the CP037 default.

Each codepage carries a *decode discriminator* (one raw byte that decodes to a different character per codepage) and a *round-trip discriminator* (the ASCII `[`, which maps to a distinct EBCDIC byte per codepage and round-trips cleanly), so a passing row is positive evidence that the requested codepage — not a silent default — governed the conversion.

### Documented decision

While building the round-trip rows I found an asymmetry worth pinning: the encode capacity check measures **UTF-8 byte length**, not character count, so a `PIC X(1)` field rejects a national character like `¢` (two UTF-8 bytes → `CBKE515`) even though it maps to a single EBCDIC byte. Rather than paper over it, the round-trip evidence uses the single-UTF-8-byte `[` and one test (`encode_capacity_is_measured_in_utf8_bytes`) documents the current observed contract. This is a candidate follow-up if the intended semantics are character-based capacity for EBCDIC codepages.

## Type of Change

- [x] Tests (test additions or improvements)
- [x] Documentation (docs/ evidence references)

## COBOL/Mainframe Context

- **COBOL features affected**: DISPLAY (`PIC X`) EBCDIC↔UTF-8 conversion across codepages CP037/CP273/CP500/CP1047/CP1140
- **Data processing impact**: decode, encode, character conversion, record framing (Fixed vs RDW)
- **Mainframe compatibility**: exercises the classic CP037 vs CP1047 bracket swap, CP500 international variant, CP273 German diacritics, and CP1140 Euro sign

## Workspace Crates Affected

- [x] copybook-codec (encoding, decoding, character conversion)
- [x] copybook-cli (CLI commands and options)

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (`docs/reference/COBOL_SUPPORT_MATRIX.md` evidence references)
- [ ] CHANGELOG.md updated (not user-facing — test/docs only)
- [x] `cargo fmt --all` passes
- [x] `cargo clippy` clean on the new targets (`-D warnings -W clippy::pedantic`)
- [x] New test suites pass locally (`cargo test`)
- [x] Follows conventional commit format (`test(codepage):`)

## Testing Instructions

```bash
cargo test --package copybook-codec --test codepage_evidence_matrix   # 9 tests
cargo test --package copybook-cli   --test codepage_precedence        # 6 tests
cargo clippy --package copybook-codec --test codepage_evidence_matrix \
             --package copybook-cli   --test codepage_precedence -- -D warnings -W clippy::pedantic
cargo fmt --all --check
```

CI is currently unavailable, so verification was performed locally: both suites pass (9 + 6 = 15 tests), and both new targets are `cargo fmt` and `clippy::pedantic` clean.

> Note: a pre-existing `clippy::pedantic` doc-backtick warning in the unrelated `sign_separate_tests.rs` is present on `main` and is out of scope for this PR.

## Performance Impact

- [x] No performance impact expected

## Breaking Changes

- [x] No breaking changes

## Related Issues

Relates to #573 (evidence coordinator issue for #551)

## Additional Notes

New files:
- `crates/copybook-codec/tests/codepage_evidence_matrix.rs`
- `crates/copybook-cli/tests/codepage_precedence.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WK5yVbkkG55fza5mPj6Zue)_