### PR TITLE
fix(release): gate publication on exact tag identity and successful registry smoke

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -48,12 +48,12 @@ jobs:
         cargo run -p xtask -- publish plan --format json > "${PLAN_JSON}"
 
         PLAN_COUNT=$(python - "${PLAN_JSON}" <<'PY'
-import json
-import sys
+        import json
+        import sys
 
-with open(sys.argv[1], encoding="utf-8") as handle:
-    print(len(json.load(handle)))
-PY
+        with open(sys.argv[1], encoding="utf-8") as handle:
+            print(len(json.load(handle)))
+        PY
         )
 
         if [ "${PLAN_COUNT}" -le 0 ]; then
@@ -71,13 +71,13 @@ PY
         echo "=== Dry-run publish for all publishable crates ==="
         PLAN_JSON="${{ steps.publish-plan.outputs.plan_json }}"
         mapfile -t PUBLISH_CRATES < <(python - "$PLAN_JSON" <<'PY'
-import json
-import sys
+        import json
+        import sys
 
-with open(sys.argv[1], encoding="utf-8") as handle:
-    for crate in json.load(handle):
-        print(crate)
-PY
+        with open(sys.argv[1], encoding="utf-8") as handle:
+            for crate in json.load(handle):
+                print(crate)
+        PY
         )
 
         if [ "${#PUBLISH_CRATES[@]}" -ne "${{ steps.publish-plan.outputs.plan_count }}" ]; then
@@ -98,13 +98,13 @@ PY
         echo "=== Package manifest check for all publishable crates ==="
         PLAN_JSON="${{ steps.publish-plan.outputs.plan_json }}"
         mapfile -t PUBLISH_CRATES < <(python - "$PLAN_JSON" <<'PY'
-import json
-import sys
+        import json
+        import sys
 
-with open(sys.argv[1], encoding="utf-8") as handle:
-    for crate in json.load(handle):
-        print(crate)
-PY
+        with open(sys.argv[1], encoding="utf-8") as handle:
+            for crate in json.load(handle):
+                print(crate)
+        PY
         )
 
         for crate in "${PUBLISH_CRATES[@]}"; do
@@ -120,13 +120,13 @@ PY
         echo ""
         echo "Validated ${{ steps.publish-plan.outputs.plan_count }} publishable crates:"
         mapfile -t PUBLISH_CRATES < <(python - "${{ steps.publish-plan.outputs.plan_json }}" <<'PY'
-import json
-import sys
+        import json
+        import sys
 
-with open(sys.argv[1], encoding="utf-8") as handle:
-    for crate in json.load(handle):
-        print(crate)
-PY
+        with open(sys.argv[1], encoding="utf-8") as handle:
+            for crate in json.load(handle):
+                print(crate)
+        PY
         )
         for crate in "${PUBLISH_CRATES[@]}"; do
           echo "  - ${crate}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,16 +19,51 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # Single source of truth for the release tag. For manual dispatch the input
+  # wins; github.ref_name is the branch the dispatch was launched from, not
+  # the entered tag, so it must not take precedence.
+  RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     environment: production
+    outputs:
+      plan_json: ${{ steps.publish-plan.outputs.plan_json }}
+      plan_count: ${{ steps.publish-plan.outputs.plan_count }}
+      plan_sha256: ${{ steps.publish-plan.outputs.plan_sha256 }}
     steps:
     - uses: actions/checkout@v7
       with:
         fetch-depth: 0
-        ref: ${{ github.event.inputs.tag || github.ref }}
+        ref: ${{ env.RELEASE_TAG }}
+
+    - name: Validate release tag identity
+      run: |
+        set -euo pipefail
+
+        TAG="${{ env.RELEASE_TAG }}"
+        if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+          echo "Malformed release tag: '${TAG}' (expected vMAJOR.MINOR.PATCH[-prerelease])"
+          exit 1
+        fi
+
+        TAG_VERSION="${TAG#v}"
+        WS_VERSION=$(python3 -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["workspace"]["package"]["version"])')
+        if [[ "${TAG_VERSION}" != "${WS_VERSION}" ]]; then
+          echo "Tag '${TAG}' does not match [workspace.package].version '${WS_VERSION}'"
+          exit 1
+        fi
+
+        git fetch --tags --force origin >/dev/null 2>&1 || true
+        TAG_COMMIT=$(git rev-list -n 1 "${TAG}")
+        HEAD_COMMIT=$(git rev-parse HEAD)
+        if [[ "${TAG_COMMIT}" != "${HEAD_COMMIT}" ]]; then
+          echo "Checked-out commit ${HEAD_COMMIT} is not the tagged commit ${TAG_COMMIT}"
+          exit 1
+        fi
+
+        echo "Release tag identity verified: ${TAG} -> ${HEAD_COMMIT} (workspace ${WS_VERSION})"
 
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
@@ -37,7 +72,7 @@ jobs:
 
     - name: Preflight checks
       run: |
-        echo "Publishing for tag: ${{ github.ref_name || github.event.inputs.tag }}"
+        echo "Publishing for tag: ${{ env.RELEASE_TAG }}"
 
         # Verify workspace builds cleanly
         cargo build --workspace --release -j 2
@@ -124,12 +159,12 @@ jobs:
         cargo run -p xtask -- publish plan --format json > "${PLAN_JSON}"
 
         PLAN_COUNT=$(python - "${PLAN_JSON}" <<'PY'
-import json
-import sys
+        import json
+        import sys
 
-with open(sys.argv[1], encoding="utf-8") as handle:
-    print(len(json.load(handle)))
-PY
+        with open(sys.argv[1], encoding="utf-8") as handle:
+            print(len(json.load(handle)))
+        PY
         )
 
         if [ "${PLAN_COUNT}" -le 0 ]; then
@@ -137,8 +172,26 @@ PY
           exit 1
         fi
 
+        PLAN_SHA256=$(sha256sum "${PLAN_JSON}" | cut -d' ' -f1)
+
         echo "plan_json=${PLAN_JSON}" >> "${GITHUB_OUTPUT}"
         echo "plan_count=${PLAN_COUNT}" >> "${GITHUB_OUTPUT}"
+        echo "plan_sha256=${PLAN_SHA256}" >> "${GITHUB_OUTPUT}"
+
+        {
+          echo "### Publish plan"
+          echo ""
+          echo "- packages: ${PLAN_COUNT}"
+          echo "- sha256: \`${PLAN_SHA256}\`"
+        } >> "${GITHUB_STEP_SUMMARY}"
+
+    - name: Upload publish plan
+      uses: actions/upload-artifact@v4
+      with:
+        name: publish-plan-${{ env.RELEASE_TAG }}
+        path: ${{ steps.publish-plan.outputs.plan_json }}
+        if-no-files-found: error
+        retention-days: 90
 
     - name: Publish all crates in dependency order
       env:
@@ -216,13 +269,13 @@ PY
         PLAN_JSON="${{ steps.publish-plan.outputs.plan_json }}"
         PLAN_COUNT="${{ steps.publish-plan.outputs.plan_count }}"
         mapfile -t PUBLISH_CRATES < <(python - "$PLAN_JSON" <<'PY'
-import json
-import sys
+        import json
+        import sys
 
-with open(sys.argv[1], encoding="utf-8") as handle:
-    for crate in json.load(handle):
-        print(crate)
-PY
+        with open(sys.argv[1], encoding="utf-8") as handle:
+            for crate in json.load(handle):
+                print(crate)
+        PY
         )
 
         if [ "${#PUBLISH_CRATES[@]}" -le 0 ]; then
@@ -246,42 +299,92 @@ PY
         echo ""
         echo "All ${PLAN_COUNT} publishable crates published successfully!"
 
+  smoke-test:
+    runs-on: ubuntu-latest
+    needs: publish
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+        ref: ${{ env.RELEASE_TAG }}
+    - uses: dtolnay/rust-toolchain@stable
+    - name: Run blocking stable-core registry smoke
+      run: |
+        VERSION="${RELEASE_TAG#v}"
+        chmod +x scripts/ci/release_smoke.sh
+        scripts/ci/release_smoke.sh "${VERSION}"
+
+  smoke-test-experimental:
+    # Advisory only: Arrow and other experimental adapters are not part of the
+    # v0.5 stable-core promise. A failure here must produce a follow-up issue,
+    # not retroactively fail an already-correct stable-core release.
+    runs-on: ubuntu-latest
+    needs: publish
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+        ref: ${{ env.RELEASE_TAG }}
+    - uses: dtolnay/rust-toolchain@stable
+    - name: Run advisory experimental-adapter smoke
+      run: |
+        VERSION="${RELEASE_TAG#v}"
+        chmod +x scripts/ci/release_smoke.sh
+        RELEASE_SMOKE_ADVISORY=1 scripts/ci/release_smoke.sh "${VERSION}"
+
+  github-release:
+    # The user-facing release is created only after crates.io publication and
+    # the blocking stable-core registry smoke have both succeeded. crates.io
+    # publication is irreversible; the GitHub release is not, so it comes last.
+    runs-on: ubuntu-latest
+    needs: [publish, smoke-test]
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+        ref: ${{ env.RELEASE_TAG }}
+    - name: Download publish plan
+      uses: actions/download-artifact@v4
+      with:
+        name: publish-plan-${{ env.RELEASE_TAG }}
+        path: ${{ runner.temp }}
     - name: Create GitHub Release
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
 
-        tag="${{ github.ref_name || github.event.inputs.tag }}"
+        tag="${RELEASE_TAG}"
         version="${tag#v}"
         repo_url="https://github.com/${{ github.repository }}"
 
-        PLAN_JSON="${{ steps.publish-plan.outputs.plan_json }}"
+        PLAN_JSON="${{ runner.temp }}/publish-plan.json"
         python - "${PLAN_JSON}" "${version}" "${repo_url}" "${tag}" <<'PY' > release-notes.md
-import json
-import sys
+        import json
+        import sys
 
-plan_path, version, repo_url, tag = sys.argv[1:]
+        plan_path, version, repo_url, tag = sys.argv[1:]
 
-with open(plan_path, encoding="utf-8") as handle:
-    crates = json.load(handle)
+        with open(plan_path, encoding="utf-8") as handle:
+            crates = json.load(handle)
 
-print(f"## copybook-rs {version}")
-print("")
-print("**Installation:**")
-print("```bash")
-print(f"cargo install copybook-cli@{version}")
-print("```")
-print("")
-print(f"**Published Crates ({len(crates)}):**")
-print("")
-print("| Crate | crates.io | docs.rs |")
-print("|-------|-----------|---------|")
-for crate in crates:
-    print(f"| {crate} | [{version}](https://crates.io/crates/{crate}/{version}) | [docs](https://docs.rs/{crate}/{version}) |")
-print("")
-print(f"See [CHANGELOG.md]({repo_url}/blob/{tag}/CHANGELOG.md) for details.")
-PY
+        print(f"## copybook-rs {version}")
+        print("")
+        print("**Installation:**")
+        print("```bash")
+        print(f"cargo install copybook-cli@{version}")
+        print("```")
+        print("")
+        print(f"**Published Crates ({len(crates)}):**")
+        print("")
+        print("| Crate | crates.io | docs.rs |")
+        print("|-------|-----------|---------|")
+        for crate in crates:
+            print(f"| {crate} | [{version}](https://crates.io/crates/{crate}/{version}) | [docs](https://docs.rs/{crate}/{version}) |")
+        print("")
+        print(f"See [CHANGELOG.md]({repo_url}/blob/{tag}/CHANGELOG.md) for details.")
+        PY
 
         if gh release view "${tag}" >/dev/null 2>&1; then
           gh release edit "${tag}" --title "copybook-rs ${version}" --notes-file release-notes.md
@@ -294,45 +397,23 @@ PY
           echo "Created release ${tag}"
         fi
 
-  smoke-test:
-    runs-on: ubuntu-latest
-    needs: publish
-    steps:
-    - uses: dtolnay/rust-toolchain@stable
-    - name: Run release smoke from registry artifacts
+    - name: Print docs.rs links (informational)
       run: |
-        VERSION="${{ github.ref_name || github.event.inputs.tag }}"
-        VERSION="${VERSION#v}"
-        chmod +x scripts/ci/release_smoke.sh
-        scripts/ci/release_smoke.sh "${VERSION}"
+        VERSION="${RELEASE_TAG#v}"
 
-    - name: Validate docs.rs builds
-      run: |
-        VERSION="${{ github.ref_name || github.event.inputs.tag }}"
-        VERSION=${VERSION#v}
-
-        echo "Checking docs.rs availability (may take a few minutes to build)..."
-
-        # Give docs.rs some time to start building
-        sleep 300
-
-        # Check if docs are available (docs.rs builds asynchronously)
+        echo "docs.rs builds asynchronously; links below become valid as builds complete."
         for crate in copybook copybook-rs copybook-core copybook-codec copybook-arrow copybook-cli; do
-          url="https://docs.rs/${crate}/${VERSION}"
-          echo "Docs will be available at: ${url}"
+          echo "https://docs.rs/${crate}/${VERSION}"
         done
-
-        echo "Documentation links generated. docs.rs builds asynchronously."
 
   notify-success:
     runs-on: ubuntu-latest
-    needs: [publish, smoke-test]
+    needs: [publish, smoke-test, github-release]
     if: success()
     steps:
     - name: Success notification
       run: |
-        VERSION="${{ github.ref_name || github.event.inputs.tag }}"
-        VERSION=${VERSION#v}
+        VERSION="${RELEASE_TAG#v}"
 
         echo "Successfully published copybook-rs ${VERSION}!"
         echo ""

--- a/scripts/ci/release_smoke.sh
+++ b/scripts/ci/release_smoke.sh
@@ -123,6 +123,7 @@ run_with_binary() {
   local data_file="$4"
   local format="$5"
   local output_dir="$6"
+  local threads="$7"
 
   local decode_out="${output_dir}/decode.jsonl"
   local encode_out="${output_dir}/encode.bin"
@@ -135,11 +136,13 @@ run_with_binary() {
   "${copybook_cli}" decode "${copybook}" "${data_file}" \
     --format "${format}" \
     --codepage cp037 \
+    --threads "${threads}" \
     --output "${decode_out}"
 
   "${copybook_cli}" encode "${copybook}" "${decode_out}" \
     --format "${format}" \
     --codepage cp037 \
+    --threads "${threads}" \
     --output "${encode_out}"
 
   "${copybook_cli}" verify "${copybook}" "${encode_out}" \
@@ -209,6 +212,24 @@ if [ "${SMOKE_MODE}" != "local" ] && [ "${SMOKE_MODE}" != "registry" ]; then
   exit 1
 fi
 
+if [ "${RELEASE_SMOKE_ADVISORY:-0}" = "1" ]; then
+  # Advisory experimental-adapter smoke only. Arrow/Parquet is in the
+  # experimental adapter track and is not part of the stable-core promise,
+  # so this mode is run from a non-blocking workflow job.
+  if [ "${SMOKE_MODE}" = "local" ]; then
+    echo "Advisory Arrow smoke requires registry mode (RELEASE_SMOKE_DEPS=registry)." >&2
+    exit 1
+  fi
+
+  INSTALL_ARROW="${RUN_DIR}/copybook-arrow"
+  echo "Installing copybook-cli@${VERSION} (arrow feature, advisory)"
+  install_copybook_cli "arrow" "${INSTALL_ARROW}"
+  "${INSTALL_ARROW}/bin/copybook" --version
+
+  echo "Advisory experimental-adapter smoke completed successfully."
+  exit 0
+fi
+
 if [ -n "${COPYBOOK_CLI_BIN:-}" ]; then
   COPYBOOK_CLI_BIN="$(readlink_f "${COPYBOOK_CLI_BIN}")"
   if [ ! -x "${COPYBOOK_CLI_BIN}" ]; then
@@ -218,15 +239,10 @@ if [ -n "${COPYBOOK_CLI_BIN:-}" ]; then
   echo "Using local copybook CLI: ${COPYBOOK_CLI_BIN}"
 else
   INSTALL_DEFAULT="${RUN_DIR}/copybook-default"
-  INSTALL_ARROW="${RUN_DIR}/copybook-arrow"
 
   echo "Installing copybook-cli@${VERSION} (default features)"
   install_copybook_cli "" "${INSTALL_DEFAULT}"
   COPYBOOK_CLI_BIN="${INSTALL_DEFAULT}/bin/copybook"
-
-  echo "Installing copybook-cli@${VERSION} (arrow feature)"
-  install_copybook_cli "arrow" "${INSTALL_ARROW}"
-  "${INSTALL_ARROW}/bin/copybook" --version
 fi
 
 "${COPYBOOK_CLI_BIN}" --version
@@ -234,20 +250,63 @@ fi
 
 emit_smoke_manifest "${PROJECT_DIR}/Cargo.toml" "${SMOKE_MODE}"
 
-cat > "${PROJECT_DIR}/src/main.rs" <<EOF
-fn main() {}
+# The clean-room project must exercise the facade, not merely resolve it:
+# parse a small copybook through copybook::core, decode/encode through
+# copybook::codec, repeat through the copybook-rs redirect surface, and prove
+# the redirect produces byte-identical behavior.
+cat > "${PROJECT_DIR}/src/main.rs" <<'EOF'
+use copybook::codec::{DecodeOptions, EncodeOptions};
+use copybook::core::parse_copybook;
+
+const COPYBOOK: &str = "       01  SMOKE-RECORD.\n           05  SMOKE-ID     PIC 9(5).\n           05  SMOKE-NAME   PIC X(5).\n";
+// CP037 bytes for "12345" followed by "AB   ".
+const RECORD: [u8; 10] = [0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xC1, 0xC2, 0x40, 0x40, 0x40];
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let schema = parse_copybook(COPYBOOK)?;
+    let decoded = copybook::codec::decode_record(&schema, &RECORD, &DecodeOptions::default())?;
+    let encoded = copybook::codec::encode_record(&schema, &decoded, &EncodeOptions::default())?;
+    assert_eq!(encoded, RECORD, "copybook facade round-trip diverged");
+
+    let rs_schema = copybook_rs::core::parse_copybook(COPYBOOK)?;
+    let rs_decoded =
+        copybook_rs::codec::decode_record(&rs_schema, &RECORD, &copybook_rs::codec::DecodeOptions::default())?;
+    let rs_encoded =
+        copybook_rs::codec::encode_record(&rs_schema, &rs_decoded, &copybook_rs::codec::EncodeOptions::default())?;
+    assert_eq!(rs_encoded, encoded, "copybook-rs redirect diverged from copybook facade");
+
+    println!(
+        "facade smoke ok: {} bytes round-tripped identically via copybook and copybook-rs",
+        encoded.len()
+    );
+    Ok(())
+}
 EOF
 
-echo "Validating copybook and copybook-rs dependency resolution"
-cargo build --manifest-path "${PROJECT_DIR}/Cargo.toml"
+echo "Building and running clean-room facade smoke project"
+cargo run --manifest-path "${PROJECT_DIR}/Cargo.toml"
 
-echo "Running smoke fixed workflow"
-run_with_binary "${COPYBOOK_CLI_BIN}" fixed "${FIXTURE_COPYBOOK}" "${FIXTURE_FIXED}" fixed "${FIXTURE_DIR}/fixed"
+echo "Running smoke fixed workflow (single worker)"
+run_with_binary "${COPYBOOK_CLI_BIN}" fixed "${FIXTURE_COPYBOOK}" "${FIXTURE_FIXED}" fixed "${FIXTURE_DIR}/fixed/t1" 1
+
+echo "Running smoke fixed workflow (multi-worker)"
+run_with_binary "${COPYBOOK_CLI_BIN}" fixed "${FIXTURE_COPYBOOK}" "${FIXTURE_FIXED}" fixed "${FIXTURE_DIR}/fixed/t4" 4
+
+echo "Comparing fixed output across worker settings"
+compare_bytes "${FIXTURE_DIR}/fixed/t1/decode.jsonl" "${FIXTURE_DIR}/fixed/t4/decode.jsonl"
+compare_bytes "${FIXTURE_DIR}/fixed/t1/encode.bin" "${FIXTURE_DIR}/fixed/t4/encode.bin"
 
 RDW_FIXTURE="${FIXTURE_DIR}/simple.rdw.bin"
 make_rdw_fixture "${FIXTURE_FIXED}" "${RDW_FIXTURE}"
 
-echo "Running smoke RDW workflow"
-run_with_binary "${COPYBOOK_CLI_BIN}" rdw "${FIXTURE_COPYBOOK}" "${RDW_FIXTURE}" rdw "${FIXTURE_DIR}/rdw"
+echo "Running smoke RDW workflow (single worker)"
+run_with_binary "${COPYBOOK_CLI_BIN}" rdw "${FIXTURE_COPYBOOK}" "${RDW_FIXTURE}" rdw "${FIXTURE_DIR}/rdw/t1" 1
+
+echo "Running smoke RDW workflow (multi-worker)"
+run_with_binary "${COPYBOOK_CLI_BIN}" rdw "${FIXTURE_COPYBOOK}" "${RDW_FIXTURE}" rdw "${FIXTURE_DIR}/rdw/t4" 4
+
+echo "Comparing RDW output across worker settings"
+compare_bytes "${FIXTURE_DIR}/rdw/t1/decode.jsonl" "${FIXTURE_DIR}/rdw/t4/decode.jsonl"
+compare_bytes "${FIXTURE_DIR}/rdw/t1/encode.bin" "${FIXTURE_DIR}/rdw/t4/encode.bin"
 
 echo "Release smoke completed successfully."


### PR DESCRIPTION
## Summary

Hardens the irreversible release control plane before v0.5.0 is tagged. Fixes confirmed release-path defects in `publish.yml`/`publish-dry-run.yml` and strengthens `scripts/ci/release_smoke.sh` so the first publication is gated on exact tag identity and a passing stable-core registry smoke.

**Confirmed defects fixed:**

- **Workflow was unparseable**: column-0 Python heredocs made `publish.yml` (and `publish-dry-run.yml`) invalid YAML — the publish workflow could never have loaded on GitHub.
- **Wrong tag on manual dispatch**: `${{ github.ref_name || github.event.inputs.tag }}` resolves to the launching branch (e.g. `main`) for `workflow_dispatch`, and was used for the GitHub release and smoke version. Now resolved once as `RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}` and consumed everywhere.
- **Smoke job had no checkout**: `smoke-test` invoked `scripts/ci/release_smoke.sh` with no `actions/checkout` step; jobs share no workspace.
- **GitHub release created before smoke**: the user-facing release now waits for blocking stable-core registry smoke. crates.io publication is irreversible; the release is not, so it comes last.
- **Facade smoke didn't exercise the facade**: the clean-room project had an empty `main()`. It now parses a small copybook via `copybook::core::parse_copybook`, round-trips a CP037 record via `copybook::codec`, repeats through `copybook_rs`, and asserts byte-identical behavior.
- **Experimental Arrow blocked stable-core smoke**: Arrow install moved to an advisory `continue-on-error` job (`RELEASE_SMOKE_ADVISORY=1`); an experimental-adapter failure now creates follow-up work instead of failing the release.

**Hardening added:**

- Tag validation before publish: `vMAJOR.MINOR.PATCH[-prerelease]` format, match against `[workspace.package].version`, and checked-out-commit == tagged-commit.
- Publish plan uploaded as an artifact before the first publish; plan count and sha256 recorded in outputs and the step summary.
- Fixed and RDW smoke run with `--threads 1` and `--threads 4`; outputs byte-compared across worker settings.
- The docs.rs step is renamed "Print docs.rs links (informational)" — it only prints URLs.
- Inspect/resume/fix-forward behavior preserved (existing-version skip, 429 backoff); no yanking introduced.

No version bump and no publication in this PR.

## Type of Change

- [x] Bugfix (fixes an issue)
- [x] CI/CD (workflow or tooling changes)

## COBOL/Mainframe Context

- **COBOL features affected**: none (release automation only)
- **Data processing impact**: smoke coverage for fixed/RDW, CP037, threaded decode/encode determinism
- **Mainframe compatibility**: n/a

## Workspace Crates Affected

None — CI workflows and `scripts/ci/release_smoke.sh` only.

## Testing

- [x] `python3 -c yaml.safe_load` passes for both workflows (previously failed)
- [x] `bash -n scripts/ci/release_smoke.sh`
- [x] Local end-to-end smoke: `cargo build -p copybook-cli --release` + `RELEASE_SMOKE_DEPS=local COPYBOOK_CLI_BIN=target/release/copybook bash scripts/ci/release_smoke.sh 0.5.0` — facade clean-room compile/run, fixed+RDW workflows, single- and multi-worker output comparison all pass
- [ ] Full publish path (intentionally not exercised — requires a real tag)

## Checklist

- [x] No version bump, no tag, no publish in this change
- [x] Inspect/resume/fix-forward semantics preserved; no yank path added
- [x] Conventional Commit title

Refs #612


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release publishing now validates version tags and confirms they match the packaged version and selected commit.
  * Release plans are recorded, summarized, and preserved as downloadable artifacts.
  * Release notes are generated automatically from the publish plan.
  * Stable and experimental smoke checks now run after publishing.

* **Bug Fixes**
  * Improved release verification helps prevent publishing from incorrect tags or commits.
  * Added checks for consistent results across single- and multi-worker processing.

* **Documentation**
  * Release workflows now provide direct documentation links after publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->