### PR TITLE
feat(contracts): add Feature::lifecycle() to reconcile COMP-1/2 stability class (#602)

### DIFF
--- a/crates/copybook-contracts/src/feature_flags.rs
+++ b/crates/copybook-contracts/src/feature_flags.rs
@@ -108,7 +108,16 @@ pub enum Feature {
 }
 
 impl Feature {
-    /// Get the category this feature belongs to.
+    /// Get the toggle-group category this feature belongs to.
+    ///
+    /// `category()` is a **grouping mechanism** used by `enable_category` /
+    /// `enabled_in_category` to toggle related flags together; it is **not** a
+    /// stability class. In particular, `FeatureCategory::Experimental` names a
+    /// toggle group, not a claim that every member is unstable — the stability
+    /// class of a feature is reported by [`Feature::lifecycle`]. For example,
+    /// `Comp1`/`Comp2` are in the `Experimental` toggle group but have
+    /// `lifecycle() == FeatureLifecycle::Stable` (they are fully supported and
+    /// enabled by default; see `docs/reference/COBOL_SUPPORT_MATRIX.md`).
     #[inline]
     #[must_use]
     pub const fn category(self) -> FeatureCategory {
@@ -134,6 +143,42 @@ impl Feature {
             | Feature::FuzzingIntegration
             | Feature::CoverageInstrumentation
             | Feature::PropertyBasedTesting => FeatureCategory::Testing,
+        }
+    }
+
+    /// Get the stability lifecycle class of this feature.
+    ///
+    /// This is the authoritative stability signal (distinct from the
+    /// toggle-group [`Feature::category`]). `SignSeparate`, `Comp1`, and
+    /// `Comp2` are promoted COBOL-language features that are fully supported
+    /// and enabled by default, so they report [`FeatureLifecycle::Stable`];
+    /// every other flag (advanced RENAMES R4-R6, enterprise/compliance,
+    /// performance, debug, and testing hooks) is opt-in and reports
+    /// [`FeatureLifecycle::Experimental`].
+    #[inline]
+    #[must_use]
+    pub const fn lifecycle(self) -> FeatureLifecycle {
+        match self {
+            Feature::SignSeparate | Feature::Comp1 | Feature::Comp2 => FeatureLifecycle::Stable,
+            Feature::RenamesR4R6
+            | Feature::AuditSystem
+            | Feature::SoxCompliance
+            | Feature::HipaaCompliance
+            | Feature::GdprCompliance
+            | Feature::PciDssCompliance
+            | Feature::SecurityMonitoring
+            | Feature::AdvancedOptimization
+            | Feature::LruCache
+            | Feature::ParallelDecode
+            | Feature::ZeroCopy
+            | Feature::VerboseLogging
+            | Feature::DiagnosticOutput
+            | Feature::Profiling
+            | Feature::MemoryTracking
+            | Feature::MutationTesting
+            | Feature::FuzzingIntegration
+            | Feature::CoverageInstrumentation
+            | Feature::PropertyBasedTesting => FeatureLifecycle::Experimental,
         }
     }
 
@@ -651,6 +696,36 @@ mod tests {
         assert!(Feature::Comp2.default_enabled());
         assert!(Feature::LruCache.default_enabled());
         assert!(!Feature::VerboseLogging.default_enabled());
+    }
+
+    #[test]
+    fn lifecycle_reconciles_comp1_comp2_with_support_matrix() {
+        // Promoted COBOL-language features report a Stable lifecycle and are
+        // enabled by default, matching docs/reference/COBOL_SUPPORT_MATRIX.md
+        // ("Fully Supported"), even though category() groups them under the
+        // Experimental toggle group. lifecycle() is the authoritative class.
+        for feat in [Feature::Comp1, Feature::Comp2, Feature::SignSeparate] {
+            assert_eq!(
+                feat.lifecycle(),
+                FeatureLifecycle::Stable,
+                "{feat} should report a Stable lifecycle"
+            );
+            assert!(feat.default_enabled(), "{feat} should be default-enabled");
+        }
+
+        // category() stays a toggle group, orthogonal to the stability class.
+        assert_eq!(Feature::Comp1.category(), FeatureCategory::Experimental);
+        assert_eq!(Feature::Comp2.category(), FeatureCategory::Experimental);
+
+        // Opt-in / advanced flags remain Experimental in lifecycle.
+        assert_eq!(
+            Feature::RenamesR4R6.lifecycle(),
+            FeatureLifecycle::Experimental
+        );
+        assert_eq!(
+            Feature::AuditSystem.lifecycle(),
+            FeatureLifecycle::Experimental
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #602 (a #551 sub-issue). Reconciles the COMP-1/COMP-2 classification inconsistency **additively**, without changing any toggle behavior (per the maintainer-approved disposition).

### The inconsistency

Three sources appeared to disagree on the class of COMP-1/COMP-2:
- `docs/reference/COBOL_SUPPORT_MATRIX.md` — "✅ Fully Supported … promoted from experimental"
- `Feature::default_enabled()` — `true` (on by default)
- `Feature::category()` — `FeatureCategory::Experimental`

Root cause: `category()` is a **toggle group** used by `enable_category()` / `enabled_in_category()`, not a stability class. The `FeatureLifecycle` enum (Experimental/Stable/Deprecated) already existed but was never wired to `Feature`.

### Changes (additive, non-breaking)

- **`Feature::lifecycle() -> FeatureLifecycle`**: the authoritative stability signal. `SignSeparate`/`Comp1`/`Comp2` → `Stable` (promoted, default-on, matrix-supported); every opt-in/enterprise/performance/debug/testing flag → `Experimental`.
- **`category()` doc** clarified: it is a grouping/toggle mechanism, not a stability class; the `Experimental` *category* does not imply a member is unstable — see `lifecycle()`.
- **Consistency test**: asserts `Comp1`/`Comp2`/`SignSeparate` are `Stable` + default-on, `category()` stays `Experimental` (orthogonal), and advanced/enterprise flags remain `Experimental` in lifecycle.

After this, the sources agree on the stability class via `lifecycle()` (Stable), and `category()` is explicitly documented as an orthogonal toggle group.

### Why additive rather than moving the category

Moving `Comp1`/`Comp2` out of the `Experimental` *category* would change `enable_category(Experimental)` behavior and break the existing category-grouping tests — and there's no fitting alternative category (Enterprise/Performance/Debug/Testing). Wiring the dedicated `lifecycle()` signal is the non-breaking reconciliation.

### Verification

- `cargo test -p copybook-contracts` green (28 tests incl. the new one); existing `enable_category`/`enabled_in_category`/category tests unchanged and passing.
- `cargo clippy -p copybook-contracts -- -D warnings -W clippy::pedantic` clean; `cargo fmt --all --check` clean.
- `lifecycle()` match is exhaustive over all 22 `Feature` variants (compile-enforced).

## Type of Change

- [x] Additive API (`lifecycle()` accessor) + docs + test; no behavior change

## Breaking Changes

- [x] None (additive read-only accessor; `category()`/`default_enabled()`/toggle behavior unchanged)

## Related Issues

Closes #602; relates to #551, #541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WK5yVbkkG55fza5mPj6Zue)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lifecycle information for feature flags, distinguishing stable and experimental features.
  * Marked key COBOL language features as stable while retaining their experimental toggle category.

* **Documentation**
  * Clarified that feature categories control grouped enablement and are separate from stability classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->