### PR TITLE
ci(perf): align remaining bench builds to x86-64-v3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,9 @@ RUN git config --global user.email "bench@copybook-rs.container" && \
 # Environment variables for benchmark configuration
 ENV BENCH_FILTER="slo_validation"
 ENV PERF=1
-ENV RUSTFLAGS="-C target-cpu=native"
+# Match CI bench builds (x86-64-v3, see scripts/bench.sh); native-compiled
+# image artifacts SIGILL when the container runs on a different CPU generation.
+ENV RUSTFLAGS="-C target-cpu=x86-64-v3"
 
 # Create output directory
 RUN mkdir -p /workspace/output

--- a/docs/PERFORMANCE_RECEIPT_REFERENCE.md
+++ b/docs/PERFORMANCE_RECEIPT_REFERENCE.md
@@ -18,7 +18,7 @@ This is the single source of truth for all performance metrics in copybook-rs. A
   "timestamp": "2025-12-16T17:05:22Z",
   "commit": "85b9f07",
   "build_profile": "release",
-  "target_cpu": "native",
+  "target_cpu": "x86-64-v3",
   "environment": {
     "os": "Linux",
     "kernel": "6.6.87.2-microsoft-standard-WSL2",

--- a/docs/exploration-benchmark-infrastructure.md
+++ b/docs/exploration-benchmark-infrastructure.md
@@ -102,7 +102,7 @@ diagnostics = []              # AC5: Infrastructure overhead (opt-in)
 **Execution**:
 ```bash
 BENCH_FILTER="${BENCH_FILTER:-slo_validation}" \
-RUSTFLAGS="-C target-cpu=native" PERF=1 \
+RUSTFLAGS="-C target-cpu=x86-64-v3" PERF=1 \
   cargo bench -p copybook-bench -- "${BENCH_FILTER}" --quiet
 ```
 
@@ -446,7 +446,7 @@ Max RSS: ≤256 MiB (current: 4 MiB)
 **Environment**:
 ```bash
 BENCH_FILTER="${BENCH_FILTER:-slo_validation}"
-RUSTFLAGS="-C target-cpu=native" PERF=1 cargo bench -p copybook-bench
+RUSTFLAGS="-C target-cpu=x86-64-v3" PERF=1 cargo bench -p copybook-bench
 ```
 
 #### scripts/perf-annotate-host.sh

--- a/docs/perf/CONTAINER_IMPLEMENTATION.md
+++ b/docs/perf/CONTAINER_IMPLEMENTATION.md
@@ -34,7 +34,7 @@ This document describes the implementation of the copybook-rs benchmark containe
 **Environment Variables**:
 - `BENCH_FILTER="slo_validation"` - Default to SLO benchmarks
 - `PERF=1` - Enable performance mode
-- `RUSTFLAGS="-C target-cpu=native"` - Optimize for host CPU
+- `RUSTFLAGS="-C target-cpu=x86-64-v3"` - Portable optimization level matching CI (native SIGILLs when image artifacts run on a different CPU generation)
 
 **Entry Point**: `/usr/local/bin/bench-entrypoint.sh`
 - Runs `scripts/bench.sh`
@@ -255,7 +255,7 @@ jq -r '"DISPLAY: \(.display_mibps) MiB/s\nCOMP-3: \(.comp3_mibps) MiB/s"' output
 
 ### 5. No ARM Support Yet
 
-**Limitation**: Dockerfile uses `target-cpu=native`, untested on ARM
+**Limitation**: Dockerfile pins `target-cpu=x86-64-v3` (x86-only), untested on ARM
 
 **Impact**: May not work on ARM-based systems (Apple Silicon, AWS Graviton)
 

--- a/docs/specifications/cicd-integration.md
+++ b/docs/specifications/cicd-integration.md
@@ -226,7 +226,7 @@ jobs:
 env:
   RUST_BACKTRACE: 1
   CARGO_INCREMENTAL: 0
-  RUSTFLAGS: "-C target-cpu=native"
+  RUSTFLAGS: "-C target-cpu=x86-64-v3"
   PERF: 1
 ```
 

--- a/justfile
+++ b/justfile
@@ -133,18 +133,20 @@ perf:
     @just bench-json
 
 # Run baseline benchmarks only (no enterprise features)
+# x86-64-v3 matches CI bench builds (#610); native risks SIGILL when cached
+# artifacts move between CPU generations.
 bench-baseline:
-    BENCH_FILTER=enterprise_baseline RUSTFLAGS="-C target-cpu=native" PERF=1 \
+    BENCH_FILTER=enterprise_baseline RUSTFLAGS="-C target-cpu=x86-64-v3" PERF=1 \
       cargo bench -p copybook-bench -- enterprise_baseline --quiet
 
 # Run enterprise benchmarks only (audit, compliance, security, combined)
 bench-enterprise:
-    RUSTFLAGS="-C target-cpu=native" PERF=1 \
+    RUSTFLAGS="-C target-cpu=x86-64-v3" PERF=1 \
       cargo bench -p copybook-bench -- "enterprise_(audit|compliance|security|combined)" --quiet
 
 # Run all enterprise SLO validation benchmarks
 bench-enterprise-slo:
-    RUSTFLAGS="-C target-cpu=native" PERF=1 \
+    RUSTFLAGS="-C target-cpu=x86-64-v3" PERF=1 \
       cargo bench -p copybook-bench -- enterprise_slo_validation --quiet
 
 # Compare baseline vs enterprise performance

--- a/tools/copybook-bench/BASELINE_METHODOLOGY.md
+++ b/tools/copybook-bench/BASELINE_METHODOLOGY.md
@@ -353,7 +353,7 @@ The full receipt is committed at
 
 ```bash
 # 1. Throughput (2+ runs for run-to-run variance)
-RUSTFLAGS="-C target-cpu=native" PERF=1 cargo bench -p copybook-bench -- slo_validation --quiet
+RUSTFLAGS="-C target-cpu=x86-64-v3" PERF=1 cargo bench -p copybook-bench -- slo_validation --quiet
 #    Read target/criterion/slo_validation/*/new/estimates.json for mean + confidence interval.
 
 # 2. Peak RSS (getrusage on a real decode of a generated mixed workload)

--- a/tools/copybook-bench/src/regression/detector.rs
+++ b/tools/copybook-bench/src/regression/detector.rs
@@ -157,7 +157,8 @@ impl PerformanceRegressionDetector {
                     OptimizationLevel::Release
                 },
                 debug_info: cfg!(debug_assertions),
-                target_cpu: std::env::var("TARGET_CPU").unwrap_or_else(|_| "native".to_string()),
+                target_cpu: std::env::var("TARGET_CPU")
+                    .unwrap_or_else(|_| "x86-64-v3".to_string()),
                 features_enabled: Vec::new(),
             },
         })

--- a/tools/copybook-bench/src/regression/detector.rs
+++ b/tools/copybook-bench/src/regression/detector.rs
@@ -157,8 +157,7 @@ impl PerformanceRegressionDetector {
                     OptimizationLevel::Release
                 },
                 debug_info: cfg!(debug_assertions),
-                target_cpu: std::env::var("TARGET_CPU")
-                    .unwrap_or_else(|_| "x86-64-v3".to_string()),
+                target_cpu: std::env::var("TARGET_CPU").unwrap_or_else(|_| "x86-64-v3".to_string()),
                 features_enabled: Vec::new(),
             },
         })


### PR DESCRIPTION
## Summary

Follow-up to #610: the justfile bench recipes, the bench `Dockerfile`, and the `copybook-bench` environment-detector fallback still defaulted to `-C target-cpu=native`. That leaves two problems: image artifacts compiled `native` SIGILL when the container runs on a different CPU generation, and local/container receipts aren't comparable to CI receipts (which are v3 since #610).

## Changes

- `justfile` bench recipes (`bench-baseline`, `bench-enterprise`, `bench-enterprise-slo`) → `x86-64-v3`
- `Dockerfile` `ENV RUSTFLAGS` → `x86-64-v3` (and `scripts/bench.sh` already pins it since #610)
- `tools/copybook-bench` detector fallback label → `x86-64-v3` (still `TARGET_CPU`-overridable)
- Docs (`BASELINE_METHODOLOGY.md`, `CONTAINER_IMPLEMENTATION.md`, `cicd-integration.md`, `exploration-benchmark-infrastructure.md`, `PERFORMANCE_RECEIPT_REFERENCE.md`) updated to match

Historical receipts (`scripts/bench/perf-linux-native.json`) and test fixtures keep their recorded values.

## Verification

- `cargo check -p copybook-bench` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Standardized benchmark builds on the portable `x86-64-v3` CPU target.
  * Improved consistency between local, containerized, and CI benchmark environments.
  * Reduced the risk of illegal-instruction failures across different CPU generations.

* **Documentation**
  * Updated performance receipts, benchmark instructions, and CI/CD guidance to reflect the fixed CPU target.
  * Clarified that the configuration is x86-only and untested on ARM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->