### PR TITLE
test(codec): gate debug-build throughput floors behind opt-in env var

### DIFF
--- a/crates/copybook-codec/tests/cobol_fixture_zoned_encoding_tests.rs
+++ b/crates/copybook-codec/tests/cobol_fixture_zoned_encoding_tests.rs
@@ -504,12 +504,16 @@ fn test_enterprise_scale_fixture_performance() -> Result<(), Box<dyn Error>> {
         enterprise_data.len() / single_record_data.len()
     );
 
-    // Verify reasonable enterprise performance - relaxed threshold for safety
-    // With panic elimination optimizations, performance may trade some speed for safety
-    assert!(
-        throughput_mb_per_s > 0.5,
-        "Enterprise fixture processing should be performant: {throughput_mb_per_s:.2} MB/s"
-    );
+    // Throughput is informational here: a debug-build assertion on shared CI
+    // runners is flaky (observed 0.30-0.43 MB/s on macos-latest) and duplicates
+    // the canonical bench gate (`bench-report gate`, docs/PERFORMANCE_GOVERNANCE.md).
+    // Set COPYBOOK_TEST_PERF_ASSERT=1 to enforce the floor locally.
+    if std::env::var_os("COPYBOOK_TEST_PERF_ASSERT").is_some() {
+        assert!(
+            throughput_mb_per_s > 0.5,
+            "Enterprise fixture processing should be performant: {throughput_mb_per_s:.2} MB/s"
+        );
+    }
 
     // Verify output integrity
     let output_str = String::from_utf8(output)?;

--- a/crates/copybook-codec/tests/enterprise_mainframe_production_scenarios.rs
+++ b/crates/copybook-codec/tests/enterprise_mainframe_production_scenarios.rs
@@ -34,6 +34,14 @@ use copybook_core::parse_copybook;
 use std::io::Cursor;
 use std::time::Instant;
 
+/// Absolute-throughput assertions in debug builds flake on shared CI runners,
+/// and throughput gating belongs to the canonical bench gate
+/// (`bench-report gate`, docs/PERFORMANCE_GOVERNANCE.md). Measurements are
+/// always printed; floors are enforced only when `COPYBOOK_TEST_PERF_ASSERT=1`.
+fn perf_assert_enabled() -> bool {
+    std::env::var_os("COPYBOOK_TEST_PERF_ASSERT").is_some()
+}
+
 /// Enterprise Banking Transaction Processing Scenario
 ///
 /// Simulates high-volume daily transaction processing with complex record structures
@@ -169,12 +177,14 @@ fn test_enterprise_banking_transaction_processing() -> Result<(), Box<dyn std::e
     // Threshold lowered on Windows to account for shared CI runner variance while
     // still failing major throughput regressions.
     let minimum_banking_throughput_mib_per_s = if cfg!(windows) { 0.40 } else { 0.45 };
-    assert!(
-        throughput_mb_per_s > minimum_banking_throughput_mib_per_s,
-        "Banking transaction processing should exceed {:.2} MiB/s: {:.2} MiB/s",
-        minimum_banking_throughput_mib_per_s,
-        throughput_mb_per_s
-    );
+    if perf_assert_enabled() {
+        assert!(
+            throughput_mb_per_s > minimum_banking_throughput_mib_per_s,
+            "Banking transaction processing should exceed {:.2} MiB/s: {:.2} MiB/s",
+            minimum_banking_throughput_mib_per_s,
+            throughput_mb_per_s
+        );
+    }
 
     // Memory usage validation
     assert!(
@@ -317,11 +327,13 @@ fn test_enterprise_insurance_claims_processing() -> Result<(), Box<dyn std::erro
         summary.records_with_errors, 0,
         "Should have no processing failures"
     );
-    assert!(
-        throughput_records_per_s > 50.0,
-        "Insurance processing should exceed 50 records/s: {:.1} records/s",
-        throughput_records_per_s
-    );
+    if perf_assert_enabled() {
+        assert!(
+            throughput_records_per_s > 50.0,
+            "Insurance processing should exceed 50 records/s: {:.1} records/s",
+            throughput_records_per_s
+        );
+    }
 
     Ok(())
 }
@@ -469,19 +481,20 @@ fn test_enterprise_retail_pos_processing() -> Result<(), Box<dyn std::error::Err
         summary.records_with_errors, 0,
         "Should have no processing failures"
     );
-    // Threshold lowered to account for shared CI runner variance while
+    // Thresholds lowered to account for shared CI runner variance while
     // still catching major throughput regressions.
-    assert!(
-        throughput_records_per_s > 3000.0,
-        "POS processing should exceed 3000 records/s: {:.0} records/s",
-        throughput_records_per_s
-    );
-    // Threshold lowered to 0.25 MiB/s to account for debug-build and shared CI runner variance
-    assert!(
-        throughput_mb_per_s > 0.25,
-        "POS throughput should exceed 0.25 MiB/s: {:.2} MiB/s",
-        throughput_mb_per_s
-    );
+    if perf_assert_enabled() {
+        assert!(
+            throughput_records_per_s > 3000.0,
+            "POS processing should exceed 3000 records/s: {:.0} records/s",
+            throughput_records_per_s
+        );
+        assert!(
+            throughput_mb_per_s > 0.25,
+            "POS throughput should exceed 0.25 MiB/s: {:.2} MiB/s",
+            throughput_mb_per_s
+        );
+    }
 
     Ok(())
 }
@@ -633,11 +646,13 @@ fn test_enterprise_manufacturing_quality_control() -> Result<(), Box<dyn std::er
         summary.records_with_errors, 0,
         "Should have no processing failures"
     );
-    assert!(
-        throughput_records_per_s > 100.0,
-        "QC processing should exceed 100 records/s: {:.1} records/s",
-        throughput_records_per_s
-    );
+    if perf_assert_enabled() {
+        assert!(
+            throughput_records_per_s > 100.0,
+            "QC processing should exceed 100 records/s: {:.1} records/s",
+            throughput_records_per_s
+        );
+    }
 
     // Validate output contains precision values
     let output_str = String::from_utf8_lossy(&output);

--- a/crates/copybook-codec/tests/performance_hardening_validation.rs
+++ b/crates/copybook-codec/tests/performance_hardening_validation.rs
@@ -33,6 +33,14 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Instant;
 
+/// Absolute-throughput assertions in debug builds flake on shared CI runners,
+/// and throughput gating belongs to the canonical bench gate
+/// (`bench-report gate`, docs/PERFORMANCE_GOVERNANCE.md). Measurements are
+/// always printed; floors are enforced only when `COPYBOOK_TEST_PERF_ASSERT=1`.
+fn perf_assert_enabled() -> bool {
+    std::env::var_os("COPYBOOK_TEST_PERF_ASSERT").is_some()
+}
+
 /// Test memory usage patterns with large datasets
 #[test]
 fn test_memory_usage_large_datasets() -> Result<(), Box<dyn std::error::Error>> {
@@ -106,11 +114,13 @@ fn test_memory_usage_large_datasets() -> Result<(), Box<dyn std::error::Error>> 
         summary.records_processed as usize, num_records,
         "Should process all records"
     );
-    assert!(
-        throughput_mb_s > 1.0,
-        "Memory-efficient processing should maintain reasonable throughput: {:.2} MB/s",
-        throughput_mb_s
-    );
+    if perf_assert_enabled() {
+        assert!(
+            throughput_mb_s > 1.0,
+            "Memory-efficient processing should maintain reasonable throughput: {:.2} MB/s",
+            throughput_mb_s
+        );
+    }
 
     // Memory usage validation (output size should be reasonable)
     let output_mb = output.len() as f64 / (1024.0 * 1024.0);
@@ -216,11 +226,13 @@ fn test_performance_regression_detection() -> Result<(), Box<dyn std::error::Err
     );
 
     let throughput_records_s = num_records as f64 / avg_duration.as_secs_f64();
-    assert!(
-        throughput_records_s > 1000.0,
-        "Average throughput should be reasonable: {:.0} records/s",
-        throughput_records_s
-    );
+    if perf_assert_enabled() {
+        assert!(
+            throughput_records_s > 1000.0,
+            "Average throughput should be reasonable: {:.0} records/s",
+            throughput_records_s
+        );
+    }
 
     Ok(())
 }
@@ -301,23 +313,25 @@ fn test_throughput_load_patterns() -> Result<(), Box<dyn std::error::Error>> {
         );
 
         // Validate load-specific performance
-        match pattern_name {
-            "Small Burst" => assert!(
-                throughput_records_s > 2000.0,
-                "Small burst should have high record rate: {:.0} records/s",
-                throughput_records_s
-            ),
-            "Medium Sustained" => assert!(
-                throughput_mb_s > 0.6,
-                "Medium sustained should have good throughput: {:.2} MB/s",
-                throughput_mb_s
-            ),
-            "Large Batch" => assert!(
-                throughput_mb_s > 0.75,
-                "Large batch should leverage parallelism: {:.2} MB/s",
-                throughput_mb_s
-            ),
-            _ => {}
+        if perf_assert_enabled() {
+            match pattern_name {
+                "Small Burst" => assert!(
+                    throughput_records_s > 2000.0,
+                    "Small burst should have high record rate: {:.0} records/s",
+                    throughput_records_s
+                ),
+                "Medium Sustained" => assert!(
+                    throughput_mb_s > 0.6,
+                    "Medium sustained should have good throughput: {:.2} MB/s",
+                    throughput_mb_s
+                ),
+                "Large Batch" => assert!(
+                    throughput_mb_s > 0.75,
+                    "Large batch should leverage parallelism: {:.2} MB/s",
+                    throughput_mb_s
+                ),
+                _ => {}
+            }
         }
 
         assert_eq!(
@@ -575,10 +589,12 @@ fn test_error_handling_performance_impact() -> Result<(), Box<dyn std::error::Er
         1.0 / performance_impact
     );
 
-    assert!(
-        mixed_throughput > 1000.0,
-        "Mixed processing should maintain reasonable throughput: {mixed_throughput:.0} records/s"
-    );
+    if perf_assert_enabled() {
+        assert!(
+            mixed_throughput > 1000.0,
+            "Mixed processing should maintain reasonable throughput: {mixed_throughput:.0} records/s"
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Several codec integration tests assert absolute throughput floors in **debug builds**. On shared CI runners these flake (0.30–0.43 MB/s observed on `macos-latest`), and they are currently failing main CI (e.g. run 30328761664) and blocking PRs #607 and #608. Some thresholds had already been lowered repeatedly to chase runner variance — a losing game.

Per `docs/PERFORMANCE_GOVERNANCE.md`, throughput gating belongs to the canonical bench gate (`bench-report gate` with CI-grounded floors), not to debug-mode unit tests.

## Changes

All absolute-throughput floors are now enforced only when `COPYBOOK_TEST_PERF_ASSERT=1` is set; measurements are still always printed:

- `cobol_fixture_zoned_encoding_tests.rs` — enterprise-scale fixture floor (> 0.5 MB/s)
- `performance_hardening_validation.rs` — memory, regression, load-pattern, and error-impact floors
- `enterprise_mainframe_production_scenarios.rs` — banking/insurance/POS/QC scenario floors

Unchanged: functional assertions (record counts, error counts, output integrity) and **relative** performance checks (variance ratio, thread scaling efficiency, error-impact ratio) still run unconditionally.

## Verification

- `cargo test -p copybook-codec --test cobol_fixture_zoned_encoding_tests --test performance_hardening_validation --test enterprise_mainframe_production_scenarios` — all pass
- Same with `COPYBOOK_TEST_PERF_ASSERT=1` — all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved performance test stability by making throughput checks optional.
  * Performance measurements continue to be collected and reported during test runs.
  * Strict throughput thresholds can be enabled explicitly when performance validation is required.
  * Reduced the risk of intermittent test failures caused by temporary or environment-specific performance variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->