### PR TITLE
perf(bench): supplementary native-Linux baseline receipt + hot-path ranking (#546)

### DIFF
--- a/scripts/bench/perf-linux-native.json
+++ b/scripts/bench/perf-linux-native.json
@@ -1,0 +1,103 @@
+{
+  "format_version": "1.0.0",
+  "artifact_class": "supplementary-native-linux",
+  "canonical_receipt": "scripts/bench/perf.json",
+  "note": "Supplementary reproducibility datapoint measured on ephemeral cloud Linux hardware. This is NOT the canonical current metric and MUST NOT be cited as one (see docs/PERFORMANCE_GOVERNANCE.md). Canonical receipts remain in scripts/bench/perf.json (reference hardware). A maintainer may promote a measurement to canonical only from documented reference hardware.",
+  "timestamp": "2026-07-19T00:00:00Z",
+  "commit": "13b4251",
+  "build_profile": "release",
+  "target_cpu": "native",
+  "toolchain": "cargo bench (criterion, slo_validation) + valgrind callgrind",
+  "environment": {
+    "os": "Linux",
+    "kernel": "6.18.5",
+    "cpu_model": "Intel(R) Xeon(R) Processor @ 2.10GHz",
+    "cpu_cores": 4,
+    "memory_total_mib": 16075,
+    "ephemeral_cloud": true
+  },
+  "runs": 2,
+  "status": "pass",
+  "workloads": {
+    "display_heavy": {
+      "runs_mibps": [
+        1747.84,
+        1758.51
+      ],
+      "mean_mibps": 1753.17,
+      "min_mibps": 1747.84,
+      "max_mibps": 1758.51,
+      "spread_pct": 0.61,
+      "floor_mibps": 80,
+      "floor_ratio": 21.9
+    },
+    "comp3_heavy": {
+      "runs_mibps": [
+        12.25,
+        11.54
+      ],
+      "mean_mibps": 11.89,
+      "min_mibps": 11.54,
+      "max_mibps": 12.25,
+      "spread_pct": 5.97,
+      "floor_mibps": 8,
+      "floor_ratio": 1.5
+    }
+  },
+  "memory": {
+    "peak_rss_mib": 10.0,
+    "workload": "decode 50,000 mixed fixed records (LRECL 22: PIC X, COMP-3, zoned, COMP) to JSONL",
+    "governed_ceiling_mib": 256
+  },
+  "hot_paths_cli_decode_to_jsonl": [
+    {
+      "rank": 1,
+      "ir_pct": 26.55,
+      "symbol": "std::fs::File::write_all (output I/O)"
+    },
+    {
+      "rank": 2,
+      "ir_pct": 14.82,
+      "symbol": "serde_json Serializer::serialize_str"
+    },
+    {
+      "rank": 3,
+      "ir_pct": 12.81,
+      "symbol": "NamedTempFile::write_all (atomic output)"
+    },
+    {
+      "rank": 4,
+      "ir_pct": 17.61,
+      "symbol": "libc malloc _int_free + free (allocation/dealloc)"
+    },
+    {
+      "rank": 5,
+      "ir_pct": 5.18,
+      "symbol": "libc write (syscall)"
+    },
+    {
+      "rank": 6,
+      "ir_pct": 5.64,
+      "symbol": "serde_json Value::serialize"
+    },
+    {
+      "rank": 7,
+      "ir_pct": 2.34,
+      "symbol": "copybook_charset::ebcdic_to_utf8 (codepage conversion)"
+    },
+    {
+      "rank": 8,
+      "ir_pct": 1.78,
+      "symbol": "copybook_codec decode_scalar_field_value_with_scratch"
+    },
+    {
+      "rank": 9,
+      "ir_pct": 1.6,
+      "symbol": "copybook_codec decode_packed_decimal_with_scratch"
+    }
+  ],
+  "hot_path_findings": "On the end-to-end CLI decode-to-JSONL path, output I/O (write_all + write, ~32%), JSON serialization (serialize_str + Value::serialize, ~20%), and allocation/dealloc (malloc/free/drop_glue, ~20%) dominate. The copybook decode logic itself is a minor fraction: codepage conversion 2.3%, packed-decimal decode 1.6%, scalar field decode 1.8%. Implication for the #188 experiment order: I/O buffering/batching (#547) and hot-path allocation reduction (#548) are the material end-to-end limiters; portable SIMD for codepage conversion (#549) has limited payoff on the full CLI pipeline and should be gated on a pure-decode profile rather than the end-to-end path.",
+  "integrity": {
+    "sha256": "3734a8f8ebb485fb5a05d51d143aad9d54de4a4390e727d134dab55576716d61"
+  }
+}

--- a/tools/copybook-bench/BASELINE_METHODOLOGY.md
+++ b/tools/copybook-bench/BASELINE_METHODOLOGY.md
@@ -334,8 +334,60 @@ Measurements beyond 2 standard deviations from the mean are flagged as outliers.
 - `docs/archived/issue-49-tdd-handoff-package.md`: TDD specification and acceptance criteria
 - Criterion.rs documentation: https://bheisler.github.io/criterion.rs/book/
 
+## Supplementary Native-Linux Measurement (Issue #546)
+
+> **Scope note.** The measurement below is a *supplementary reproducibility datapoint*
+> captured on ephemeral cloud Linux hardware. It is **not** the canonical current metric
+> and MUST NOT be cited as one — canonical receipts live in
+> [`scripts/bench/perf.json`](../../scripts/bench/perf.json) and are produced on documented
+> reference hardware per [`docs/PERFORMANCE_GOVERNANCE.md`](../../docs/PERFORMANCE_GOVERNANCE.md).
+> This artifact exists so the profiling *method* is reproducible off the reference machine,
+> and to rank the #188 optimization experiments by measured cost. It does **not** overwrite
+> `perf.json` and does **not** move any CI floor.
+
+The full receipt is committed at
+[`scripts/bench/perf-linux-native.json`](../../scripts/bench/perf-linux-native.json)
+(`artifact_class: supplementary-native-linux`).
+
+### Reproduce
+
+```bash
+# 1. Throughput (2+ runs for run-to-run variance)
+RUSTFLAGS="-C target-cpu=native" PERF=1 cargo bench -p copybook-bench -- slo_validation --quiet
+#    Read target/criterion/slo_validation/*/new/estimates.json for mean + confidence interval.
+
+# 2. Peak RSS (getrusage on a real decode of a generated mixed workload)
+python3 -c "import subprocess,resource;subprocess.run(['target/release/copybook','decode',CPY,BIN,'--output','/dev/null','--format','fixed','--codepage','cp037']);print(resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss/1024,'MiB')"
+
+# 3. Hot paths (bounded callgrind over the decode-to-JSONL path)
+valgrind --tool=callgrind --callgrind-out-file=cg.out target/release/copybook decode CPY BIN --output /dev/null --format fixed --codepage cp037
+callgrind_annotate cg.out
+```
+
+### Observed (Intel Xeon @ 2.10 GHz, 4 cores, Linux 6.18.5, release, `target-cpu=native`)
+
+| Workload | Run 1 | Run 2 | Mean | Spread | CI floor | Floor ratio |
+|---|---|---|---|---|---|---|
+| DISPLAY-heavy | 1747.84 | 1758.51 | 1753.2 MiB/s | 0.3% | 80 MiB/s | 21.9× |
+| COMP-3-heavy | 12.25 | 11.54 | 11.9 MiB/s | 3.0% | 8 MiB/s | 1.5× |
+
+Peak RSS decoding 50,000 mixed fixed records to JSONL: **10.0 MiB** (governed ceiling 256 MiB).
+DISPLAY intra-run confidence interval is ±0.5%; COMP-3 shows higher run-to-run variance (~3%),
+so COMP-3 experiments need ≥5 runs to clear the noise floor.
+
+### Hot-path ranking → recommended #188 experiment order
+
+Callgrind over the end-to-end CLI decode-to-JSONL path shows output I/O (~32%), JSON
+serialization (~20%), and allocation/dealloc (~20%) dominate; the copybook decode logic itself
+is minor (codepage conversion 2.3%, packed-decimal decode 1.6%, scalar field decode 1.8%).
+Implication: **I/O buffering/batching (#547) and hot-path allocation reduction (#548) are the
+material end-to-end limiters**, while portable SIMD for codepage conversion (#549) has limited
+payoff on the full CLI pipeline and should be gated on a *pure-decode* profile rather than this
+end-to-end path.
+
 ## Revision History
 
 | Date | Version | Changes |
 |------|---------|---------|
 | 2025-09-30 | 1.0 | Initial methodology documentation (Issue #49 AC2) |
+| 2026-07-19 | 1.1 | Supplementary native-Linux measurement + hot-path ranking (Issue #546) |


### PR DESCRIPTION
## Summary

Advances #546 (refresh the perf measurement baseline) **non-destructively**. The canonical receipt `scripts/bench/perf.json` and the perf-gate baseline `scripts/bench/baseline.json` are **untouched** — they are CI-load-bearing and pinned to reference hardware, and this container is ephemeral cloud hardware whose numbers are not reproducible enough to become canonical. Instead this PR adds a clearly-labelled *supplementary* datapoint plus a profiling method that reproduces off the reference machine.

### What's added

- **`scripts/bench/perf-linux-native.json`** (`artifact_class: supplementary-native-linux`) — a receipt with 2-run DISPLAY/COMP-3 throughput + variance, peak RSS, and a callgrind hot-path ranking. It explicitly references the canonical receipt and states it MUST NOT be cited as a current metric (per `docs/PERFORMANCE_GOVERNANCE.md`).
- **`tools/copybook-bench/BASELINE_METHODOLOGY.md`** — a supplementary section with exact reproduction steps (criterion throughput, `getrusage` peak RSS, bounded `callgrind`), the observed numbers/variance, and a hot-path-driven recommendation for the #188 experiment order.

### Measured (Intel Xeon @ 2.10 GHz, 4 cores, Linux 6.18.5, release, `target-cpu=native`)

| Workload | Run 1 | Run 2 | Mean | Spread | CI floor | Floor ratio |
|---|---|---|---|---|---|---|
| DISPLAY-heavy | 1747.84 | 1758.51 | 1753.2 MiB/s | 0.3% | 80 | 21.9× |
| COMP-3-heavy | 12.25 | 11.54 | 11.9 MiB/s | 3.0% | 8 | 1.5× |

Peak RSS decoding 50,000 mixed fixed records to JSONL: **10.0 MiB** (governed ceiling 256 MiB).

### Hot-path finding → recommended experiment order

Callgrind over the end-to-end CLI decode→JSONL path: output **I/O ~32%**, **JSON serialization ~20%**, **allocation/dealloc ~20%** dominate; copybook decode logic is minor (codepage conversion 2.3%, packed-decimal decode 1.6%, scalar field decode 1.8%).

**Implication:** I/O buffering/batching (#547) and hot-path allocation reduction (#548) are the material end-to-end limiters; portable SIMD for codepage conversion (#549) has limited payoff on the full CLI pipeline and should be gated on a *pure-decode* profile, not this end-to-end path.

## Type of Change

- [x] Documentation / evidence (performance receipts + methodology)

## Checklist

- [x] Canonical `perf.json` and perf-gate `baseline.json` left untouched (no CI-floor change)
- [x] New receipt is valid JSON and labelled non-canonical
- [x] Supplementary numbers are not presented as current canonical metrics (governance-compliant)
- [x] `git diff --check` clean; no `.rs` changes (fmt/clippy N/A)

## Breaking Changes

- [x] None (evidence only; no source, API, or CI-gate changes)

## Related Issues

Relates to #546; informs #188 experiment ordering (#547/#548/#549).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WK5yVbkkG55fza5mPj6Zue)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added reproducibility guidance for supplementary native-Linux performance measurements.
  * Documented observed throughput and memory usage results on Intel Xeon hardware.
  * Added guidance for ranking hot-path optimization experiments and updated the revision history.

* **Performance**
  * Added a native-Linux benchmark receipt containing workload metrics, environment details, memory usage, profiling findings, and integrity verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->