### PR TITLE
docs(errors): mark CBKD431/CBKD432 as reserved, not currently emitted (#599)

### DIFF
--- a/crates/copybook-error/src/lib.rs
+++ b/crates/copybook-error/src/lib.rs
@@ -208,9 +208,13 @@ pub enum ErrorCode {
     CBKD422_EDITED_PIC_SIGN_MISMATCH,
     /// CBKD423: Edited PIC blank when zero handling error
     CBKD423_EDITED_PIC_BLANK_WHEN_ZERO,
-    /// CBKD431: Floating-point field contains NaN (decoded as null)
+    /// CBKD431: Floating-point field contains NaN. Reserved — not currently
+    /// emitted; the decode path converts NaN to JSON `null` instead of raising
+    /// this code. See `docs/reference/ERROR_CODES.md`.
     CBKD431_FLOAT_NAN,
-    /// CBKD432: Floating-point field contains infinity (decoded as null)
+    /// CBKD432: Floating-point field contains infinity. Reserved — not
+    /// currently emitted; the decode path converts ±Infinity to JSON `null`
+    /// instead of raising this code. See `docs/reference/ERROR_CODES.md`.
     CBKD432_FLOAT_INFINITY,
 
     // =============================================================================

--- a/docs/reference/ERROR_CODES.md
+++ b/docs/reference/ERROR_CODES.md
@@ -512,15 +512,17 @@ All spaces decoded as "0"
 
 #### CBKD431_FLOAT_NAN
 **Description**: Floating-point field (COMP-1/COMP-2) contains NaN; the value is decoded as JSON null
-**Severity**: Error
+**Severity**: Reserved — not currently emitted (see note)
 **Context**: Record number, field path
 **Resolution**: Check upstream data generation for uninitialized float fields; null output is the documented behavior
+**Note**: The current decode path converts NaN to JSON `null` and does **not** raise this code — it is reserved in the taxonomy for a future strict float-handling policy. The null-decode contract is pinned by `crates/copybook-codec/tests/numeric_evidence_matrix.rs::float_special_values_decode_to_null`.
 
 #### CBKD432_FLOAT_INFINITY
 **Description**: Floating-point field (COMP-1/COMP-2) contains infinity; the value is decoded as JSON null
-**Severity**: Error
+**Severity**: Reserved — not currently emitted (see note)
 **Context**: Record number, field path
 **Resolution**: Check upstream data generation for overflowed float values; null output is the documented behavior
+**Note**: The current decode path converts ±Infinity to JSON `null` and does **not** raise this code — it is reserved in the taxonomy for a future strict float-handling policy. The null-decode contract is pinned by `crates/copybook-codec/tests/numeric_evidence_matrix.rs::float_special_values_decode_to_null`.
 
 ### Data Encoding Errors (CBKE*)
 
@@ -915,8 +917,8 @@ All 63 stable error codes across 10 families:
 | CBKD421 | Decode | Fatal | Edited PIC: Invalid format (Phase E2) |
 | CBKD422 | Decode | Fatal | Edited PIC: Sign mismatch (Phase E2) |
 | CBKD423 | Decode | Warning | Edited PIC: Blank when zero (Phase E2) |
-| CBKD431 | Decode | Error | Float NaN (decoded as null) |
-| CBKD432 | Decode | Error | Float infinity (decoded as null) |
+| CBKD431 | Decode | Reserved | Float NaN (decoded as null; code not currently emitted) |
+| CBKD432 | Decode | Reserved | Float infinity (decoded as null; code not currently emitted) |
 | CBKI001 | Infrastructure | Fatal | Invalid iterator/internal state |
 | CBKE501 | Encode | Fatal | JSON type mismatch |
 | CBKE505 | Encode | Fatal | Decimal scale mismatch |


### PR DESCRIPTION
## Summary

Closes #599 (a #551 sub-issue). Reconciles the error taxonomy with actual decode behavior.

`CBKD431_FLOAT_NAN` and `CBKD432_FLOAT_INFINITY` are declared stable error codes but are **never raised** on the decode path: NaN/±Infinity in COMP-1/COMP-2 fields decode to JSON `null`. The docs listed them as **Severity: Error** (implying they are emitted) even though the same entries said "decoded as null" — an internal contradiction, and a mismatch with the #551 program metric *"every stable error code has a dedicated test that triggers the exact code"* (these two cannot be triggered).

### Changes (no behavior change)

- **`docs/reference/ERROR_CODES.md`**: severity → **Reserved** for both codes, with an explicit note that the decode path yields `null` and does not raise the code (reserved for a future strict float-handling policy). Summary-table rows updated to match.
- **`crates/copybook-error/src/lib.rs`**: enum doc comments updated to state "Reserved — not currently emitted".

### Why "reserved" rather than adding a strict-raise policy

Making these codes reachable would require a new `DecodeOptions` field — **stable-core API expansion**, which the #189 freeze guardrail disallows without explicit classification. Documenting them honestly as reserved is the freeze-compatible resolution and matches the #535 metric *"Docs-truth contradictions: 0"*. If the maintainers later want a strict float policy, that's a separate, classified feature decision (noted in #599).

### Verification

- Error-code **count parity preserved** (63 codes in source, 63 detail entries in docs) — the xtask `error-code-inventory` check is count-based and unaffected.
- `cargo build -p copybook-error` clean; `cargo fmt --all --check` clean.
- The null-decode contract is already pinned by the merged test `crates/copybook-codec/tests/numeric_evidence_matrix.rs::float_special_values_decode_to_null`.

## Type of Change

- [x] Documentation / taxonomy reconciliation (no behavior change)

## Breaking Changes

- [x] None (docs + doc-comments only; no code paths, API, or error-code set changed)

## Related Issues

Closes #599; relates to #551.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WK5yVbkkG55fza5mPj6Zue)_