### PR TITLE
feat(codec): honor threaded decode configuration

### DIFF
--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -2729,14 +2729,7 @@ fn process_rdw_records<R: Read, W: Write>(
         if let Some(schema_lrecl) = schema.lrecl_fixed
             && rdw_record.payload.len() < schema_lrecl as usize
         {
-            let error = Error::new(
-                ErrorCode::CBKF221_RDW_UNDERFLOW,
-                format!(
-                    "RDW payload too short: {} bytes, schema requires {} bytes",
-                    rdw_record.payload.len(),
-                    schema_lrecl
-                ),
-            );
+            let error = rdw_underflow_error(schema_lrecl, rdw_record.payload.len());
 
             summary.records_with_errors += 1;
             let family = error.family_prefix();
@@ -2747,17 +2740,7 @@ fn process_rdw_records<R: Read, W: Write>(
             continue;
         }
 
-        let full_raw_data = match options.emit_raw {
-            crate::options::RawMode::RecordRDW => {
-                let mut full_data =
-                    Vec::with_capacity(rdw_record.header.len() + rdw_record.payload.len());
-                full_data.extend_from_slice(&rdw_record.header);
-                full_data.extend_from_slice(&rdw_record.payload);
-                Some(full_data)
-            }
-            crate::options::RawMode::Record => Some(rdw_record.payload.clone()),
-            _ => None,
-        };
+        let full_raw_data = rdw_raw_data(&rdw_record, options.emit_raw);
 
         match decode_record_with_scratch_and_raw(
             schema,
@@ -2783,6 +2766,29 @@ fn process_rdw_records<R: Read, W: Write>(
     }
 
     Ok(())
+}
+
+fn rdw_underflow_error(schema_lrecl: u32, payload_len: usize) -> Error {
+    Error::new(
+        ErrorCode::CBKF221_RDW_UNDERFLOW,
+        format!("RDW payload too short: {payload_len} bytes, schema requires {schema_lrecl} bytes"),
+    )
+}
+
+fn rdw_raw_data(
+    record: &crate::record::RDWRecord,
+    raw_mode: crate::options::RawMode,
+) -> Option<Vec<u8>> {
+    match raw_mode {
+        crate::options::RawMode::RecordRDW => {
+            let mut full_data = Vec::with_capacity(record.header.len() + record.payload.len());
+            full_data.extend_from_slice(&record.header);
+            full_data.extend_from_slice(&record.payload);
+            Some(full_data)
+        }
+        crate::options::RawMode::Record => Some(record.payload.clone()),
+        _ => None,
+    }
 }
 
 fn process_rdw_records_parallel<R: Read, W: Write>(
@@ -2826,14 +2832,7 @@ fn process_rdw_records_parallel<R: Read, W: Write>(
         if let Some(schema_lrecl) = schema.lrecl_fixed
             && rdw_record.payload.len() < schema_lrecl as usize
         {
-            let error = Error::new(
-                ErrorCode::CBKF221_RDW_UNDERFLOW,
-                format!(
-                    "RDW payload too short: {} bytes, schema requires {} bytes",
-                    rdw_record.payload.len(),
-                    schema_lrecl
-                ),
-            );
+            let error = rdw_underflow_error(schema_lrecl, rdw_record.payload.len());
 
             summary.records_with_errors += 1;
             let family = error.family_prefix();
@@ -2851,17 +2850,7 @@ fn process_rdw_records_parallel<R: Read, W: Write>(
             continue;
         }
 
-        let full_raw_data = match options.emit_raw {
-            crate::options::RawMode::RecordRDW => {
-                let mut full_data =
-                    Vec::with_capacity(rdw_record.header.len() + rdw_record.payload.len());
-                full_data.extend_from_slice(&rdw_record.header);
-                full_data.extend_from_slice(&rdw_record.payload);
-                Some(full_data)
-            }
-            crate::options::RawMode::Record => Some(rdw_record.payload.clone()),
-            _ => None,
-        };
+        let full_raw_data = rdw_raw_data(&rdw_record, options.emit_raw);
 
         if let Err(error) = pool.submit(DecodeWork {
             payload: rdw_record.payload,

--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -16,6 +16,7 @@ use copybook_core::{Error, ErrorCode, Result, Schema};
 use serde_json::Value;
 use std::convert::TryFrom;
 use std::io::{BufRead, BufReader, Read, Write};
+use std::sync::Arc;
 use tracing::info;
 
 mod envelope;
@@ -2406,6 +2407,10 @@ fn encode_binary_int_field(
 ///
 /// Reads records from `input` using the configured [`RecordFormat`]
 ///
+/// When `options.threads` is greater than one, records are decoded through a
+/// bounded worker pool and emitted in input order. A zero thread setting uses
+/// one worker for a safe single-threaded fallback.
+///
 /// # Examples
 ///
 /// ```
@@ -2434,7 +2439,7 @@ pub fn decode_file_to_jsonl(
     options: &DecodeOptions,
 ) -> Result<RunSummary> {
     let start_time = std::time::Instant::now();
-    let mut summary = RunSummary::new();
+    let mut summary = RunSummary::with_threads(options.threads.max(1));
     summary.set_schema_fingerprint(schema.fingerprint.clone());
 
     reset_warning_counter();
@@ -2482,6 +2487,10 @@ fn process_fixed_records<R: Read, W: Write>(
     options: &DecodeOptions,
     summary: &mut RunSummary,
 ) -> Result<()> {
+    if options.threads > 1 {
+        return process_fixed_records_parallel(schema, reader, output, options, summary);
+    }
+
     let mut reader = crate::record::FixedRecordReader::new(reader, schema.lrecl_fixed)?;
     let mut scratch = crate::memory::ScratchBuffers::new();
     let mut record_index = 0u64;
@@ -2522,6 +2531,177 @@ fn process_fixed_records<R: Read, W: Write>(
     Ok(())
 }
 
+struct DecodeWork {
+    payload: Vec<u8>,
+    raw_data: Option<Vec<u8>>,
+    record_index: u64,
+}
+
+struct DecodeOutcome {
+    result: Result<Value>,
+    warnings: u64,
+}
+
+fn decode_worker_pool(
+    schema: &Schema,
+    options: &DecodeOptions,
+) -> crate::memory::WorkerPool<DecodeWork, DecodeOutcome> {
+    let workers = options.threads.max(1);
+    let channel_capacity = workers.saturating_mul(4).max(1);
+    let max_window_size = workers.saturating_mul(2).max(1);
+    let schema = Arc::new(schema.clone());
+    let options = Arc::new(options.clone());
+
+    crate::memory::WorkerPool::new(
+        workers,
+        channel_capacity,
+        max_window_size,
+        move |work: DecodeWork, scratch: &mut crate::memory::ScratchBuffers| {
+            let warning_count_before = warning_count();
+            let result = decode_record_with_scratch_and_raw(
+                &schema,
+                &work.payload,
+                &options,
+                work.raw_data,
+                work.record_index,
+                scratch,
+            );
+            let warnings = warning_count().saturating_sub(warning_count_before);
+            DecodeOutcome { result, warnings }
+        },
+    )
+}
+
+fn process_decode_batch<W: Write>(
+    pool: &mut crate::memory::WorkerPool<DecodeWork, DecodeOutcome>,
+    batch_len: usize,
+    output: &mut W,
+    options: &DecodeOptions,
+    summary: &mut RunSummary,
+) -> Result<()> {
+    let mut first_error = None;
+
+    for _ in 0..batch_len {
+        let outcome = pool
+            .recv_ordered()
+            .map_err(|error| Error::new(ErrorCode::CBKI001_INVALID_STATE, error.to_string()))?
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::CBKI001_INVALID_STATE,
+                    "decode worker pool ended before the submitted batch completed",
+                )
+            })?;
+
+        for _ in 0..outcome.warnings {
+            increment_warning_counter();
+        }
+
+        if first_error.is_some() {
+            continue;
+        }
+
+        match outcome.result {
+            Ok(json_value) => {
+                write_json_record(output, &json_value)?;
+                summary.records_processed += 1;
+            }
+            Err(error) => {
+                summary.records_with_errors += 1;
+                let family = error.family_prefix();
+                telemetry::record_error(family);
+                if options.strict_mode {
+                    first_error = Some(error);
+                }
+            }
+        }
+    }
+
+    first_error.map_or(Ok(()), Err)
+}
+
+fn process_fixed_records_parallel<R: Read, W: Write>(
+    schema: &Schema,
+    reader: R,
+    output: &mut W,
+    options: &DecodeOptions,
+    summary: &mut RunSummary,
+) -> Result<()> {
+    let mut reader = crate::record::FixedRecordReader::new(reader, schema.lrecl_fixed)?;
+    let workers = options.threads.max(1);
+    let batch_capacity = workers.saturating_mul(4).max(1);
+    let mut pool = decode_worker_pool(schema, options);
+    let mut record_index = 0_u64;
+    let mut batch_len = 0_usize;
+
+    loop {
+        let record = match reader.read_record() {
+            Ok(record) => record,
+            Err(error) => {
+                let pending_result = if batch_len > 0 {
+                    process_decode_batch(&mut pool, batch_len, output, options, summary)
+                } else {
+                    Ok(())
+                };
+                let _ = pool.shutdown();
+                pending_result?;
+                return Err(error);
+            }
+        };
+        let Some(record_data) = record else { break };
+
+        record_index += 1;
+        summary.bytes_processed += record_data.len() as u64;
+        telemetry::record_read(record_data.len(), options);
+        let raw_data = match options.emit_raw {
+            crate::options::RawMode::Record => Some(record_data.clone()),
+            _ => None,
+        };
+
+        if let Err(error) = pool.submit(DecodeWork {
+            payload: record_data,
+            raw_data,
+            record_index,
+        }) {
+            let pending_result = if batch_len > 0 {
+                process_decode_batch(&mut pool, batch_len, output, options, summary)
+            } else {
+                Ok(())
+            };
+            let _ = pool.shutdown();
+            pending_result?;
+            return Err(Error::new(
+                ErrorCode::CBKI001_INVALID_STATE,
+                error.to_string(),
+            ));
+        }
+        batch_len += 1;
+
+        if batch_len == batch_capacity {
+            let result = process_decode_batch(&mut pool, batch_len, output, options, summary);
+            batch_len = 0;
+            if let Err(error) = result {
+                let _ = pool.shutdown();
+                return Err(error);
+            }
+        }
+    }
+
+    if batch_len > 0 {
+        let result = process_decode_batch(&mut pool, batch_len, output, options, summary);
+        if let Err(error) = result {
+            let _ = pool.shutdown();
+            return Err(error);
+        }
+    }
+
+    pool.shutdown().map_err(|error| {
+        Error::new(
+            ErrorCode::CBKI001_INVALID_STATE,
+            format!("decode worker pool shutdown failed: {error}"),
+        )
+    })
+}
+
 fn process_rdw_records<R: Read, W: Write>(
     schema: &Schema,
     reader: R,
@@ -2529,6 +2709,10 @@ fn process_rdw_records<R: Read, W: Write>(
     options: &DecodeOptions,
     summary: &mut RunSummary,
 ) -> Result<()> {
+    if options.threads > 1 {
+        return process_rdw_records_parallel(schema, reader, output, options, summary);
+    }
+
     let mut reader = crate::record::RDWRecordReader::new(reader, options.strict_mode);
     let mut scratch = crate::memory::ScratchBuffers::new();
     let mut record_index = 0u64;
@@ -2599,6 +2783,129 @@ fn process_rdw_records<R: Read, W: Write>(
     }
 
     Ok(())
+}
+
+fn process_rdw_records_parallel<R: Read, W: Write>(
+    schema: &Schema,
+    reader: R,
+    output: &mut W,
+    options: &DecodeOptions,
+    summary: &mut RunSummary,
+) -> Result<()> {
+    let mut reader = crate::record::RDWRecordReader::new(reader, options.strict_mode);
+    let workers = options.threads.max(1);
+    let batch_capacity = workers.saturating_mul(4).max(1);
+    let mut pool = decode_worker_pool(schema, options);
+    let mut record_index = 0_u64;
+    let mut batch_len = 0_usize;
+
+    loop {
+        let rdw_record = match reader.read_record() {
+            Ok(record) => record,
+            Err(error) => {
+                let pending_result = if batch_len > 0 {
+                    process_decode_batch(&mut pool, batch_len, output, options, summary)
+                } else {
+                    Ok(())
+                };
+                let _ = pool.shutdown();
+                pending_result?;
+                return Err(error);
+            }
+        };
+        let Some(rdw_record) = rdw_record else { break };
+
+        record_index += 1;
+        let record_bytes = rdw_record.header.len() + rdw_record.payload.len();
+        summary.bytes_processed += record_bytes as u64;
+        telemetry::record_read(record_bytes, options);
+        if rdw_record.reserved() != 0 {
+            increment_warning_counter();
+        }
+
+        if let Some(schema_lrecl) = schema.lrecl_fixed
+            && rdw_record.payload.len() < schema_lrecl as usize
+        {
+            let error = Error::new(
+                ErrorCode::CBKF221_RDW_UNDERFLOW,
+                format!(
+                    "RDW payload too short: {} bytes, schema requires {} bytes",
+                    rdw_record.payload.len(),
+                    schema_lrecl
+                ),
+            );
+
+            summary.records_with_errors += 1;
+            let family = error.family_prefix();
+            telemetry::record_error(family);
+            if options.strict_mode {
+                let pending_result = if batch_len > 0 {
+                    process_decode_batch(&mut pool, batch_len, output, options, summary)
+                } else {
+                    Ok(())
+                };
+                let _ = pool.shutdown();
+                pending_result?;
+                return Err(error);
+            }
+            continue;
+        }
+
+        let full_raw_data = match options.emit_raw {
+            crate::options::RawMode::RecordRDW => {
+                let mut full_data =
+                    Vec::with_capacity(rdw_record.header.len() + rdw_record.payload.len());
+                full_data.extend_from_slice(&rdw_record.header);
+                full_data.extend_from_slice(&rdw_record.payload);
+                Some(full_data)
+            }
+            crate::options::RawMode::Record => Some(rdw_record.payload.clone()),
+            _ => None,
+        };
+
+        if let Err(error) = pool.submit(DecodeWork {
+            payload: rdw_record.payload,
+            raw_data: full_raw_data,
+            record_index,
+        }) {
+            let pending_result = if batch_len > 0 {
+                process_decode_batch(&mut pool, batch_len, output, options, summary)
+            } else {
+                Ok(())
+            };
+            let _ = pool.shutdown();
+            pending_result?;
+            return Err(Error::new(
+                ErrorCode::CBKI001_INVALID_STATE,
+                error.to_string(),
+            ));
+        }
+        batch_len += 1;
+
+        if batch_len == batch_capacity {
+            let result = process_decode_batch(&mut pool, batch_len, output, options, summary);
+            batch_len = 0;
+            if let Err(error) = result {
+                let _ = pool.shutdown();
+                return Err(error);
+            }
+        }
+    }
+
+    if batch_len > 0 {
+        let result = process_decode_batch(&mut pool, batch_len, output, options, summary);
+        if let Err(error) = result {
+            let _ = pool.shutdown();
+            return Err(error);
+        }
+    }
+
+    pool.shutdown().map_err(|error| {
+        Error::new(
+            ErrorCode::CBKI001_INVALID_STATE,
+            format!("decode worker pool shutdown failed: {error}"),
+        )
+    })
 }
 
 #[inline]

--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -29,6 +29,8 @@ pub use run_summary::RunSummary;
 pub use warnings::increment_warning_counter;
 use warnings::{reset_warning_counter, warning_count};
 
+const MAX_DECODE_WORKERS: usize = 64;
+
 /// Decode one fixed-size COBOL record into the public JSON envelope.
 ///
 /// This uses the supplied schema and decode options, returning the same
@@ -2409,7 +2411,8 @@ fn encode_binary_int_field(
 ///
 /// When `options.threads` is greater than one, records are decoded through a
 /// bounded worker pool and emitted in input order. A zero thread setting uses
-/// one worker for a safe single-threaded fallback.
+/// one worker for a safe single-threaded fallback; requests above the safe
+/// worker limit are capped.
 ///
 /// # Examples
 ///
@@ -2439,7 +2442,7 @@ pub fn decode_file_to_jsonl(
     options: &DecodeOptions,
 ) -> Result<RunSummary> {
     let start_time = std::time::Instant::now();
-    let mut summary = RunSummary::with_threads(options.threads.max(1));
+    let mut summary = RunSummary::with_threads(effective_decode_workers(options.threads));
     summary.set_schema_fingerprint(schema.fingerprint.clone());
 
     reset_warning_counter();
@@ -2542,11 +2545,15 @@ struct DecodeOutcome {
     warnings: u64,
 }
 
+fn effective_decode_workers(requested: usize) -> usize {
+    requested.clamp(1, MAX_DECODE_WORKERS)
+}
+
 fn decode_worker_pool(
     schema: &Schema,
     options: &DecodeOptions,
 ) -> crate::memory::WorkerPool<DecodeWork, DecodeOutcome> {
-    let workers = options.threads.max(1);
+    let workers = effective_decode_workers(options.threads);
     let channel_capacity = workers.saturating_mul(4).max(1);
     let max_window_size = workers.saturating_mul(2).max(1);
     let schema = Arc::new(schema.clone());
@@ -2627,7 +2634,7 @@ fn process_fixed_records_parallel<R: Read, W: Write>(
     summary: &mut RunSummary,
 ) -> Result<()> {
     let mut reader = crate::record::FixedRecordReader::new(reader, schema.lrecl_fixed)?;
-    let workers = options.threads.max(1);
+    let workers = effective_decode_workers(options.threads);
     let batch_capacity = workers.saturating_mul(4).max(1);
     let mut pool = decode_worker_pool(schema, options);
     let mut record_index = 0_u64;
@@ -2799,7 +2806,7 @@ fn process_rdw_records_parallel<R: Read, W: Write>(
     summary: &mut RunSummary,
 ) -> Result<()> {
     let mut reader = crate::record::RDWRecordReader::new(reader, options.strict_mode);
-    let workers = options.threads.max(1);
+    let workers = effective_decode_workers(options.threads);
     let batch_capacity = workers.saturating_mul(4).max(1);
     let mut pool = decode_worker_pool(schema, options);
     let mut record_index = 0_u64;

--- a/crates/copybook-codec/tests/streaming_file_tests.rs
+++ b/crates/copybook-codec/tests/streaming_file_tests.rs
@@ -539,6 +539,7 @@ fn decode_fixed_threaded_recovery_summary() {
         assert_eq!(summary.records_with_errors, 1);
         assert_eq!(summary.total_records(), 4);
         assert_eq!(summary.bytes_processed, 20);
+        assert_eq!(summary.threads_used, threads);
         assert_eq!(
             String::from_utf8(output.clone()).unwrap().lines().count(),
             3
@@ -737,9 +738,44 @@ fn decode_thread_count_in_summary() {
     let opts = ascii_decode_opts().with_threads(1);
     let mut output = Vec::new();
     let summary = decode_file_to_jsonl(&schema, Cursor::new(data), &mut output, &opts).unwrap();
-    // threads_used should be populated in single-threaded path
-    // The exact value depends on implementation; just verify it exists
-    assert!(summary.threads_used <= 1 || summary.threads_used > 0);
+    assert_eq!(summary.threads_used, 1);
+}
+
+#[test]
+fn decode_parallel_strict_mode_stops_in_input_order() {
+    let schema = parse_copybook(SIMPLE_SCHEMA).unwrap();
+    let data = [
+        b"00001".as_slice(),
+        b"AB12C".as_slice(),
+        b"00003".as_slice(),
+        b"00004".as_slice(),
+    ]
+    .concat();
+    let opts = ascii_decode_opts().with_threads(4).with_strict_mode(true);
+    let mut output = Vec::new();
+
+    let error = decode_file_to_jsonl(&schema, Cursor::new(data), &mut output, &opts)
+        .expect_err("strict parallel decode should return the first record error");
+
+    assert_eq!(error.code, ErrorCode::CBKD411_ZONED_BAD_SIGN);
+    assert_eq!(String::from_utf8(output).unwrap().lines().count(), 1);
+}
+
+#[test]
+fn decode_parallel_rdw_strict_mode_emits_prior_records() {
+    let schema = parse_copybook(RDW_SCHEMA).unwrap();
+    let data = build_rdw_records(&["HELLO", "ABC"]);
+    let opts = ascii_decode_opts()
+        .with_format(RecordFormat::RDW)
+        .with_threads(4)
+        .with_strict_mode(true);
+    let mut output = Vec::new();
+
+    let error = decode_file_to_jsonl(&schema, Cursor::new(data), &mut output, &opts)
+        .expect_err("strict parallel RDW decode should reject the short record");
+
+    assert_eq!(error.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+    assert_eq!(String::from_utf8(output).unwrap().lines().count(), 1);
 }
 
 #[test]
@@ -751,8 +787,10 @@ fn decode_fixed_threaded_deterministic() {
     for threads in [1_usize, 2, 4] {
         let opts = ascii_decode_opts().with_threads(threads);
         let mut output = Vec::new();
-        copybook_codec::decode_file_to_jsonl(&schema, Cursor::new(&data), &mut output, &opts)
-            .unwrap();
+        let summary =
+            copybook_codec::decode_file_to_jsonl(&schema, Cursor::new(&data), &mut output, &opts)
+                .unwrap();
+        assert_eq!(summary.threads_used, threads);
         outputs.push((threads, output));
     }
 
@@ -804,8 +842,10 @@ fn decode_rdw_threaded_deterministic() {
             .with_format(RecordFormat::RDW)
             .with_threads(threads);
         let mut output = Vec::new();
-        copybook_codec::decode_file_to_jsonl(&schema, Cursor::new(&data), &mut output, &opts)
-            .unwrap();
+        let summary =
+            copybook_codec::decode_file_to_jsonl(&schema, Cursor::new(&data), &mut output, &opts)
+                .unwrap();
+        assert_eq!(summary.threads_used, threads);
         outputs.push((threads, output));
     }
 


### PR DESCRIPTION
## Summary

- Honor `DecodeOptions::threads` for fixed and RDW file decoding.
- Use the existing bounded `WorkerPool` and ordered sequence emission so JSONL output remains deterministic.
- Preserve strict and lenient error behavior, raw-record capture, warning accounting, and effective worker counts in `RunSummary`.
- Add focused fixed/RDW worker-matrix and strict-order regression coverage.

## Why

The existing #578 determinism tests varied `with_threads(1|2|4)`, but the decode pipeline ignored that setting and remained single-threaded. This PR wires the decode path to the repository's existing bounded worker primitive.

## Validation

- `cargo +1.92.0 fmt --all -- --check`
- `cargo +1.92.0 clippy -p copybook-codec --all-features --tests -- -D warnings`
- `cargo +1.92.0 test -p copybook-codec --all-features --test streaming_file_tests` (56 passed)
- `git diff --check`

The encode half of #578 remains a separate follow-up slice so this PR stays reviewable.