### PR TITLE
test(errors): consolidate stable-error and rejection-path evidence (#576)

### DIFF
--- a/crates/copybook-cli/tests/rejection_exit_codes.rs
+++ b/crates/copybook-cli/tests/rejection_exit_codes.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! CLI command-context evidence for deliberate rejections (issue #576).
+//!
+//! `copybook-cli/tests/exit_code_mapping.rs` already covers the mapped error
+//! families (`CBKD`→2, `CBKE`→3, `CBKF`→4, `CBKI`→5). This suite fills the
+//! documented gap for **structural** rejections: parse/schema errors in the
+//! `CBKP*` / `CBKS*` families are not present in `ExitCode::from_family_prefix`
+//! (`crates/copybook-cli/src/exit_codes.rs`), so they fall through to exit code
+//! **5 (Internal orchestration error)** — the same code a genuine panic
+//! produces.
+//!
+//! These tests pin that **current, observed** behavior so a regression is
+//! visible, and document the mismatch against `docs/reference/COBOL_SUPPORT_MATRIX.md`
+//! (which assigns each scenario a stable `CBKP*`/`CBKS*` code). Whether these
+//! structural rejections should map to a dedicated, non-`Internal` exit code is
+//! a stability-contract decision left to the maintainers (see the PR notes); the
+//! library layer already reports the precise, stable code — see
+//! `copybook-codec/tests/rejection_evidence_matrix.rs`.
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::unwrap_used)]
+
+mod common;
+
+use assert_fs::prelude::*;
+use common::bin;
+
+/// Documented structural-rejection exit code (Internal). Named so the intent —
+/// and the fact that it collides with the panic exit code — is explicit.
+const STRUCTURAL_REJECTION_EXIT: i32 = 5;
+
+fn path_str(p: &std::path::Path) -> String {
+    p.to_string_lossy().into_owned()
+}
+
+/// Run `copybook parse` on `copybook_text` and assert the process exit code.
+fn assert_parse_exit(copybook_text: &str, expected_code: i32) {
+    let dir = assert_fs::TempDir::new().unwrap();
+    let cpy = dir.child("rej.cpy");
+    cpy.write_str(copybook_text).unwrap();
+
+    bin()
+        .args(["parse", &path_str(cpy.path())])
+        .assert()
+        .failure()
+        .code(expected_code);
+}
+
+// ====================================================================
+// CBKP* structural parse rejections (currently exit 5 / Internal)
+// ====================================================================
+
+#[test]
+fn cli_odo_not_tail_exit_code() {
+    // O4 / CBKP021_ODO_NOT_TAIL
+    assert_parse_exit(
+        "01 INV-REC.\n   05 ITEM-COUNT PIC 9(3).\n   05 ITEMS OCCURS 1 TO 10 TIMES DEPENDING ON ITEM-COUNT.\n      10 ITEM-CODE PIC X(4).\n   05 TRAILER PIC X(5).\n",
+        STRUCTURAL_REJECTION_EXIT,
+    );
+}
+
+#[test]
+fn cli_nested_odo_exit_code() {
+    // O5 / CBKP022_NESTED_ODO
+    assert_parse_exit(
+        "01 OUTER-REC.\n   05 OUTER-COUNT PIC 9(2).\n   05 OUTER-GROUP OCCURS 1 TO 50 TIMES DEPENDING ON OUTER-COUNT.\n      10 INNER-COUNT PIC 9(2).\n      10 INNER-ARRAY OCCURS 1 TO 100 TIMES DEPENDING ON INNER-COUNT.\n         15 DATA-VALUE PIC X(10).\n",
+        STRUCTURAL_REJECTION_EXIT,
+    );
+}
+
+#[test]
+fn cli_odo_over_redefines_exit_code() {
+    // O6 / CBKP023_ODO_REDEFINES
+    assert_parse_exit(
+        "01 TRANSACTION-REC.\n   05 TRANS-TYPE PIC X(1).\n   05 TRANS-COUNT PIC 9(2).\n   05 TRANS-DATA PIC X(100).\n   05 TRANS-DETAIL REDEFINES TRANS-DATA.\n      10 DETAIL-ITEM OCCURS 1 TO 100 TIMES DEPENDING ON TRANS-COUNT.\n         15 DETAIL-FIELD PIC X(10).\n",
+        STRUCTURAL_REJECTION_EXIT,
+    );
+}
+
+// ====================================================================
+// CBKS* schema/resolver parse rejection (currently exit 5 / Internal)
+// ====================================================================
+
+#[test]
+fn cli_renames_over_occurs_exit_code() {
+    // renames-occurs / CBKS607_RENAME_CROSSES_OCCURS
+    assert_parse_exit(
+        "01 ROOT-REC.\n   05 FIELD-A PIC X(5).\n   05 ARRAY-FIELD PIC 9(3) OCCURS 5 TIMES.\n   05 FIELD-B PIC X(2).\n   66 ALIAS RENAMES FIELD-A THRU FIELD-B.\n",
+        STRUCTURAL_REJECTION_EXIT,
+    );
+}
+
+// ====================================================================
+// Control: a valid copybook parses successfully (exit 0), proving the
+// rejection exit codes above are triggered by the defect, not by the
+// harness.
+// ====================================================================
+
+#[test]
+fn cli_valid_copybook_parses_successfully() {
+    let dir = assert_fs::TempDir::new().unwrap();
+    let cpy = dir.child("ok.cpy");
+    cpy.write_str("01 REC.\n   05 ITEM-COUNT PIC 9(3).\n   05 ITEMS OCCURS 1 TO 10 TIMES DEPENDING ON ITEM-COUNT.\n      10 ITEM-CODE PIC X(4).\n")
+        .unwrap();
+    bin()
+        .args(["parse", &path_str(cpy.path())])
+        .assert()
+        .success();
+}

--- a/crates/copybook-codec/tests/rejection_evidence_matrix.rs
+++ b/crates/copybook-codec/tests/rejection_evidence_matrix.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+//! Consolidated stable-error / deliberate-rejection evidence matrix (issue #576).
+//!
+//! Existing negative coverage is thorough but scattered across many files and
+//! partly gated behind the `comprehensive-tests` feature. This suite pins, in a
+//! single **default-feature** place, the mapping from each documented
+//! unsupported/rejected scenario to its **stable error code**, exercised through
+//! the public library entry points across all three phases:
+//!
+//! * **parse** (`parse_copybook`) — structural `CBKP*` / `CBKS*` rejections,
+//! * **decode** (`decode_record`) — data `CBKD*` / `CBKC*` rejections,
+//! * **encode** (`encode_record`) — `CBKE*` rejections.
+//!
+//! Each row carries a scenario id that matches `docs/reference/COBOL_SUPPORT_MATRIX.md`
+//! (e.g. `O4`/`O5`/`O6`, `renames-occurs`, `renames-redefines`) so the evidence
+//! plane is traceable back to the support matrix. The CLI command-context
+//! mapping (family → process exit code) lives in
+//! `copybook-cli/tests/rejection_exit_codes.rs`.
+
+use copybook_codec::{
+    Codepage, DecodeOptions, EncodeOptions, RecordFormat, UnmappablePolicy, decode_record,
+    encode_record,
+};
+use copybook_core::{ErrorCode, parse_copybook};
+
+// ===========================================================================
+// Parse-phase structural rejections (CBKP* / CBKS*)
+// ===========================================================================
+
+/// `(scenario_id, copybook, expected_code)`. Copybooks are minimal, verified
+/// reproductions of the documented rejection scenarios.
+const PARSE_REJECTIONS: &[(&str, &str, ErrorCode)] = &[
+    // O4 — ODO array followed by a storage sibling (not at tail).
+    (
+        "O4:odo-not-tail",
+        "01 INV-REC.\n   05 ITEM-COUNT PIC 9(3).\n   05 ITEMS OCCURS 1 TO 10 TIMES DEPENDING ON ITEM-COUNT.\n      10 ITEM-CODE PIC X(4).\n   05 TRAILER PIC X(5).\n",
+        ErrorCode::CBKP021_ODO_NOT_TAIL,
+    ),
+    // O5 — ODO nested inside another ODO.
+    (
+        "O5:nested-odo",
+        "01 OUTER-REC.\n   05 OUTER-COUNT PIC 9(2).\n   05 OUTER-GROUP OCCURS 1 TO 50 TIMES DEPENDING ON OUTER-COUNT.\n      10 INNER-COUNT PIC 9(2).\n      10 INNER-ARRAY OCCURS 1 TO 100 TIMES DEPENDING ON INNER-COUNT.\n         15 DATA-VALUE PIC X(10).\n",
+        ErrorCode::CBKP022_NESTED_ODO,
+    ),
+    // O6 — ODO declared inside a REDEFINES region.
+    (
+        "O6:odo-over-redefines",
+        "01 TRANSACTION-REC.\n   05 TRANS-TYPE PIC X(1).\n   05 TRANS-COUNT PIC 9(2).\n   05 TRANS-DATA PIC X(100).\n   05 TRANS-DETAIL REDEFINES TRANS-DATA.\n      10 DETAIL-ITEM OCCURS 1 TO 100 TIMES DEPENDING ON TRANS-COUNT.\n         15 DETAIL-FIELD PIC X(10).\n",
+        ErrorCode::CBKP023_ODO_REDEFINES,
+    ),
+    // renames-occurs — RENAMES range crosses an OCCURS boundary.
+    (
+        "renames-occurs",
+        "01 ROOT-REC.\n   05 FIELD-A PIC X(5).\n   05 ARRAY-FIELD PIC 9(3) OCCURS 5 TIMES.\n   05 FIELD-B PIC X(2).\n   66 ALIAS RENAMES FIELD-A THRU FIELD-B.\n",
+        ErrorCode::CBKS607_RENAME_CROSSES_OCCURS,
+    ),
+    // renames-redefines — RENAMES span includes a REDEFINES field.
+    (
+        "renames-redefines",
+        "01 ROOT-REC.\n   05 FIELD-A PIC X(5).\n   05 FIELD-B REDEFINES FIELD-A PIC X(5).\n   05 FIELD-C PIC 9(3).\n   66 ALIAS RENAMES FIELD-A THRU FIELD-C.\n",
+        ErrorCode::CBKS609_RENAME_OVER_REDEFINES,
+    ),
+    // RENAMES with an unknown FROM field.
+    (
+        "renames-unknown-from",
+        "01 ROOT-REC.\n   05 FIELD-A PIC X(5).\n   05 FIELD-B PIC X(2).\n   66 ALIAS RENAMES NOPE THRU FIELD-B.\n",
+        ErrorCode::CBKS601_RENAME_UNKNOWN_FROM,
+    ),
+];
+
+#[test]
+fn parse_rejections_map_to_stable_codes() {
+    for (scenario, copybook, expected) in PARSE_REJECTIONS {
+        let err = parse_copybook(copybook)
+            .expect_err(&format!("{scenario} must be rejected at parse time"));
+        assert_eq!(
+            err.code, *expected,
+            "scenario {scenario}: expected {expected:?}, got {:?} ({})",
+            err.code, err.message
+        );
+    }
+}
+
+// ===========================================================================
+// Decode-phase data rejections (CBKD* / CBKC*)
+// ===========================================================================
+
+#[test]
+fn decode_record_too_short_is_cbkd301() {
+    // ODO array declares up to 5 elements; record supplies only the count byte.
+    let copybook = "01 RECORD.\n   05 ARRAY-COUNT PIC 9(1).\n   05 DYNAMIC-ARRAY OCCURS 1 TO 5 TIMES DEPENDING ON ARRAY-COUNT.\n      10 ELEMENT PIC X(10).\n";
+    let schema = parse_copybook(copybook).expect("copybook parses");
+    let options = DecodeOptions::new()
+        .with_format(RecordFormat::Fixed)
+        .with_codepage(Codepage::CP037);
+
+    // EBCDIC '3' = 0xF3 => count 3 => needs 30 more bytes, none present.
+    let err = decode_record(&schema, &[0xF3], &options)
+        .expect_err("record shorter than ODO-driven length must be rejected");
+    assert_eq!(err.code, ErrorCode::CBKD301_RECORD_TOO_SHORT);
+}
+
+#[test]
+fn decode_unmappable_byte_is_cbkc301() {
+    let copybook = "01 REC.\n   05 SIG PIC X(1).\n";
+    let schema = parse_copybook(copybook).expect("copybook parses");
+    let options = DecodeOptions::new()
+        .with_format(RecordFormat::Fixed)
+        .with_codepage(Codepage::CP037)
+        .with_unmappable_policy(UnmappablePolicy::Error);
+
+    // 0x00 (EBCDIC NUL) is an unmappable control byte under the Error policy.
+    let err = decode_record(&schema, &[0x00], &options)
+        .expect_err("unmappable control byte must be rejected under Error policy");
+    assert_eq!(err.code, ErrorCode::CBKC301_INVALID_EBCDIC_BYTE);
+}
+
+// ===========================================================================
+// Encode-phase rejections (CBKE*)
+// ===========================================================================
+
+#[test]
+fn encode_numeric_overflow_is_cbke510() {
+    let copybook = "01 REC.\n   05 N PIC 9(3).\n";
+    let schema = parse_copybook(copybook).expect("copybook parses");
+    let options = EncodeOptions::new()
+        .with_format(RecordFormat::Fixed)
+        .with_codepage(Codepage::CP037);
+
+    // 5 digits into a 3-digit field.
+    let json = serde_json::json!({ "N": "99999" });
+    let err = encode_record(&schema, &json, &options)
+        .expect_err("value exceeding field digits must be rejected");
+    assert_eq!(err.code, ErrorCode::CBKE510_NUMERIC_OVERFLOW);
+}
+
+#[test]
+fn encode_string_too_long_is_cbke515() {
+    let copybook = "01 REC.\n   05 S PIC X(3).\n";
+    let schema = parse_copybook(copybook).expect("copybook parses");
+    let options = EncodeOptions::new()
+        .with_format(RecordFormat::Fixed)
+        .with_codepage(Codepage::CP037);
+
+    let json = serde_json::json!({ "S": "TOOLONG" });
+    let err = encode_record(&schema, &json, &options)
+        .expect_err("string longer than field capacity must be rejected");
+    assert_eq!(err.code, ErrorCode::CBKE515_STRING_LENGTH_VIOLATION);
+}
+
+// ===========================================================================
+// Error-code stability: every asserted code reports its documented family
+// prefix, so the family → exit-code contract (see CLI suite) stays anchored.
+// ===========================================================================
+
+#[test]
+fn asserted_codes_report_documented_family_prefixes() {
+    let expectations = [
+        (ErrorCode::CBKP021_ODO_NOT_TAIL, "CBKP"),
+        (ErrorCode::CBKP022_NESTED_ODO, "CBKP"),
+        (ErrorCode::CBKP023_ODO_REDEFINES, "CBKP"),
+        (ErrorCode::CBKS601_RENAME_UNKNOWN_FROM, "CBKS"),
+        (ErrorCode::CBKS607_RENAME_CROSSES_OCCURS, "CBKS"),
+        (ErrorCode::CBKS609_RENAME_OVER_REDEFINES, "CBKS"),
+        (ErrorCode::CBKD301_RECORD_TOO_SHORT, "CBKD"),
+        (ErrorCode::CBKC301_INVALID_EBCDIC_BYTE, "CBKC"),
+        (ErrorCode::CBKE510_NUMERIC_OVERFLOW, "CBKE"),
+        (ErrorCode::CBKE515_STRING_LENGTH_VIOLATION, "CBKE"),
+    ];
+    for (code, family) in expectations {
+        assert_eq!(
+            code.family_prefix(),
+            family,
+            "{code:?} must report family {family}"
+        );
+    }
+}

--- a/crates/copybook-codec/tests/rejection_evidence_matrix.rs
+++ b/crates/copybook-codec/tests/rejection_evidence_matrix.rs
@@ -12,10 +12,13 @@
 //! * **decode** (`decode_record`) — data `CBKD*` / `CBKC*` rejections,
 //! * **encode** (`encode_record`) — `CBKE*` rejections.
 //!
-//! Each row carries a scenario id that matches `docs/reference/COBOL_SUPPORT_MATRIX.md`
-//! (e.g. `O4`/`O5`/`O6`, `renames-occurs`, `renames-redefines`) so the evidence
-//! plane is traceable back to the support matrix. The CLI command-context
-//! mapping (family → process exit code) lives in
+//! Each row carries a scenario id: the structural rows match a scenario in
+//! `docs/reference/COBOL_SUPPORT_MATRIX.md` (`O4`/`O5`/`O6`, `renames-occurs`,
+//! `renames-redefines`); the remaining rows are keyed by their stable error code
+//! as documented in `docs/reference/ERROR_CODES.md` (e.g. `renames-unknown-from`
+//! → `CBKS601`). The copybooks are independent reproductions, not copies of the
+//! scattered single-purpose negative tests they overlap with. The CLI
+//! command-context mapping (family → process exit code) lives in
 //! `copybook-cli/tests/rejection_exit_codes.rs`.
 
 use copybook_codec::{
@@ -37,28 +40,31 @@ const PARSE_REJECTIONS: &[(&str, &str, ErrorCode)] = &[
         "01 INV-REC.\n   05 ITEM-COUNT PIC 9(3).\n   05 ITEMS OCCURS 1 TO 10 TIMES DEPENDING ON ITEM-COUNT.\n      10 ITEM-CODE PIC X(4).\n   05 TRAILER PIC X(5).\n",
         ErrorCode::CBKP021_ODO_NOT_TAIL,
     ),
-    // O5 — ODO nested inside another ODO.
+    // O5 — ODO nested inside another ODO. (Independent reproduction, distinct
+    // from `nested_odo_negative_tests.rs`, to keep this row genuinely additive.)
     (
         "O5:nested-odo",
-        "01 OUTER-REC.\n   05 OUTER-COUNT PIC 9(2).\n   05 OUTER-GROUP OCCURS 1 TO 50 TIMES DEPENDING ON OUTER-COUNT.\n      10 INNER-COUNT PIC 9(2).\n      10 INNER-ARRAY OCCURS 1 TO 100 TIMES DEPENDING ON INNER-COUNT.\n         15 DATA-VALUE PIC X(10).\n",
+        "01 REPORT-REC.\n   05 SECTION-COUNT PIC 9(2).\n   05 SECTION OCCURS 1 TO 20 TIMES DEPENDING ON SECTION-COUNT.\n      10 LINE-COUNT PIC 9(2).\n      10 LINE-ITEM OCCURS 1 TO 40 TIMES DEPENDING ON LINE-COUNT.\n         15 LINE-TEXT PIC X(8).\n",
         ErrorCode::CBKP022_NESTED_ODO,
     ),
-    // O6 — ODO declared inside a REDEFINES region.
+    // O6 — ODO declared inside a REDEFINES region. (Independent reproduction.)
     (
         "O6:odo-over-redefines",
-        "01 TRANSACTION-REC.\n   05 TRANS-TYPE PIC X(1).\n   05 TRANS-COUNT PIC 9(2).\n   05 TRANS-DATA PIC X(100).\n   05 TRANS-DETAIL REDEFINES TRANS-DATA.\n      10 DETAIL-ITEM OCCURS 1 TO 100 TIMES DEPENDING ON TRANS-COUNT.\n         15 DETAIL-FIELD PIC X(10).\n",
+        "01 MSG-REC.\n   05 MSG-KIND PIC X(2).\n   05 ELEM-COUNT PIC 9(2).\n   05 MSG-BODY PIC X(80).\n   05 MSG-ELEMS REDEFINES MSG-BODY.\n      10 ELEM OCCURS 1 TO 40 TIMES DEPENDING ON ELEM-COUNT.\n         15 ELEM-VAL PIC X(2).\n",
         ErrorCode::CBKP023_ODO_REDEFINES,
     ),
-    // renames-occurs — RENAMES range crosses an OCCURS boundary.
+    // renames-occurs — RENAMES range crosses an OCCURS boundary. (Independent
+    // reproduction, distinct from `renames_resolver_negative_tests.rs`.)
     (
         "renames-occurs",
-        "01 ROOT-REC.\n   05 FIELD-A PIC X(5).\n   05 ARRAY-FIELD PIC 9(3) OCCURS 5 TIMES.\n   05 FIELD-B PIC X(2).\n   66 ALIAS RENAMES FIELD-A THRU FIELD-B.\n",
+        "01 ACCT-REC.\n   05 ACCT-HEAD PIC X(4).\n   05 BUCKET PIC 9(2) OCCURS 6 TIMES.\n   05 ACCT-TAIL PIC X(3).\n   66 ACCT-SPAN RENAMES ACCT-HEAD THRU ACCT-TAIL.\n",
         ErrorCode::CBKS607_RENAME_CROSSES_OCCURS,
     ),
-    // renames-redefines — RENAMES span includes a REDEFINES field.
+    // renames-redefines — RENAMES span includes a REDEFINES field. (Independent
+    // reproduction.)
     (
         "renames-redefines",
-        "01 ROOT-REC.\n   05 FIELD-A PIC X(5).\n   05 FIELD-B REDEFINES FIELD-A PIC X(5).\n   05 FIELD-C PIC 9(3).\n   66 ALIAS RENAMES FIELD-A THRU FIELD-C.\n",
+        "01 POLICY-REC.\n   05 PRIMARY PIC X(6).\n   05 SECONDARY REDEFINES PRIMARY PIC X(6).\n   05 SUFFIX PIC 9(4).\n   66 POLICY-SPAN RENAMES PRIMARY THRU SUFFIX.\n",
         ErrorCode::CBKS609_RENAME_OVER_REDEFINES,
     ),
     // RENAMES with an unknown FROM field.

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -578,6 +578,8 @@ copybook decode legacy-schema.cpy data.bin --format fixed --strict-comments --ou
 
 Some subcommands document additional command-specific semantics: `verify` reports 3 for validation errors and 2 for fatal I/O/schema errors; `determinism` reports 0 for deterministic, 2 for drift detected, and 3 for codec/usage errors.
 
+> **Note (current behavior):** only the `CBKD`/`CBKE`/`CBKF`/`CBKI` families have a dedicated exit-code mapping. Structural parse/schema rejections in the `CBKP*` and `CBKS*` families (e.g. `CBKP021_ODO_NOT_TAIL`, `CBKP022_NESTED_ODO`, `CBKP023_ODO_REDEFINES`, `CBKS607_RENAME_CROSSES_OCCURS`, `CBKS609_RENAME_OVER_REDEFINES`) currently fall through to exit code **5**, the same code a panic produces. The library API always reports the precise, stable code regardless. This behavior is pinned by `copybook-cli/tests/rejection_exit_codes.rs`; assigning these families a dedicated, non-`Internal` exit code is a potential future stability-contract change.
+
 ## Character Encodings
 
 ### EBCDIC Code Pages

--- a/docs/reference/COBOL_SUPPORT_MATRIX.md
+++ b/docs/reference/COBOL_SUPPORT_MATRIX.md
@@ -379,9 +379,9 @@ See `docs/design/NESTED_ODO_BEHAVIOR.md` (Issue #164) for complete design specif
 | O1  | Simple tail ODO                         | ✅     | -                     | `golden_fixtures_ac3_child_inside_odo.rs::test_ac3_basic_child_inside_odo_pass` |
 | O2  | Tail ODO with DYNAMIC (AC1/AC2)         | ✅     | -                     | `odo_comprehensive.rs` (21 tests), `odo_counter_types.rs`        |
 | O3  | Group-with-ODO tail (AC3)               | ✅     | -                     | `golden_fixtures_ac3_child_inside_odo.rs::test_ac3_nested_groups_inside_odo_pass` |
-| O4  | ODO with sibling after (AC4)            | 🚫     | CBKP021_ODO_NOT_TAIL  | `golden_fixtures_ac4_sibling_after_odo_fail.rs` (8 negative tests)|
-| O5  | Nested ODO (ODO inside ODO)             | 🚫     | CBKP022_NESTED_ODO    | Phase N1: reject; Phase N2: review if user demand emerges        |
-| O6  | ODO over REDEFINES                      | 🚫     | CBKP023_ODO_REDEFINES | Phase N1: reject; Phase N3: dedicated design required            |
+| O4  | ODO with sibling after (AC4)            | 🚫     | CBKP021_ODO_NOT_TAIL  | `golden_fixtures_ac4_sibling_after_odo_fail.rs` (8 negative tests); `rejection_evidence_matrix.rs::parse_rejections_map_to_stable_codes` (`O4`)|
+| O5  | Nested ODO (ODO inside ODO)             | 🚫     | CBKP022_NESTED_ODO    | Phase N1: reject; Phase N2: review if user demand emerges; `rejection_evidence_matrix.rs::parse_rejections_map_to_stable_codes` (`O5`) |
+| O6  | ODO over REDEFINES                      | 🚫     | CBKP023_ODO_REDEFINES | Phase N1: reject; Phase N3: dedicated design required; `rejection_evidence_matrix.rs::parse_rejections_map_to_stable_codes` (`O6`) |
 | O7  | ODO over RENAMES span (R4/R5 scenarios) | 🚫     | Out of scope          | RENAMES R4-R6 explicitly deferred (see RENAMES section)          |
 
 **Evidence:**
@@ -465,8 +465,8 @@ See `docs/design/RENAMES_NESTED_GROUPS.md` for complete design specification.
 | `renames-same-scope-group`  | 66-level – group alias       | ✅      | Parser + resolver (R2) with correct tree building; codec decode ✅ |
 | `renames-nested-group`      | 66-level – nested group      | ✅      | Parser + resolver (R3) with recursive target lookup; codec decode ✅ |
 | `renames-codec-projection`  | 66-level – codec projection  | ✅      | Schema provides `find_field_or_alias` and `resolve_alias_to_target` for codec integration |
-| `renames-redefines`         | 66-level – over REDEFINES    | 🚫      | Out of scope; requires separate design for interaction semantics |
-| `renames-occurs`            | 66-level – over OCCURS       | 🚫      | Out of scope; requires separate design for array aliasing        |
+| `renames-redefines`         | 66-level – over REDEFINES    | 🚫      | Out of scope; `CBKS609_RENAME_OVER_REDEFINES`; `rejection_evidence_matrix.rs::parse_rejections_map_to_stable_codes` (`renames-redefines`) |
+| `renames-occurs`            | 66-level – over OCCURS       | 🚫      | Out of scope; `CBKS607_RENAME_CROSSES_OCCURS`; `rejection_evidence_matrix.rs::parse_rejections_map_to_stable_codes` (`renames-occurs`) |
 
 **Evidence:**
 


### PR DESCRIPTION
## Summary

Addresses the "stable errors & deliberate rejection paths" evidence gap in #576 by consolidating the mapping from each documented unsupported/rejected COBOL scenario to its **stable error code**, exercised through both the **library API** and the **CLI command context** — the two dimensions the issue asks for. Prior negative coverage is thorough but scattered across many files and partly gated behind `comprehensive-tests`; this adds a single **default-feature** evidence plane keyed by support-matrix scenario id.

The issue's own comments confirm no product defect remained after the SIGN-clause follow-up (#582) was resolved, so this is an evidence/traceability deliverable — with one documented gap finding (below).

### New evidence

**`crates/copybook-codec/tests/rejection_evidence_matrix.rs`** — one place mapping scenario → stable code across all three phases:
- **parse** (`parse_copybook`): `O4`→`CBKP021_ODO_NOT_TAIL`, `O5`→`CBKP022_NESTED_ODO`, `O6`→`CBKP023_ODO_REDEFINES`, `renames-occurs`→`CBKS607_RENAME_CROSSES_OCCURS`, `renames-redefines`→`CBKS609_RENAME_OVER_REDEFINES`, `renames-unknown-from`→`CBKS601_RENAME_UNKNOWN_FROM`.
- **decode** (`decode_record`): `CBKD301_RECORD_TOO_SHORT`, `CBKC301_INVALID_EBCDIC_BYTE`.
- **encode** (`encode_record`): `CBKE510_NUMERIC_OVERFLOW`, `CBKE515_STRING_LENGTH_VIOLATION`.
- a `family_prefix()` stability check anchoring each asserted code to its documented family.

**`crates/copybook-cli/tests/rejection_exit_codes.rs`** — the CLI command-context dimension, filling a real coverage hole: no existing test exercised a `CBKP*`/`CBKS*` rejection's CLI exit code.

### Documented finding (candidate follow-up, not fixed here)

`ExitCode::from_family_prefix` (`crates/copybook-cli/src/exit_codes.rs`) maps only `CBKD`→2, `CBKE`→3, `CBKF`→4, `CBKI`→5. Structural parse/schema rejections (`CBKP*`/`CBKS*`) are unmapped and fall through to exit code **5 (Internal orchestration error)** — the same code a genuine panic produces, so a bad copybook is indistinguishable from a crash at the process boundary. The library API always reports the precise, stable code.

The new CLI tests **pin this current behavior** (so a regression is visible) and the docs note it explicitly. Assigning `CBKP*`/`CBKS*` a dedicated, non-`Internal` exit code is a **stability-contract change** (exit codes are covered by `docs/STABILITY_GUARANTEES.md`) and is deliberately left to the maintainers rather than changed unilaterally in an evidence PR.

## Type of Change

- [x] Tests (new consolidated evidence suite)
- [x] Documentation (support-matrix evidence anchors + CLI exit-code note)

## Workspace Crates Affected

- [x] copybook-codec (rejection evidence via public decode/encode/parse)
- [x] copybook-cli (CLI exit-code evidence)

## Checklist

- [x] Tests added
- [x] Documentation updated (`COBOL_SUPPORT_MATRIX.md` anchors, `CLI_REFERENCE.md` exit-code note)
- [ ] CHANGELOG.md updated (tests/docs only — not user-facing behavior)
- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy` clean on both new targets (`-D warnings -W clippy::pedantic`)
- [x] New suites pass locally (`cargo test`)
- [x] Conventional-commit title (`test(errors):`)

## Testing Instructions

```bash
cargo test --package copybook-codec --test rejection_evidence_matrix   # 6 tests
cargo test --package copybook-cli   --test rejection_exit_codes        # 5 tests
cargo clippy --package copybook-codec --test rejection_evidence_matrix \
             --package copybook-cli   --test rejection_exit_codes -- -D warnings -W clippy::pedantic
cargo fmt --all --check
```

Both suites are default-feature (run under a plain `cargo test`); verified locally green (6 + 5 = 11 tests), fmt + `clippy::pedantic` clean.

## Breaking Changes

- [x] No breaking changes (no behavior change; current exit-code behavior is pinned, not altered)

## Related Issues

Relates to #576 (evidence coordinator for #551)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WK5yVbkkG55fza5mPj6Zue)_