### PR TITLE
fix: clarify CLI rejection mapping and encoded PIC X length handling

### DIFF
--- a/crates/copybook-cli/src/exit_codes.rs
+++ b/crates/copybook-cli/src/exit_codes.rs
@@ -134,7 +134,9 @@ impl ExitCode {
     pub fn from_family_prefix(prefix: &str) -> Option<Self> {
         match prefix {
             "CBKD" => Some(ExitCode::Data),
-            "CBKE" => Some(ExitCode::Encode),
+            "CBKE" | "CBKP" | "CBKS" => Some(ExitCode::Encode),
+            // Parse/schema rejections (syntax + validation families).
+            // Map to Encode/validation at the process boundary for stable CLI UX.
             "CBKF" => Some(ExitCode::Format),
             "CBKI" => Some(ExitCode::Internal),
             _ => None,

--- a/crates/copybook-cli/tests/exit_code_mapping.rs
+++ b/crates/copybook-cli/tests/exit_code_mapping.rs
@@ -21,6 +21,17 @@ fn run_and_status(args: &[OsString]) -> TestResult<i32> {
     Ok(status.code().unwrap_or(1))
 }
 
+fn run_and_status_with_stderr(args: &[OsString]) -> TestResult<(i32, String)> {
+    let bin = env!("CARGO_BIN_EXE_copybook");
+    let output = Command::new(bin)
+        .args(args)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()?;
+    let code = output.status.code().unwrap_or(1);
+    Ok((code, String::from_utf8_lossy(&output.stderr).into_owned()))
+}
+
 #[test]
 #[serial]
 fn exit_code_cbkf_is_4() -> TestResult<()> {
@@ -117,7 +128,7 @@ fn exit_code_cbke_is_3() -> TestResult<()> {
 
 #[test]
 #[serial]
-fn exit_code_cbki_is_5() -> TestResult<()> {
+fn decode_empty_input_with_determined_lrecl_succeeds() -> TestResult<()> {
     // ODO + fixed now works (lrecl_fixed computed from max_count).
     // Empty input → 0 records → success.
     let copybook = NamedTempFile::new()?;
@@ -153,7 +164,33 @@ fn exit_code_cbki_is_5() -> TestResult<()> {
 
 #[test]
 #[serial]
-fn panic_is_mapped_to_internal_exit_code() -> TestResult<()> {
+fn exit_code_cbkp_is_3() -> TestResult<()> {
+    let copybook = NamedTempFile::new()?;
+    write_file(
+        copybook.path(),
+        "01 OUTER-REC.\n   05 OUTER-COUNT PIC 9(2).\n   05 OUTER-GROUP OCCURS 1 TO 50 TIMES DEPENDING ON OUTER-COUNT.\n      10 INNER-COUNT PIC 9(2).\n      10 INNER-ARRAY OCCURS 1 TO 100 TIMES DEPENDING ON INNER-COUNT.\n         15 DATA-VALUE PIC X(10).\n",
+    )?;
+
+    let args = vec![
+        OsString::from("parse"),
+        copybook.path().as_os_str().to_owned(),
+    ];
+    let (code, stderr) = run_and_status_with_stderr(&args)?;
+
+    assert_eq!(
+        code, 3,
+        "Nested ODO parse rejection (CBKP022) should map to CBKE exit code 3"
+    );
+    assert!(
+        stderr.contains("CBKP022"),
+        "stderr should contain CBKP022 family code: {stderr}"
+    );
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn exit_code_cbki_is_5() -> TestResult<()> {
     let bin = env!("CARGO_BIN_EXE_copybook");
     let status = Command::new(bin)
         .env("COPYBOOK_TEST_PANIC", "1")

--- a/crates/copybook-cli/tests/rejection_exit_codes.rs
+++ b/crates/copybook-cli/tests/rejection_exit_codes.rs
@@ -2,20 +2,9 @@
 //! CLI command-context evidence for deliberate rejections (issue #576).
 //!
 //! `copybook-cli/tests/exit_code_mapping.rs` already covers the mapped error
-//! families (`CBKD`→2, `CBKE`→3, `CBKF`→4, `CBKI`→5). This suite fills the
-//! documented gap for **structural** rejections: parse/schema errors in the
-//! `CBKP*` / `CBKS*` families are not present in `ExitCode::from_family_prefix`
-//! (`crates/copybook-cli/src/exit_codes.rs`), so they fall through to exit code
-//! **5 (Internal orchestration error)** — the same code a genuine panic
-//! produces.
-//!
-//! These tests pin that **current, observed** behavior so a regression is
-//! visible, and document the mismatch against `docs/reference/COBOL_SUPPORT_MATRIX.md`
-//! (which assigns each scenario a stable `CBKP*`/`CBKS*` code). Whether these
-//! structural rejections should map to a dedicated, non-`Internal` exit code is
-//! a stability-contract decision left to the maintainers (see the PR notes); the
-//! library layer already reports the precise, stable code — see
-//! `copybook-codec/tests/rejection_evidence_matrix.rs`.
+//! families (`CBKD`→2, `CBKE`→3, `CBKF`→4, `CBKI`→5). This suite asserts the
+//! mapped behavior for **structural** parse/schema rejections (`CBKP*` / `CBKS*`):
+//! they are surfaced as exit code **3** via the `CBKE` mapping.
 
 #![allow(clippy::expect_used)]
 #![allow(clippy::unwrap_used)]
@@ -24,17 +13,17 @@ mod common;
 
 use assert_fs::prelude::*;
 use common::bin;
+use predicates::str::contains;
 
-/// Documented structural-rejection exit code (Internal). Named so the intent —
-/// and the fact that it collides with the panic exit code — is explicit.
-const STRUCTURAL_REJECTION_EXIT: i32 = 5;
+/// Documented structural-rejection exit code (mapped to `CBKE`).
+const STRUCTURAL_REJECTION_EXIT: i32 = 3;
 
 fn path_str(p: &std::path::Path) -> String {
     p.to_string_lossy().into_owned()
 }
 
 /// Run `copybook parse` on `copybook_text` and assert the process exit code.
-fn assert_parse_exit(copybook_text: &str, expected_code: i32) {
+fn assert_parse_exit(copybook_text: &str, expected_code: i32, expected_error: &str) {
     let dir = assert_fs::TempDir::new().unwrap();
     let cpy = dir.child("rej.cpy");
     cpy.write_str(copybook_text).unwrap();
@@ -43,11 +32,12 @@ fn assert_parse_exit(copybook_text: &str, expected_code: i32) {
         .args(["parse", &path_str(cpy.path())])
         .assert()
         .failure()
-        .code(expected_code);
+        .code(expected_code)
+        .stderr(contains(expected_error));
 }
 
 // ====================================================================
-// CBKP* structural parse rejections (currently exit 5 / Internal)
+// CBKP* structural parse rejections (mapped to exit 3 / CBKE)
 // ====================================================================
 
 #[test]
@@ -56,6 +46,7 @@ fn cli_odo_not_tail_exit_code() {
     assert_parse_exit(
         "01 INV-REC.\n   05 ITEM-COUNT PIC 9(3).\n   05 ITEMS OCCURS 1 TO 10 TIMES DEPENDING ON ITEM-COUNT.\n      10 ITEM-CODE PIC X(4).\n   05 TRAILER PIC X(5).\n",
         STRUCTURAL_REJECTION_EXIT,
+        "CBKP021_ODO_NOT_TAIL",
     );
 }
 
@@ -65,6 +56,7 @@ fn cli_nested_odo_exit_code() {
     assert_parse_exit(
         "01 OUTER-REC.\n   05 OUTER-COUNT PIC 9(2).\n   05 OUTER-GROUP OCCURS 1 TO 50 TIMES DEPENDING ON OUTER-COUNT.\n      10 INNER-COUNT PIC 9(2).\n      10 INNER-ARRAY OCCURS 1 TO 100 TIMES DEPENDING ON INNER-COUNT.\n         15 DATA-VALUE PIC X(10).\n",
         STRUCTURAL_REJECTION_EXIT,
+        "CBKP022_NESTED_ODO",
     );
 }
 
@@ -74,11 +66,12 @@ fn cli_odo_over_redefines_exit_code() {
     assert_parse_exit(
         "01 TRANSACTION-REC.\n   05 TRANS-TYPE PIC X(1).\n   05 TRANS-COUNT PIC 9(2).\n   05 TRANS-DATA PIC X(100).\n   05 TRANS-DETAIL REDEFINES TRANS-DATA.\n      10 DETAIL-ITEM OCCURS 1 TO 100 TIMES DEPENDING ON TRANS-COUNT.\n         15 DETAIL-FIELD PIC X(10).\n",
         STRUCTURAL_REJECTION_EXIT,
+        "CBKP023_ODO_REDEFINES",
     );
 }
 
 // ====================================================================
-// CBKS* schema/resolver parse rejection (currently exit 5 / Internal)
+// CBKS* schema/resolver parse rejection (mapped to exit 3 / CBKE)
 // ====================================================================
 
 #[test]
@@ -87,6 +80,7 @@ fn cli_renames_over_occurs_exit_code() {
     assert_parse_exit(
         "01 ROOT-REC.\n   05 FIELD-A PIC X(5).\n   05 ARRAY-FIELD PIC 9(3) OCCURS 5 TIMES.\n   05 FIELD-B PIC X(2).\n   66 ALIAS RENAMES FIELD-A THRU FIELD-B.\n",
         STRUCTURAL_REJECTION_EXIT,
+        "CBKS607_RENAME_CROSSES_OCCURS",
     );
 }
 

--- a/crates/copybook-codec/src/json.rs
+++ b/crates/copybook-codec/src/json.rs
@@ -1684,21 +1684,25 @@ impl JsonEncoder {
         match &field.kind {
             FieldKind::Alphanum { len: _ } => {
                 if let Value::String(text) = value {
-                    // Validate string length doesn't exceed field capacity
-                    if text.len() > field.len as usize {
+                    // Validate encoded byte length doesn't exceed field capacity.
+                    let encoded = crate::charset::utf8_to_ebcdic(text, self.options.codepage)?;
+                    if encoded.len() > field.len as usize {
                         return Err(Error::new(
                             ErrorCode::CBKE515_STRING_LENGTH_VIOLATION,
-                            format!("String length {} exceeds field capacity {} for alphanumeric field {}",
-                                text.len(), field.len, field.path),
-                        ).with_field(field.path.clone()));
+                            format!(
+                                "Encoded byte length {} exceeds field capacity {} for alphanumeric field {}",
+                                encoded.len(),
+                                field.len,
+                                field.path
+                            ),
+                        )
+                        .with_field(field.path.clone()));
                     }
 
-                    let encoded = crate::numeric::encode_alphanumeric(
-                        text,
-                        field.len as usize,
-                        self.options.codepage,
-                    )?;
-                    field_data.copy_from_slice(&encoded);
+                    let space = crate::charset::space_byte(self.options.codepage);
+                    let field_len = field.len as usize;
+                    field_data[..encoded.len()].copy_from_slice(&encoded);
+                    field_data[encoded.len()..field_len].fill(space);
                 } else {
                     return Err(Error::new(
                         ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
@@ -1858,13 +1862,14 @@ impl JsonEncoder {
         field_data: &mut [u8],
     ) -> Result<()> {
         if let Value::String(text) = value {
-            // Validate string length doesn't exceed field capacity
-            if text.len() > field.len as usize {
+            // Validate encoded byte length doesn't exceed field capacity.
+            let encoded = crate::charset::utf8_to_ebcdic(text, self.options.codepage)?;
+            if encoded.len() > field.len as usize {
                 return Err(Error::new(
                     ErrorCode::CBKE515_STRING_LENGTH_VIOLATION,
                     format!(
-                        "String length {} exceeds field capacity {} for alphanumeric field {}",
-                        text.len(),
+                        "Encoded byte length {} exceeds field capacity {} for alphanumeric field {}",
+                        encoded.len(),
                         field.len,
                         field.path
                     ),
@@ -1872,12 +1877,10 @@ impl JsonEncoder {
                 .with_field(field.path.clone()));
             }
 
-            let encoded = crate::numeric::encode_alphanumeric(
-                text,
-                field.len as usize,
-                self.options.codepage,
-            )?;
-            field_data.copy_from_slice(&encoded);
+            let space = crate::charset::space_byte(self.options.codepage);
+            let field_len = field.len as usize;
+            field_data[..encoded.len()].copy_from_slice(&encoded);
+            field_data[encoded.len()..field_len].fill(space);
         } else {
             return Err(Error::new(
                 ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
@@ -2416,6 +2419,46 @@ impl<W: Write> OrderedJsonWriter<W> {
 mod tests {
     use super::*;
     use std::io::Cursor;
+    use crate::options::Codepage;
+
+    fn direct_path_schema(field_len: u32) -> Schema {
+        let field = Field {
+            path: "ROOT.SHORT-FIELD".to_string(),
+            name: "SHORT-FIELD".to_string(),
+            level: 5,
+            kind: FieldKind::Alphanum { len: field_len },
+            offset: 0,
+            len: field_len,
+            redefines_of: None,
+            occurs: None,
+            sync_padding: None,
+            synchronized: false,
+            blank_when_zero: false,
+            children: Vec::new(),
+        };
+
+        let root = Field {
+            path: "ROOT".to_string(),
+            name: "ROOT".to_string(),
+            level: 1,
+            kind: FieldKind::Group,
+            offset: 0,
+            len: field_len,
+            redefines_of: None,
+            occurs: None,
+            sync_padding: None,
+            synchronized: false,
+            blank_when_zero: false,
+            children: vec![field],
+        };
+
+        Schema {
+            fields: vec![root],
+            lrecl_fixed: Some(field_len),
+            tail_odo: None,
+            fingerprint: String::new(),
+        }
+    }
 
     fn build_test_schema() -> Schema {
         let field_a = Field {
@@ -2520,5 +2563,39 @@ mod tests {
         assert_eq!(names.len(), 2);
         assert!(names.contains(&"FIELD-B"));
         assert!(names.contains(&"FIELD-C"));
+    }
+
+    #[test]
+    fn test_json_encoder_valid_encoded_length_is_accepted() {
+        let schema = direct_path_schema(1);
+        let encoder = JsonEncoder::new(EncodeOptions::new().with_codepage(Codepage::CP037));
+        let payload = serde_json::json!({
+            "ROOT": {
+                "SHORT-FIELD": "¢",
+            },
+        });
+        let encoded = encoder
+            .encode_record(&schema, &payload)
+            .unwrap_or_else(|e| panic!("single-byte symbol should fit after encoding: {e}"));
+        let expected = crate::charset::utf8_to_ebcdic("¢", Codepage::CP037)
+            .expect("symbol should encode under CP037");
+
+        assert_eq!(encoded, expected);
+    }
+
+    #[test]
+    fn test_json_encoder_encoded_length_violation_for_wide_input() {
+        let schema = direct_path_schema(1);
+        let encoder = JsonEncoder::new(EncodeOptions::new().with_codepage(Codepage::CP037));
+        let payload = serde_json::json!({
+            "ROOT": {
+                "SHORT-FIELD": "¢¢",
+            },
+        });
+        let result = encoder
+            .encode_record(&schema, &payload)
+            .expect_err("double-byte field value should violate length check");
+
+        assert_eq!(result.code, ErrorCode::CBKE515_STRING_LENGTH_VIOLATION);
     }
 }

--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -2233,13 +2233,14 @@ fn encode_alphanum_field(
     let field_len = field.len as usize;
 
     if let Some(text) = json_obj.get(&field.name).and_then(|value| value.as_str()) {
-        // Validate string length doesn't exceed field capacity
-        if text.len() > field_len {
+        // Validate encoded byte length doesn't exceed field capacity.
+        let bytes = crate::charset::utf8_to_ebcdic(text, options.codepage)?;
+        if bytes.len() > field_len {
             return Err(Error::new(
                 ErrorCode::CBKE515_STRING_LENGTH_VIOLATION,
                 format!(
-                    "String length {} exceeds field capacity {} for alphanumeric field {}",
-                    text.len(),
+                    "Encoded byte length {} exceeds field capacity {} for alphanumeric field {}",
+                    bytes.len(),
                     field_len,
                     field.path
                 ),
@@ -2247,11 +2248,10 @@ fn encode_alphanum_field(
             .with_field(field.path.clone()));
         }
 
-        let bytes = crate::charset::utf8_to_ebcdic(text, options.codepage)?;
-        let copy_len = bytes.len().min(field_len);
+        let copy_len = bytes.len();
 
         if current_offset + field_len <= buffer.len() {
-            buffer[current_offset..current_offset + copy_len].copy_from_slice(&bytes[..copy_len]);
+            buffer[current_offset..current_offset + copy_len].copy_from_slice(&bytes);
             // Pad with codepage-aware space (0x40 for EBCDIC, 0x20 for ASCII)
             let space = crate::charset::space_byte(options.codepage);
             buffer[current_offset + copy_len..current_offset + field_len].fill(space);

--- a/crates/copybook-codec/tests/codepage_evidence_matrix.rs
+++ b/crates/copybook-codec/tests/codepage_evidence_matrix.rs
@@ -18,11 +18,7 @@
 //!   to a *different* character (`probe_ch`) under each codepage (e.g. byte
 //!   `0x4A` is `¢` in CP037 but `Ä` in CP273 and `[` in CP500).
 //! * **Round-trip discriminator** — the ASCII character `[` (`RT_CH`), which
-//!   maps to a *different* EBCDIC byte (`rt_byte`) under each codepage. `[` is a
-//!   single UTF-8 byte, so it also round-trips cleanly through the encode
-//!   capacity check for a one-byte `PIC X(1)` field (unlike a national
-//!   character such as `¢`, which is two UTF-8 bytes — see
-//!   `encode_capacity_is_measured_in_utf8_bytes`).
+//!   maps to a *different* EBCDIC byte (`rt_byte`) under each codepage.
 
 use copybook_codec::charset::{ebcdic_to_utf8, utf8_to_ebcdic};
 use copybook_codec::{
@@ -425,22 +421,38 @@ fn encode_euro_is_specific_to_cp1140() {
 }
 
 // ===========================================================================
-// Documented asymmetry: the encode capacity check counts UTF-8 bytes, not
-// characters, so a single-byte alphanumeric field cannot hold a national
-// character that occupies more than one UTF-8 byte even though it maps to a
-// single EBCDIC byte. This pins the current, observed contract.
+// Capacity is enforced after codepage encoding, so a field size is measured
+// in encoded bytes (e.g. EBCDIC bytes), not UTF-8 source bytes.
 // ===========================================================================
 
 #[test]
-fn encode_capacity_is_measured_in_utf8_bytes() {
+fn encode_capacity_is_measured_after_codepage_encoding() {
     let schema = parse_copybook(SIG_COPYBOOK).expect("copybook parses");
-    // "¢" is one character but two UTF-8 bytes; PIC X(1) has capacity one byte.
-    let json = serde_json::json!({ "SIG": "¢" });
-    let err = encode_record(
-        &schema,
-        &json,
-        &encode_opts(Codepage::CP037, RecordFormat::Fixed),
-    )
-    .expect_err("2-byte UTF-8 char must not fit a 1-byte field");
-    assert_eq!(err.code, ErrorCode::CBKE515_STRING_LENGTH_VIOLATION);
+
+    // Multi-byte UTF-8 characters that can be represented as one EBCDIC byte.
+    let samples = [
+        (Codepage::CP037, "¢"),
+        (Codepage::CP273, "Ä"),
+        (Codepage::CP500, "["),
+        (Codepage::CP1047, "Ý"),
+        (Codepage::CP1140, "€"),
+    ];
+
+    for (cp, symbol) in samples {
+        let encoded = utf8_to_ebcdic(symbol, cp).expect("symbol must encode");
+        assert_eq!(encoded.len(), 1, "sample must be one byte under {cp}");
+
+        let ok = serde_json::json!({ "SIG": symbol });
+        let encoded_value = encode_record(&schema, &ok, &encode_opts(cp, RecordFormat::Fixed))
+            .unwrap_or_else(|e| panic!("{cp}: '{symbol}' should fit after conversion: {e}"));
+        assert_eq!(
+            encoded_value, encoded,
+            "one-byte field must retain single-byte codepage encoding"
+        );
+
+        let too_long = serde_json::json!({ "SIG": format!("{symbol}{symbol}") });
+        let err = encode_record(&schema, &too_long, &encode_opts(cp, RecordFormat::Fixed))
+            .expect_err("double character should exceed one-byte field");
+        assert_eq!(err.code, ErrorCode::CBKE515_STRING_LENGTH_VIOLATION);
+    }
 }

--- a/crates/copybook-codec/tests/error_code_tests.rs
+++ b/crates/copybook-codec/tests/error_code_tests.rs
@@ -162,8 +162,9 @@ fn test_cbke515_string_length_exceeds_capacity() {
             err.code
         );
         assert!(
-            err.message.contains("String length") && err.message.contains("exceeds"),
-            "Error should mention string length exceeds capacity: {}",
+            (err.message.contains("Encoded byte length") || err.message.contains("String length"))
+                && err.message.contains("exceeds"),
+            "Error should mention length exceeds capacity: {}",
             err.message
         );
     }

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -570,15 +570,13 @@ copybook decode legacy-schema.cpy data.bin --format fixed --strict-comments --ou
 | Code | Tag | Meaning |
 |-----:|:---:|---------|
 | 0 | OK | Success |
-| 1 | CBK? | Unhandled failure (panic, unknown errors) |
+| 1 | CBK? | Unknown/unclassified failure (e.g. unknown `support --check` feature ID) |
 | 2 | CBKD | Data quality failure |
-| 3 | CBKE | Encode/validation failure |
+| 3 | CBKE | Encode/validation failure (including structural parse/schema rejections) |
 | 4 | CBKF | Record format/RDW failure |
-| 5 | CBKI | Internal orchestration error |
+| 5 | CBKI | Internal orchestration error (including panics and otherwise unmapped errors) |
 
 Some subcommands document additional command-specific semantics: `verify` reports 3 for validation errors and 2 for fatal I/O/schema errors; `determinism` reports 0 for deterministic, 2 for drift detected, and 3 for codec/usage errors.
-
-> **Note (current behavior):** only the `CBKD`/`CBKE`/`CBKF`/`CBKI` families have a dedicated exit-code mapping. Structural parse/schema rejections in the `CBKP*` and `CBKS*` families (e.g. `CBKP021_ODO_NOT_TAIL`, `CBKP022_NESTED_ODO`, `CBKP023_ODO_REDEFINES`, `CBKS607_RENAME_CROSSES_OCCURS`, `CBKS609_RENAME_OVER_REDEFINES`) currently fall through to exit code **5**, the same code a panic produces. The library API always reports the precise, stable code regardless. This behavior is pinned by `copybook-cli/tests/rejection_exit_codes.rs`; assigning these families a dedicated, non-`Internal` exit code is a potential future stability-contract change.
 
 ## Character Encodings
 

--- a/docs/contracts/stable-surface-contract.json
+++ b/docs/contracts/stable-surface-contract.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
-  "generated_at": "2026-07-11T03:15:43.621899+00:00",
+  "generated_at": "2026-07-25T19:21:28.602743586+00:00",
   "generated_by": "cargo run -p xtask -- docs contracts generate",
-  "source_revision": "efafd101255fd163abf486346e1ae9527bab24a9",
+  "source_revision": "46613ace970ed3fb8ad5ed2a7302a2e65c9f64bd",
   "source_paths": [
     "crates/copybook-cli/src/main.rs",
     "crates/copybook-cli/src/exit_codes.rs",
@@ -147,13 +147,15 @@
       "Data",
       "Encode",
       "Format",
+      "Internal",
       "Ok",
       "Unknown"
     ],
     "tags": [
       "CBKD",
       "CBKE",
-      "CBKF"
+      "CBKF",
+      "CBKI"
     ]
   },
   "jsonl": {

--- a/docs/reference/COBOL_SUPPORT_MATRIX.md
+++ b/docs/reference/COBOL_SUPPORT_MATRIX.md
@@ -1,7 +1,7 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 # COBOL Feature Support Matrix
 
-**Last Updated**: 2026-02-15
+**Last Updated**: 2026-07-25
 **Version**: copybook-rs v0.4.3
 **Canonical Reference**: This document is the authoritative source for COBOL feature support
 
@@ -69,6 +69,7 @@
 | CP500 (International) | ✅ Fully Supported | `prop_codepage_parity_extra.rs`, `decimal_edge_cases.rs::test_zoned_overpunch_by_codepage`, `codepage_evidence_matrix.rs`, `codepage_precedence.rs::cli_decode_cp500_signature` | International variant support |
 | CP1047 (Latinized) | ✅ Fully Supported | `prop_codepage_parity_extra.rs`, `decimal_edge_cases.rs::test_zoned_overpunch_by_codepage`, `codepage_evidence_matrix.rs`, `codepage_precedence.rs::cli_decode_cp1047_signature` | Latin-1 based EBCDIC |
 | CP1140 (Euro) | ✅ Fully Supported | `prop_codepage_parity_extra.rs`, `decimal_edge_cases.rs::test_zoned_overpunch_by_codepage`, `codepage_evidence_matrix.rs::encode_euro_is_specific_to_cp1140`, `codepage_precedence.rs::cli_decode_cp1140_signature` | Euro currency support |
+| CLI codepage handling | ✅ Fully Supported | `cli_args.rs::decode_defaults_codepage_cp037`, `cli_args.rs::invalid_codepage_rejected`, `codepage_precedence.rs::cli_codepage_flag_changes_decoded_character`, `codepage_precedence.rs::cli_explicit_codepage_overrides_default` | `--codepage` default behavior, explicit override semantics, and invalid-codepage rejection |
 | ASCII (supplementary) | ✅ Fully Supported | `binary_roundtrip_fidelity_tests.rs::test_ascii_zoned_roundtrip_byte_identical`, `encode_options_zoned_encoding_tests.rs::test_encode_preserves_ascii_format` | For comparison/testing purposes |
 
 ## Edited PIC Clauses
@@ -301,12 +302,12 @@ copybook determinism decode --output json --format fixed --codepage cp037 schema
 | **Total** | | **63** |
 
 ### Parse Errors (CBKP*)
-- `CBKP001_SYNTAX`: Copybook syntax errors — `comprehensive_parser_tests.rs::test_error_context_with_line_numbers`
-- `CBKP011_UNSUPPORTED_CLAUSE`: Unsupported COBOL clause — `comprehensive_parser_tests.rs::test_sign_clause_as_edited_pic_normative`
+- `CBKP001_SYNTAX`: Copybook syntax errors — `comprehensive_parser_tests.rs::test_error_context_with_line_numbers`, `comprehensive_parser_tests.rs::test_sign_clause_as_edited_pic_normative`
+- `CBKP011_UNSUPPORTED_CLAUSE`: Unsupported COBOL clause (feature-disabled path) — `feature_gating_disabled_tests.rs::test_disabled_comp_features_reject_comp1_comp2_clauses`
 - `CBKP021_ODO_NOT_TAIL`: ODO not at tail — `golden_fixtures_ac4_sibling_after_odo_fail.rs::test_ac4_basic_storage_after_odo_fail`
 - `CBKP022_NESTED_ODO`: Nested ODO rejected — `nested_odo_negative_tests.rs::test_o5_nested_odo_basic_rejection`
 - `CBKP023_ODO_REDEFINES`: ODO over REDEFINES rejected — `nested_odo_negative_tests.rs::test_o6_odo_over_redefines_basic`
-- `CBKP051_UNSUPPORTED_EDITED_PIC`: Unsupported edited PIC token (Space `B` insertion only; all other patterns supported)
+- `CBKP051_UNSUPPORTED_EDITED_PIC`: Unsupported edited PIC token (Space `B` insertion only; all other patterns supported) — `e2e_error_codes.rs::cbkp051_unsupported_edited_pic`
 
 ### Schema Validation Errors (CBKS*)
 - `CBKS121_COUNTER_NOT_FOUND`: ODO counter not found — `odo_comprehensive.rs::test_odo_driver_in_redefines_rejection`
@@ -379,9 +380,9 @@ See `docs/design/NESTED_ODO_BEHAVIOR.md` (Issue #164) for complete design specif
 | O1  | Simple tail ODO                         | ✅     | -                     | `golden_fixtures_ac3_child_inside_odo.rs::test_ac3_basic_child_inside_odo_pass` |
 | O2  | Tail ODO with DYNAMIC (AC1/AC2)         | ✅     | -                     | `odo_comprehensive.rs` (21 tests), `odo_counter_types.rs`        |
 | O3  | Group-with-ODO tail (AC3)               | ✅     | -                     | `golden_fixtures_ac3_child_inside_odo.rs::test_ac3_nested_groups_inside_odo_pass` |
-| O4  | ODO with sibling after (AC4)            | 🚫     | CBKP021_ODO_NOT_TAIL  | `golden_fixtures_ac4_sibling_after_odo_fail.rs` (8 negative tests); `rejection_evidence_matrix.rs::parse_rejections_map_to_stable_codes` (`O4`)|
-| O5  | Nested ODO (ODO inside ODO)             | 🚫     | CBKP022_NESTED_ODO    | Phase N1: reject; Phase N2: review if user demand emerges; `rejection_evidence_matrix.rs::parse_rejections_map_to_stable_codes` (`O5`) |
-| O6  | ODO over REDEFINES                      | 🚫     | CBKP023_ODO_REDEFINES | Phase N1: reject; Phase N3: dedicated design required; `rejection_evidence_matrix.rs::parse_rejections_map_to_stable_codes` (`O6`) |
+| O4  | ODO with sibling after (AC4)            | 🚫     | CBKP021_ODO_NOT_TAIL  | `golden_fixtures_ac4_sibling_after_odo_fail.rs` (`test_ac4_basic_storage_after_odo_fail`, 8 cases); `nested_odo_negative_tests.rs::test_regression_o4_odo_with_sibling_still_fails` |
+| O5  | Nested ODO (ODO inside ODO)             | 🚫     | CBKP022_NESTED_ODO    | Rejected by design; `nested_odo_negative_tests.rs::test_o5_nested_odo_basic_rejection` |
+| O6  | ODO over REDEFINES                      | 🚫     | CBKP023_ODO_REDEFINES | Rejected by design; `nested_odo_negative_tests.rs::test_o6_odo_over_redefines_basic` |
 | O7  | ODO over RENAMES span (R4/R5 scenarios) | 🚫     | Out of scope          | RENAMES R4-R6 explicitly deferred (see RENAMES section)          |
 
 **Evidence:**
@@ -465,8 +466,8 @@ See `docs/design/RENAMES_NESTED_GROUPS.md` for complete design specification.
 | `renames-same-scope-group`  | 66-level – group alias       | ✅      | Parser + resolver (R2) with correct tree building; codec decode ✅ |
 | `renames-nested-group`      | 66-level – nested group      | ✅      | Parser + resolver (R3) with recursive target lookup; codec decode ✅ |
 | `renames-codec-projection`  | 66-level – codec projection  | ✅      | Schema provides `find_field_or_alias` and `resolve_alias_to_target` for codec integration |
-| `renames-redefines`         | 66-level – over REDEFINES    | 🚫      | Out of scope; `CBKS609_RENAME_OVER_REDEFINES`; `rejection_evidence_matrix.rs::parse_rejections_map_to_stable_codes` (`renames-redefines`) |
-| `renames-occurs`            | 66-level – over OCCURS       | 🚫      | Out of scope; `CBKS607_RENAME_CROSSES_OCCURS`; `rejection_evidence_matrix.rs::parse_rejections_map_to_stable_codes` (`renames-occurs`) |
+| `renames-redefines`         | 66-level – over REDEFINES    | 🚫      | Out of scope; `CBKS609_RENAME_OVER_REDEFINES`; `renames_r4_r6_bdd_tests.rs::test_r4_renames_over_redefines_rejected_when_flag_disabled` |
+| `renames-occurs`            | 66-level – over OCCURS       | 🚫      | Out of scope; `CBKS607_RENAME_CROSSES_OCCURS`; `renames_r4_r6_bdd_tests.rs::test_r5_renames_over_occurs_rejected_when_flag_disabled` |
 
 **Evidence:**
 

--- a/docs/reference/ERROR_CODES.md
+++ b/docs/reference/ERROR_CODES.md
@@ -568,13 +568,13 @@ Value: 12345 exceeds 3-digit capacity
 #### CBKE515_STRING_LENGTH_VIOLATION
 **Description**: String value exceeds the field's declared size during encoding
 **Severity**: Fatal
-**Context**: Field path, field size, string length
+**Context**: Field path, field size, encoded byte length
 **Resolution**: Truncate the string or widen the PIC X(n) field size
 
-```
+```text
 Error: CBKE515_STRING_LENGTH_VIOLATION
 Field: ROOT.CUSTOMER.NAME (PIC X(20))
-String length: 27 exceeds field size 20
+Encoded byte length: 27 exceeds field capacity 20
 ```
 
 #### CBKE521_ARRAY_LEN_OOB


### PR DESCRIPTION
## Summary

This PR resolves three open issues:

- issue 600: CLI collapses CBKP/CBKS structural parse/schema rejections to exit code 5
- issue 601: encode capacity check for PIC X was measured in UTF-8 bytes instead of codepage output bytes
- issue 605: stable-surface contract omitted Internal/CBKI in exit-code surface

## Changes

### Issue 600
- Map CBKP* and CBKS* family prefixes to ExitCode Encode in copybook-cli exit-code mapping.
- Add assertion updates in CLI tests so structural parse/schema rejections map to exit code 3.
- Update CLI reference wording for structural parse/schema rejections.

### Issue 601
- In codec encode paths, check PIC X field capacity by encoded byte length:
  - crates/copybook-codec/src/json.rs
  - crates/copybook-codec/src/lib_api.rs
- Update tests and docs:
  - crates/copybook-codec/tests/codepage_evidence_matrix.rs
  - crates/copybook-codec/tests/error_code_tests.rs
  - docs/reference/ERROR_CODES.md

### Issue 605
- Regenerate docs/contracts/stable-surface-contract.json so ExitCode.variants include Internal and ExitCode tags include CBKI.
- Refresh COBOL support matrix evidence anchors and Last Updated timestamp.

## Verification

- cargo test -p copybook-cli --test exit_code_mapping --test rejection_exit_codes -- --nocapture
- cargo test -p copybook-codec --test codepage_evidence_matrix -- --nocapture
- cargo test -p copybook-codec --test error_code_tests -- --nocapture
- cargo run -p xtask -- docs freeze contracts

Closes: #600, #601, #605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alphanumeric (PIC X) encoding to validate against **EBCDIC/ASCII-encoded byte length**, then copy/pad correctly across supported code pages.
  * Structural parse/schema rejections in the `CBKP*` / `CBKS*` families now map to **exit code 3** (CBKE), and tests verify the associated rejection code is shown on stderr.
  * Empty fixed-format input can now decode successfully when **LRECL is determined from the copybook**.

* **Documentation**
  * Updated CLI and error-code docs to reflect encoded-byte-length validation and the corrected exit-code mapping.
  * Refreshed reference metadata and the COBOL support matrix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->