### PR TITLE
ci(perf): pin bench builds to x86-64-v3 instead of target-cpu=native

### DIFF
--- a/.github/workflows/enterprise-perf.yml
+++ b/.github/workflows/enterprise-perf.yml
@@ -44,32 +44,32 @@ jobs:
 
       - name: Run baseline benchmarks
         run: |
-          RUSTFLAGS="-C target-cpu=native" PERF=1 \
+          RUSTFLAGS="-C target-cpu=x86-64-v3" PERF=1 \
             cargo bench -p copybook-bench -- enterprise_baseline --quiet
 
       - name: Run audit benchmarks
         run: |
-          RUSTFLAGS="-C target-cpu=native" PERF=1 \
+          RUSTFLAGS="-C target-cpu=x86-64-v3" PERF=1 \
             cargo bench -p copybook-bench -- enterprise_audit --quiet
 
       - name: Run compliance benchmarks
         run: |
-          RUSTFLAGS="-C target-cpu=native" PERF=1 \
+          RUSTFLAGS="-C target-cpu=x86-64-v3" PERF=1 \
             cargo bench -p copybook-bench -- enterprise_compliance --quiet
 
       - name: Run security benchmarks
         run: |
-          RUSTFLAGS="-C target-cpu=native" PERF=1 \
+          RUSTFLAGS="-C target-cpu=x86-64-v3" PERF=1 \
             cargo bench -p copybook-bench -- enterprise_security --quiet
 
       - name: Run combined benchmarks
         run: |
-          RUSTFLAGS="-C target-cpu=native" PERF=1 \
+          RUSTFLAGS="-C target-cpu=x86-64-v3" PERF=1 \
             cargo bench -p copybook-bench -- enterprise_combined --quiet
 
       - name: Run enterprise SLO benchmarks
         run: |
-          RUSTFLAGS="-C target-cpu=native" PERF=1 \
+          RUSTFLAGS="-C target-cpu=x86-64-v3" PERF=1 \
             cargo bench -p copybook-bench -- enterprise_slo_validation --quiet
 
       - name: Calculate enterprise overhead

--- a/.github/workflows/perf-validation.yml
+++ b/.github/workflows/perf-validation.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           # Use enhanced benchmark script
           chmod +x scripts/bench-enhanced.sh
-          BUILD_PROFILE=release TARGET_CPU=native ./scripts/bench-enhanced.sh
+          BUILD_PROFILE=release ./scripts/bench-enhanced.sh
 
       - name: Check for performance receipt
         id: check-receipt

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -90,7 +90,9 @@ jobs:
 
       - name: Run enterprise benches
         run: |
-          RUSTFLAGS="-C target-cpu=native" PERF=1 \
+          # x86-64-v3 (not native): cached artifacts must be portable across
+          # heterogeneous runner CPUs; native-compiled cache hits SIGILL.
+          RUSTFLAGS="-C target-cpu=x86-64-v3" PERF=1 \
             cargo bench -p copybook-bench -- "enterprise_(baseline|audit|compliance|security|combined|slo)" --quiet
 
       - name: Annotate perf with host info

--- a/scripts/bench-enhanced.sh
+++ b/scripts/bench-enhanced.sh
@@ -7,9 +7,11 @@ set -euo pipefail
 # Allow callers to widen scope by exporting BENCH_FILTER.
 BENCH_FILTER="${BENCH_FILTER:-slo_validation}"
 
-# Capture build profile and target CPU flags
+# Capture build profile and target CPU flags. Default is x86-64-v3 (not
+# native): cached CI artifacts compiled for one runner CPU SIGILL when
+# restored on a different CPU generation; override via TARGET_CPU locally.
 BUILD_PROFILE="${BUILD_PROFILE:-release}"
-TARGET_CPU="${TARGET_CPU:-native}"
+TARGET_CPU="${TARGET_CPU:-x86-64-v3}"
 RUSTFLAGS="-C target-cpu=${TARGET_CPU}" PERF=1 \
   cargo bench -p copybook-bench -- "${BENCH_FILTER}" --quiet
 

--- a/scripts/bench.bat
+++ b/scripts/bench.bat
@@ -1,7 +1,8 @@
 @echo off
 setlocal enabledelayedexpansion
 set PERF=1
-set RUSTFLAGS=-C target-cpu=native
+REM Pin x86-64-v3 (not native) so cached artifacts stay portable across runner CPUs
+set RUSTFLAGS=-C target-cpu=x86-64-v3
 if "%BENCH_FILTER%"=="" (
   set "BENCH_FILTER=slo_validation"
 )

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -6,7 +6,11 @@ set -euo pipefail
 # tripwire: no-op change to trigger perf workflow without affecting behavior.
 # Allow callers to widen scope by exporting BENCH_FILTER.
 BENCH_FILTER="${BENCH_FILTER:-slo_validation}"
-RUSTFLAGS="-C target-cpu=native" PERF=1 \
+# Pin x86-64-v3 instead of native: CI restores rust-cache artifacts across
+# heterogeneous runner CPUs, and native-compiled cached proc macros/binaries
+# SIGILL when executed on a different CPU generation. v3 (AVX2) is supported
+# by all GitHub-hosted runners and keeps receipts cache-safe and comparable.
+RUSTFLAGS="-C target-cpu=x86-64-v3" PERF=1 \
   cargo bench -p copybook-bench -- "${BENCH_FILTER}" --quiet
 
 python3 <<'PY'

--- a/scripts/ci/bench.sh
+++ b/scripts/ci/bench.sh
@@ -5,7 +5,9 @@ set -euo pipefail
 echo "==> Running benchmark suite"
 # Bench receipts: small JSON artifact; no HTML, no lcov
 
-export RUSTFLAGS="-C target-cpu=native"
+# Pin x86-64-v3 instead of native: cached artifacts compiled for one runner
+# CPU SIGILL when restored and executed on a different CPU generation.
+export RUSTFLAGS="-C target-cpu=x86-64-v3"
 export PERF=1
 
 # Ensure target directory exists


### PR DESCRIPTION
## Summary

Since this morning's GitHub runner change, the perf workflow's **Run benches (JSON)** step fails with `rustc interrupted by SIGILL` while compiling `copybook-lexer` (e.g. runs 30354091518, 30355056462, 30355854082, and 30353836817 on the #607 branch). Main's nightly run at 03:59 UTC still passed; every PR run after ~11:00 UTC fails.

## Root cause

The bench steps set `RUSTFLAGS="-C target-cpu=native"`, and `Swatinem/rust-cache` (saved from main, restored by PRs) carries proc-macro dylibs and bench artifacts compiled for one CPU generation. GitHub's `ubuntu-latest` pool is heterogeneous; when a restored `native`-compiled proc macro (e.g. `logos_derive`, loaded by `rustc` while compiling `copybook-lexer`) executes on a different CPU generation, it hits an illegal instruction. The metadata hash of the failing artifact is identical across runs and branches, confirming a stale cache artifact rather than a source problem.

## Changes

Pin `-C target-cpu=x86-64-v3` (AVX2; supported by every GitHub-hosted runner) for the CI bench invocations so cached artifacts are portable across the runner pool and receipts stay comparable run-to-run:

- `scripts/bench.sh` (used by perf.yml, perf-gate.yml, soak.yml)
- `scripts/ci/bench.sh` (ci-bench.yml, pr-bench-comment.yml)
- `scripts/bench-enhanced.sh` — default `TARGET_CPU` (still overridable locally)
- `scripts/bench.bat`
- enterprise bench steps in `perf.yml` and `enterprise-perf.yml`

Out of scope (deliberately): `justfile` local-dev recipes and the single-machine `Dockerfile` keep `native`.

## Verification

- `RUSTFLAGS="-C target-cpu=x86-64-v3" PERF=1 cargo bench -p copybook-bench --no-run` — compiles
- `bash -n` on edited scripts; YAML parse of edited workflows
- This PR's own perf workflow run is the end-to-end proof