### PR TITLE
chore(release): prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-07-28
+
 ### Added
 
 - **ci**: Add blocking performance regression gate (`perf-gate.yml`) enforcing absolute floors (DISPLAY ≥80, COMP-3 ≥8 MiB/s) and >5% relative regression vs committed baseline; ships `bench-report gate` subcommand, `scripts/bench/baseline.json`, and canonical SLO constants in `copybook-bench::slo`. COMP-3 floor is CI-grounded (12–14 MiB/s observed on `ubuntu-latest`; throughput decreases with larger payloads, so 8 MiB/s gives ~35% headroom).
@@ -28,6 +30,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **docs**: Add explicit pre-v1 migration/retention decision notes for deprecated Rust, CLI/schema/output surfaces in `docs/reports/deprecation-audit.json` and `docs/reports/surface-deprecation-audit.json`
 
 ### Fixed
+
+- **cli**: Map CBKP*/CBKS* structural parse/schema rejections to exit code 3 (CBKE) instead of 5 (#600)
+- **codec**: Check PIC X encode capacity in codepage output bytes instead of UTF-8 bytes, fixing false `CBKE515` rejections for non-ASCII input (#601)
+- **contracts**: Include `Internal`/CBKI in the stable-surface exit-code contract (#605)
+- **docs**: Correct panic exit-status mapping in the CLI reference (panics exit 5/CBKI, not 1/CBK?)
+- **test**: Gate debug-build throughput floor assertions behind `COPYBOOK_TEST_PERF_ASSERT=1`; they flaked on shared CI runners and blocked main (perf gating remains with the canonical bench gate)
+- **ci**: Pin bench builds to `x86-64-v3` instead of `target-cpu=native`; cached native-compiled artifacts SIGILLed on heterogeneous runner CPUs. Regression-gate baseline re-grounded for the v3 toolchain
+- **deps**: Routine minor/patch dependency group updates
 
 - **codec**: Reject ODO (OCCURS DEPENDING ON) encode input where the JSON counter value disagrees with the array length instead of silently writing extra elements that are unrecoverable on decode (`CBKE521_ARRAY_LEN_OOB`)
 - **codec**: Keep `RawMode::Field` output scoped to `<field>_raw_b64` values instead of also emitting whole-record `raw_b64` and `__raw_b64` payloads

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "copybook"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "copybook-charset",
  "copybook-codec",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-arrow"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "copybook-codec",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-bdd"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-bench"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-charset"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "copybook-codepage",
  "copybook-error",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-cli"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-cli-determinism"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-codec"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-codec-memory"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "copybook-sequence-ring",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-codepage"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "clap",
  "serde",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-contracts"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-core"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-corruption"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "copybook-core",
  "copybook-corruption-detectors",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-corruption-detectors"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "copybook-core",
  "copybook-corruption-predicates",
@@ -981,11 +981,11 @@ dependencies = [
 
 [[package]]
 name = "copybook-corruption-predicates"
-version = "0.4.3"
+version = "0.5.0"
 
 [[package]]
 name = "copybook-corruption-rdw"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "copybook-core",
  "copybook-corruption",
@@ -996,7 +996,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-determinism"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "blake3",
  "copybook-codec",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-dialect"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-e2e"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-error"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-error-reporter"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "copybook-error",
  "serde_json",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-fixed"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "copybook-core",
  "copybook-error",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-gen"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "copybook-codec",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-governance"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "copybook-governance-grid",
  "copybook-governance-runtime",
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-governance-contracts"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "copybook-contracts",
  "copybook-support-matrix",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-governance-grid"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "copybook-governance-contracts",
  "serde_plain",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-governance-runtime"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "copybook-governance-grid",
  "serde",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-lexer"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "logos",
  "proptest",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-options"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "clap",
  "copybook-charset",
@@ -1128,14 +1128,14 @@ dependencies = [
 
 [[package]]
 name = "copybook-overflow"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "copybook-error",
 ]
 
 [[package]]
 name = "copybook-overpunch"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "copybook-codepage",
  "copybook-error",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-proptest"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "copybook-charset",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-rdw"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "copybook-core",
  "copybook-error",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-rdw-predicates"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "copybook-corruption",
  "copybook-corruption-rdw",
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-record-io"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "copybook-error",
  "copybook-fixed",
@@ -1212,14 +1212,14 @@ dependencies = [
 
 [[package]]
 name = "copybook-rs"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "copybook",
 ]
 
 [[package]]
 name = "copybook-safe-index"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "copybook-error",
  "proptest",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-safe-ops"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "copybook-error",
  "copybook-overflow",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-safe-text"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "copybook-error",
  "copybook-safe-ops",
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-scripts"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-sequence-ring"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "crossbeam-channel",
  "tracing",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-support-matrix"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-utils"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "copybook-error",
  "copybook-safe-ops",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "copybook-zoned-format"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "clap",
  "proptest",
@@ -4797,7 +4797,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.3"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.92" # MSRV (validated in .github/workflows/ci.yml)
 license = "AGPL-3.0-or-later"
@@ -67,43 +67,43 @@ categories = ["parsing", "encoding", "command-line-utilities"]
 
 [workspace.dependencies]
 # Internal workspace crates (pin exact versions for publish)
-copybook = { version = "=0.4.3", path = "crates/copybook" }
-copybook-error = { version = "=0.4.3", path = "crates/copybook-error" }
-copybook-error-reporter = { version = "=0.4.3", path = "crates/copybook-error-reporter" }
-copybook-utils = { version = "=0.4.3", path = "crates/copybook-utils" }
-copybook-overflow = { version = "=0.4.3", path = "crates/copybook-overflow" }
-copybook-zoned-format = { version = "=0.4.3", path = "crates/copybook-zoned-format" }
-copybook-fixed = { version = "=0.4.3", path = "crates/copybook-fixed" }
-copybook-rdw = { version = "=0.4.3", path = "crates/copybook-rdw" }
-copybook-record-io = { version = "=0.4.3", path = "crates/copybook-record-io" }
-copybook-overpunch = { version = "=0.4.3", path = "crates/copybook-overpunch" }
-copybook-determinism = { version = "=0.4.3", path = "crates/copybook-determinism" }
-copybook-safe-ops = { version = "=0.4.3", path = "crates/copybook-safe-ops" }
-copybook-safe-text = { version = "=0.4.3", path = "crates/copybook-safe-text" }
-copybook-safe-index = { version = "=0.4.3", path = "crates/copybook-safe-index" }
-copybook-rdw-predicates = { version = "=0.4.3", path = "crates/copybook-rdw-predicates" }
-copybook-codepage = { version = "=0.4.3", path = "crates/copybook-codepage" }
-copybook-charset = { version = "=0.4.3", path = "crates/copybook-charset" }
-copybook-options = { version = "=0.4.3", path = "crates/copybook-options" }
-copybook-lexer = { version = "=0.4.3", path = "crates/copybook-lexer" }
-copybook-core = { version = "=0.4.3", path = "crates/copybook-core" }
-copybook-corruption = { version = "=0.4.3", path = "crates/copybook-corruption" }
-copybook-corruption-detectors = { version = "=0.4.3", path = "crates/copybook-corruption-detectors" }
-copybook-corruption-rdw = { version = "=0.4.3", path = "crates/copybook-corruption-rdw" }
-copybook-corruption-predicates = { version = "=0.4.3", path = "crates/copybook-corruption-predicates" }
-copybook-dialect = { version = "=0.4.3", path = "crates/copybook-dialect" }
-copybook-codec = { version = "=0.4.3", path = "crates/copybook-codec" }
-copybook-codec-memory = { version = "=0.4.3", path = "crates/copybook-codec-memory" }
-copybook-cli-determinism = { version = "=0.4.3", path = "crates/copybook-cli-determinism" }
-copybook-sequence-ring = { version = "=0.4.3", path = "crates/copybook-sequence-ring" }
-copybook-arrow = { version = "=0.4.3", path = "crates/copybook-arrow" }
-copybook-governance = { version = "=0.4.3", path = "crates/copybook-governance" }
-copybook-governance-grid = { version = "=0.4.3", path = "crates/copybook-governance-grid" }
-copybook-governance-runtime = { version = "=0.4.3", path = "crates/copybook-governance-runtime" }
-copybook-governance-contracts = { version = "=0.4.3", path = "crates/copybook-governance-contracts" }
-copybook-bench = { version = "=0.4.3", path = "tools/copybook-bench" }
-copybook-contracts = { version = "=0.4.3", path = "crates/copybook-contracts" }
-copybook-support-matrix = { version = "=0.4.3", path = "crates/copybook-support-matrix" }
+copybook = { version = "=0.5.0", path = "crates/copybook" }
+copybook-error = { version = "=0.5.0", path = "crates/copybook-error" }
+copybook-error-reporter = { version = "=0.5.0", path = "crates/copybook-error-reporter" }
+copybook-utils = { version = "=0.5.0", path = "crates/copybook-utils" }
+copybook-overflow = { version = "=0.5.0", path = "crates/copybook-overflow" }
+copybook-zoned-format = { version = "=0.5.0", path = "crates/copybook-zoned-format" }
+copybook-fixed = { version = "=0.5.0", path = "crates/copybook-fixed" }
+copybook-rdw = { version = "=0.5.0", path = "crates/copybook-rdw" }
+copybook-record-io = { version = "=0.5.0", path = "crates/copybook-record-io" }
+copybook-overpunch = { version = "=0.5.0", path = "crates/copybook-overpunch" }
+copybook-determinism = { version = "=0.5.0", path = "crates/copybook-determinism" }
+copybook-safe-ops = { version = "=0.5.0", path = "crates/copybook-safe-ops" }
+copybook-safe-text = { version = "=0.5.0", path = "crates/copybook-safe-text" }
+copybook-safe-index = { version = "=0.5.0", path = "crates/copybook-safe-index" }
+copybook-rdw-predicates = { version = "=0.5.0", path = "crates/copybook-rdw-predicates" }
+copybook-codepage = { version = "=0.5.0", path = "crates/copybook-codepage" }
+copybook-charset = { version = "=0.5.0", path = "crates/copybook-charset" }
+copybook-options = { version = "=0.5.0", path = "crates/copybook-options" }
+copybook-lexer = { version = "=0.5.0", path = "crates/copybook-lexer" }
+copybook-core = { version = "=0.5.0", path = "crates/copybook-core" }
+copybook-corruption = { version = "=0.5.0", path = "crates/copybook-corruption" }
+copybook-corruption-detectors = { version = "=0.5.0", path = "crates/copybook-corruption-detectors" }
+copybook-corruption-rdw = { version = "=0.5.0", path = "crates/copybook-corruption-rdw" }
+copybook-corruption-predicates = { version = "=0.5.0", path = "crates/copybook-corruption-predicates" }
+copybook-dialect = { version = "=0.5.0", path = "crates/copybook-dialect" }
+copybook-codec = { version = "=0.5.0", path = "crates/copybook-codec" }
+copybook-codec-memory = { version = "=0.5.0", path = "crates/copybook-codec-memory" }
+copybook-cli-determinism = { version = "=0.5.0", path = "crates/copybook-cli-determinism" }
+copybook-sequence-ring = { version = "=0.5.0", path = "crates/copybook-sequence-ring" }
+copybook-arrow = { version = "=0.5.0", path = "crates/copybook-arrow" }
+copybook-governance = { version = "=0.5.0", path = "crates/copybook-governance" }
+copybook-governance-grid = { version = "=0.5.0", path = "crates/copybook-governance-grid" }
+copybook-governance-runtime = { version = "=0.5.0", path = "crates/copybook-governance-runtime" }
+copybook-governance-contracts = { version = "=0.5.0", path = "crates/copybook-governance-contracts" }
+copybook-bench = { version = "=0.5.0", path = "tools/copybook-bench" }
+copybook-contracts = { version = "=0.5.0", path = "crates/copybook-contracts" }
+copybook-support-matrix = { version = "=0.5.0", path = "crates/copybook-support-matrix" }
 
 # Core dependencies
 serde = { version = "1.0.228", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Rust toolkit for COBOL copybook parsing and fixed-record data conversion. Determ
 
 ## Status
 
-Engineering Preview (v0.4.3). Stable CLI and library APIs; feature completeness is preview-level. See [ROADMAP.md](docs/ROADMAP.md) for adoption guidance and known limitations.
+Engineering Preview (v0.5.0). Stable CLI and library APIs; feature completeness is preview-level. See [ROADMAP.md](docs/ROADMAP.md) for adoption guidance and known limitations.
 
 <!-- TEST_STATUS:BEGIN -->
 **conformance:** 9881/9881 â€¢ **roundtrip:** N/A â€¢ **negative:** N/A â€¢ **skipped:** 0 â€¢ **leaks:** 0  

--- a/crates/copybook-rs/README.md
+++ b/crates/copybook-rs/README.md
@@ -11,7 +11,7 @@ Use `copybook` directly in new projects:
 
 ```toml
 [dependencies]
-copybook = "0.4"
+copybook = "0.5"
 ```
 
 Use `copybook-core` and `copybook-codec` directly only when you need the

--- a/crates/copybook/README.md
+++ b/crates/copybook/README.md
@@ -49,5 +49,5 @@ Add `copybook` in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-copybook = "0.4"
+copybook = "0.5"
 ```

--- a/docs/REPORT.md
+++ b/docs/REPORT.md
@@ -3,9 +3,9 @@
 
 ---
 
-**Status**: ⚠️ **Engineering Preview (v0.4.3)** - See
+**Status**: ⚠️ **Engineering Preview (v0.5.0)** - See
 [ROADMAP.md](ROADMAP.md) for adoption guidance
-**Last Updated**: 2026-06-16
+**Last Updated**: 2026-07-28
 
 **Readiness**: Cautious Adoption Recommended - See
 [Readiness Assessment](#readiness-assessment) below

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,7 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 # Roadmap
 
-**Status**: Engineering Preview (v0.4.3)
+**Status**: Engineering Preview (v0.5.0)
 **Release target**: v1.0.0 after the product-readiness gates below pass; there is no calendar-only release promise.
 **Program tracker**: [#535 — v1 Product Readiness](https://github.com/EffortlessMetrics/copybook-rs/issues/535)
 

--- a/docs/reference/LIBRARY_API.md
+++ b/docs/reference/LIBRARY_API.md
@@ -24,7 +24,7 @@ Add the canonical `copybook` facade crate to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-copybook = "0.4"
+copybook = "0.5"
 ```
 
 `copybook-core` and `copybook-codec` remain available for advanced users who need a smaller dependency surface.

--- a/examples/kafka_pipeline/Cargo.toml
+++ b/examples/kafka_pipeline/Cargo.toml
@@ -24,8 +24,8 @@ path = "src/main.rs"
 
 [dependencies]
 # Internal workspace dependencies
-copybook-core = { version = "=0.4.3", path = "../../crates/copybook-core" }
-copybook-codec = { version = "=0.4.3", path = "../../crates/copybook-codec" }
+copybook-core = { version = "=0.5.0", path = "../../crates/copybook-core" }
+copybook-codec = { version = "=0.5.0", path = "../../crates/copybook-codec" }
 
 # Kafka dependencies
 rdkafka = { version = "0.37", features = ["cmake-build", "ssl-vendored"] }

--- a/examples/kafka_streaming/Cargo.lock
+++ b/examples/kafka_streaming/Cargo.lock
@@ -47,7 +47,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -69,9 +69,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "base64"
@@ -81,9 +81,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "blake3"
@@ -110,15 +110,15 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -166,24 +166,24 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "constant_time_eq"
@@ -481,18 +481,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -527,7 +527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -543,35 +543,91 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "futures-channel"
-version = "0.3.32"
+name = "futures"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
-name = "futures-task"
-version = "0.3.32"
+name = "futures-executor"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+
+[[package]]
+name = "futures-task"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+
+[[package]]
+name = "futures-util"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
  "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -616,18 +672,18 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "kafka-pipeline"
+name = "kafka-streaming"
 version = "0.4.3"
 dependencies = [
  "copybook-codec",
  "copybook-core",
+ "futures",
  "rdkafka",
- "serde",
  "serde_json",
  "thiserror",
  "tokio",
@@ -643,15 +699,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libz-sys"
-version = "1.1.24"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4735e9cbde5aac84a5ce588f6b23a90b9b0b528f6c5a8db8a4aff300463a0839"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "libc",
@@ -670,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "logos"
@@ -694,7 +750,7 @@ dependencies = [
  "quote",
  "regex-automata",
  "regex-syntax",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -717,19 +773,19 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -738,14 +794,14 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -753,21 +809,21 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -777,18 +833,18 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.5+3.5.5"
+version = "300.6.1+3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -828,24 +884,24 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -902,9 +958,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -913,15 +969,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "scopeguard"
@@ -931,9 +987,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -941,22 +997,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1004,9 +1060,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1026,18 +1082,18 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1048,9 +1104,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1070,38 +1126,38 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -1111,34 +1167,34 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1148,9 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
@@ -1174,7 +1230,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1200,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -1218,9 +1274,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -1266,15 +1322,6 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -1283,81 +1330,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/examples/kafka_streaming/Cargo.toml
+++ b/examples/kafka_streaming/Cargo.toml
@@ -25,8 +25,8 @@ name = "consumer"
 path = "src/consumer.rs"
 
 [dependencies]
-copybook-core = { version = "=0.4.3", path = "../../crates/copybook-core" }
-copybook-codec = { version = "=0.4.3", path = "../../crates/copybook-codec" }
+copybook-core = { version = "=0.5.0", path = "../../crates/copybook-core" }
+copybook-codec = { version = "=0.5.0", path = "../../crates/copybook-codec" }
 
 futures = "0.3.31"
 rdkafka = { version = "0.37", features = ["cmake-build", "ssl-vendored"] }


### PR DESCRIPTION
## Summary

Release preparation for **v0.5.0** (milestone: Edited PIC Encoding & Dialects). The six open issues in the v0.5.0 milestone are all profile-led performance experiments (#546–#550, #188); per `docs/ROADMAP.md` Phase 6 release policy they are explicitly **not** release blockers while the governed floors pass.

## Changes

- Workspace version and internal crate pins: 0.4.3 → 0.5.0 (`Cargo.toml`, `Cargo.lock`)
- `CHANGELOG.md`: promote `[Unreleased]` to `[0.5.0] — 2026-07-28` and add the July fixes (#600, #601, #605, perf-test gating, x86-64-v3 bench pin and gate re-baseline)
- Status headers: `docs/ROADMAP.md`, `docs/REPORT.md`, `README.md` → Engineering Preview v0.5.0

## Runbook gates (docs/RELEASE_RUNBOOK.md §2) on this branch

- `xtask publish plan --check` — 38 publishable crates validated
- `xtask docs verify-support-matrix` — in sync (7 features)
- `cargo check --workspace` — clean at v0.5.0

## Not in this PR

Tagging `v0.5.0` and publishing via `publish.yml` stay with the maintainer per the runbook (steps 3–4: capture `release-state/v0.5.0/publish-plan.json`, tag, workflow dispatch to the protected release environment).