### PR TITLE
docs(release): reconcile v0.5.0 release process and facade-first guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.0] — 2026-07-28
 
+**Highlights**: v0.5.0 makes the canonical `copybook` facade crate the default
+onboarding path, with `copybook-rs` retained as a redirect-only compatibility
+package that mirrors the facade. Decode and encode run multi-threaded with
+byte-identical output across worker counts, and this cycle lands parsing and
+codec corrections spanning fixed and RDW record formats, ODO, and REDEFINES
+(including the ODO encode-length validation below), the CLI exit-code and
+codepage fixes delivered in #607 (issues #600, #601, #605), and a blocking CI
+performance-regression gate with machine-readable receipts.
+
 ### Added
 
 - **ci**: Add blocking performance regression gate (`perf-gate.yml`) enforcing absolute floors (DISPLAY ≥80, COMP-3 ≥8 MiB/s) and >5% relative regression vs committed baseline; ships `bench-report gate` subcommand, `scripts/bench/baseline.json`, and canonical SLO constants in `copybook-bench::slo`. COMP-3 floor is CI-grounded (12–14 MiB/s observed on `ubuntu-latest`; throughput decreases with larger payloads, so 8 MiB/s gives ~35% headroom).

--- a/docs/API_FREEZE.md
+++ b/docs/API_FREEZE.md
@@ -218,11 +218,12 @@ bash scripts/api-baseline.sh check
    git push origin main --tags
    ```
 
-5. **Publish**:
-   ```bash
-   cargo publish -p copybook-core
-   cargo publish -p copybook-codec
-   ```
+5. **Publish** via the automated release pipeline: pushing the `vX.Y.Z` tag
+   triggers `.github/workflows/publish.yml`, which publishes every crate in the
+   generated `xtask publish plan` order and runs the registry smoke gates. See
+   [RELEASE_RUNBOOK.md](RELEASE_RUNBOOK.md) (execution) and
+   [RELEASE_PROCESS.md](RELEASE_PROCESS.md) (overview). Do not publish crates
+   manually with `cargo publish -p`.
 
 6. **Re-establish freeze**:
    ```bash

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -229,16 +229,24 @@ copybook decode customer.cpy data.bin \
 ```
 
 **After (copybook-rs Rust API):**
+
+Add the canonical `copybook` facade crate:
+
+```toml
+[dependencies]
+copybook = "0.5"
+```
+
 ```rust
-use copybook_core::parse_copybook;
-use copybook_codec::{iter_records_from_file, DecodeOptions, Codepage};
+use copybook::core::parse_copybook;
+use copybook::codec::{iter_records_from_file, Codepage, DecodeOptions};
 
 let copybook_text = std::fs::read_to_string("customer.cpy")?;
 let schema = parse_copybook(&copybook_text)?;
 
 let opts = DecodeOptions {
-    codepage: Codepage::Cp037,
-    strict: true,
+    codepage: Codepage::CP037,
+    strict_mode: true,
     ..Default::default()
 };
 
@@ -248,6 +256,10 @@ for record_result in iterator {
     println!("{}", serde_json::to_string(&json)?);
 }
 ```
+
+The granular `copybook-core` and `copybook-codec` crates remain intentional,
+supported crates for advanced users who need a narrower dependency; they are
+not the default onboarding path.
 
 ## Migration from Python Tools
 
@@ -469,7 +481,7 @@ copybook encode customer.cpy transformed.jsonl \
 
 ```rust
 // Rust streaming integration
-use copybook_codec::decode_record;
+use copybook::codec::decode_record;
 use tokio::io::{AsyncBufReadExt, BufReader};
 
 #[tokio::main]

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -1,277 +1,129 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
-# Release Process
+# Release Process (Overview)
 
-This document describes the automated release process for copybook-rs using `cargo-release` and `git-cliff`.
+This document is the authority and policy overview for releasing copybook-rs.
+For step-by-step execution, use the canonical runbook:
+[RELEASE_RUNBOOK.md](RELEASE_RUNBOOK.md). This overview intentionally does not
+duplicate the runbook's step list; where the two could disagree, the runbook and
+the generated publish plan win.
 
-## Prerequisites
+## Authority model
 
-Install required tools:
+| Question | Authoritative source |
+| --- | --- |
+| Step-by-step release execution | [RELEASE_RUNBOOK.md](RELEASE_RUNBOOK.md) |
+| Publishable package set and order | `cargo run -p xtask -- publish plan` |
+| What the release automation does | `.github/workflows/publish.yml` |
+| What the post-publish smoke proves | `scripts/ci/release_smoke.sh` |
+| Versioning and compatibility policy | [STABILITY_GUARANTEES.md](STABILITY_GUARANTEES.md) |
 
-```bash
-cargo install cargo-release
-cargo install git-cliff  # Already installed
-```
+The publish plan is generated from workspace metadata at release time. The
+number of publishable packages and their dependency order come from the plan
+output — never from a hand-maintained list in documentation. If documentation
+and the plan disagree, the plan is correct and the documentation is stale.
 
-Configure GPG signing (optional but recommended):
+Package roles in the plan:
 
-```bash
-git config --global user.signingkey <your-gpg-key-id>
-git config --global commit.gpgsign false  # We only sign tags, not commits
-git config --global tag.gpgsign true
-```
-
-If GPG is not available, edit `release.toml` and set `sign-tag = false`.
+- Component crates (`copybook-core`, `copybook-codec`, and the rest of the
+  publishable workspace) publish first, in generated dependency order.
+- `copybook` is the canonical facade crate: it re-exports the component crates
+  and publishes after all of its component dependencies.
+- `copybook-rs` is a redirect-only compatibility package that points users at
+  the `copybook` facade. It publishes last.
 
 ## Pre-Release Validation Gates
 
-All of the following gates must pass before executing any release. Running these checks ensures that formatting, linting, build integrity, test coverage, and documentation are in order.
+All of the following gates must pass on the exact release commit before
+tagging. The canonical combined local gate is `just pr` (also `just ci`).
 
 | Gate | Command | Pass Criteria |
 |------|---------|---------------|
-| Format | `cargo fmt --all --check` | Exit 0 |
-| Lint | `cargo clippy --workspace -- -D warnings -W clippy::pedantic` | Exit 0 |
+| Format | `just fmt-check` (`cargo fmt --all -- --check`) | Exit 0 |
+| Lint | `just lint` (clippy, workspace, pedantic) | Exit 0 |
 | Build | `cargo build --workspace --release` | Exit 0 |
-| Test | `cargo nextest run --workspace` | All pass |
+| Test | `just test` (nextest; excludes BDD and bench crates) | All pass |
 | Doctests | `cargo test --workspace --doc` | All pass |
-| Docs | `cargo doc --workspace --no-deps` | No warnings |
-| Changelog | manual | CHANGELOG.md has unreleased section |
-
-To run all automated gates in sequence:
-
-```bash
-cargo fmt --all --check \
-  && cargo clippy --workspace -- -D warnings -W clippy::pedantic \
-  && cargo build --workspace --release \
-  && cargo nextest run --workspace \
-  && cargo test --workspace --doc \
-  && cargo doc --workspace --no-deps
-```
-
-After the automated gates pass, manually verify that `CHANGELOG.md` contains an unreleased section with entries for the upcoming release.
-
-## Quick Reference
-
-```bash
-# Preview release (no changes made)
-cargo release patch --dry-run
-
-# Patch release (0.4.2 -> 0.4.3)
-cargo release patch
-
-# Minor release (0.4.2 -> 0.5.0)
-cargo release minor
-
-# Major release (0.4.2 -> 1.0.0)
-cargo release major
-```
-
-## Release Workflow
-
-When you run `cargo release <level>`, the following happens automatically:
-
-1. **Version Bump**: Updates version in all workspace `Cargo.toml` files
-   - Workspace root: `[workspace.package] version = "X.Y.Z"`
-   - Individual crates: Inherit from workspace
-
-2. **Changelog Update**: Runs `git-cliff` to update `CHANGELOG.md`
-   - Extracts unreleased commits following conventional commits format
-   - Groups by category (Added, Fixed, Documentation, etc.)
-   - Links issue numbers to GitHub
-
-3. **Git Commit**: Creates commit with message `chore(release): prepare vX.Y.Z`
-
-4. **Git Tag**: Creates signed tag `vX.Y.Z` with message `Release vX.Y.Z`
-
-5. **Push**: Pushes commit and tag to `origin` (triggers GitHub release CI)
-
-6. **Manual Publishing**: Does NOT auto-publish to crates.io
-   - Review the release on GitHub
-   - Manually publish with `cargo publish -p <crate>` if desired
-
-## Detailed Steps
-
-### 1. Prepare Release
-
-Ensure working directory is clean:
-
-```bash
-git status  # Should be clean
-git checkout main
-git pull origin main
-```
-
-Run tests to ensure everything passes:
-
-```bash
-cargo build --workspace --release
-cargo test --workspace
-cargo clippy --workspace -- -D warnings
-```
-
-### 2. Preview Release
-
-Use `--dry-run` to see what will happen:
-
-```bash
-cargo release patch --dry-run
-```
-
-Review the output:
-- Version changes in `Cargo.toml` files
-- CHANGELOG.md diff
-- Git commit and tag details
-
-### 3. Execute Release
-
-If preview looks good, run without `--dry-run`:
-
-```bash
-cargo release patch  # or minor/major
-```
-
-This will:
-- Prompt for confirmation at each step
-- Update files
-- Create commit and tag
-- Push to remote
-
-### 4. Verify Release
-
-Check GitHub:
-
-```bash
-# View the tag
-git tag -v v0.4.3  # Verify GPG signature
-
-# View the release commit
-git show v0.4.3
-
-# Check GitHub releases page
-open https://github.com/EffortlessMetrics/copybook-rs/releases
-```
-
-### 5. Publish to crates.io (Optional)
-
-After verifying the release on GitHub:
-
-```bash
-# Publish core first (dependency order)
-cargo publish -p copybook-core
-sleep 90  # Wait for crates.io to index (matches CI workflow)
-
-cargo publish -p copybook-codec
-sleep 90  # Wait for crates.io to index (matches CI workflow)
-
-cargo publish -p copybook-arrow
-sleep 90  # Wait for crates.io to index (matches CI workflow)
-
-cargo publish -p copybook-cli
-# Note: copybook-gen, copybook-bench, xtask, tests/bdd, tests/proptest have publish = false
-```
-
-## Configuration
-
-Release behavior is controlled by `release.toml` in the workspace root.
-
-Key settings:
-- `tag-name = "v{{version}}"`: Tag format
-- `sign-tag = true`: GPG sign tags (set to `false` if GPG unavailable)
-- `publish = false`: Don't auto-publish to crates.io
-- `allow-branch = ["main"]`: Only allow releases from main branch
-- `pre-release-hook`: Runs `git-cliff` to update CHANGELOG.md
-
-## Troubleshooting
-
-### GPG signing fails
-
-If you see GPG errors:
-
-```bash
-# Option 1: Configure GPG
-git config --global user.signingkey <key-id>
-
-# Option 2: Disable signing
-# Edit release.toml and set: sign-tag = false
-```
-
-### Changelog not updated
-
-Ensure `git-cliff` is installed:
-
-```bash
-cargo install git-cliff
-```
-
-### Push fails
-
-Check remote access:
-
-```bash
-git remote -v  # Verify origin URL
-git push --dry-run origin main  # Test push access
-```
-
-### Dependency version mismatch
-
-If you see version mismatch errors, ensure all workspace crates use exact versions for internal dependencies:
-
-```toml
-# In Cargo.toml workspace.dependencies
-copybook-core = { version = "=0.4.2", path = "copybook-core" }
-copybook-codec = { version = "=0.4.2", path = "copybook-codec" }
-```
-
-## Manual Changelog Update
-
-To manually update the changelog without releasing:
-
-```bash
-# Update CHANGELOG.md with unreleased commits
-git-cliff --unreleased --output CHANGELOG.md
-
-# Or generate full changelog from scratch
-git-cliff --output CHANGELOG.md
-```
-
-## Rollback
-
-If something goes wrong after release:
-
-```bash
-# Delete local tag
-git tag -d v0.4.3
-
-# Delete remote tag (if already pushed)
-git push origin :refs/tags/v0.4.3
-
-# Reset to previous commit
-git reset --hard HEAD~1
-
-# Force push (dangerous - only if tag not yet published)
-git push --force origin main
-```
-
-## Best Practices
-
-1. **Always use `--dry-run` first** to preview changes
-2. **Test thoroughly** before releasing
-3. **Use semantic versioning**:
-   - Patch (0.4.2 -> 0.4.3): Bug fixes only
-   - Minor (0.4.2 -> 0.5.0): New features, backward compatible
-   - Major (0.4.2 -> 1.0.0): Breaking changes
-4. **Review CHANGELOG.md** after generation for accuracy
-5. **Verify GPG signatures** on tags
-6. **Wait for CI** to pass before publishing to crates.io
-7. **Coordinate with team** before major releases
+| Docs | `just docs` (`cargo doc --workspace --no-deps`) | No warnings |
+| Changelog | manual | `CHANGELOG.md` has a section for the target version |
+| Publish plan | `cargo run -p xtask -- publish plan --check` | Exit 0 |
+
+## Automated release flow
+
+A release is a single automated pipeline driven by
+`.github/workflows/publish.yml`:
+
+1. **Trigger**: push an annotated, signed `v*` tag from `main` (for example
+   `v0.5.0`), or dispatch the workflow manually with the tag as input
+   (`gh workflow run publish.yml -f tag=vX.Y.Z`).
+2. **Tag-identity validation**: the tag must match
+   `vMAJOR.MINOR.PATCH[-prerelease]`, must equal `[workspace.package].version`,
+   and the checked-out commit must be the tagged commit. Any mismatch fails the
+   run before anything is published.
+3. **Preflight**: release build of the workspace, workspace tests (excluding
+   `copybook-bench` and `copybook-bdd`), crates.io metadata validation
+   (keywords/categories limits), and packaging spot-checks.
+4. **Publish plan**: `xtask publish plan --check` regenerates and validates the
+   plan; the JSON plan (package set, order, count, sha256) is archived as a
+   workflow artifact and is the recovery reference for resumes.
+5. **Publication**: crates publish in generated dependency order. The publisher
+   honors crates.io rate limits (HTTP 429) with backoff derived from the
+   registry's retry-after hint, treats an "already exists" response as a
+   resume point, and waits for index propagation between crates.
+6. **Blocking stable-core registry smoke** (`scripts/ci/release_smoke.sh`):
+   installs `copybook-cli@<version>` from crates.io into a clean root and proves
+   the published artifacts work: default CLI install, a clean-room consumer
+   project exercising the `copybook` facade and the `copybook-rs` redirect
+   (byte-identical behavior between them), fixed-length and RDW
+   decode/encode/verify round-trips, and byte-identical output between
+   single-worker and multi-worker runs. A failure here blocks the release.
+7. **Advisory experimental-adapter smoke**: the same script in advisory mode
+   (`RELEASE_SMOKE_ADVISORY=1`) installs the CLI with the `arrow` feature.
+   Arrow and other experimental adapters are not part of the stable-core
+   promise, so this job is non-blocking: a failure produces a follow-up issue,
+   not a failed release.
+8. **GitHub release**: created (or updated) only after publication and the
+   blocking smoke pass, with per-crate crates.io/docs.rs links generated from
+   the archived plan. crates.io publication is irreversible; the GitHub release
+   is not, so it comes last. docs.rs links are informational — docs.rs builds
+   asynchronously.
+
+The publish job runs in the workflow's protected GitHub environment
+(`production`); keep environment approval guardrails in place so publication
+cannot start unreviewed.
+
+## Failure and recovery policy
+
+- **Fix forward.** Recovery from a partial publication is inspect-then-resume:
+  classify the failure, verify crate visibility on crates.io, and resume from
+  the first unpublished crate in the archived plan. The publisher already
+  treats an existing version as a successful resume point.
+- **Never yank as normal recovery.** Yank is reserved for legal/security
+  exceptions and must be documented (reason, approver, exact crates and
+  versions, replacement plan). For non-exceptional problems, prefer a patch
+  release plus clear migration notes.
+- **Never overwrite or move tags.** A published tag is immutable; a corrected
+  release gets a new version and a new tag.
+
+See [RELEASE_RUNBOOK.md](RELEASE_RUNBOOK.md) sections 5–7 for the detailed
+recovery and rollback procedure.
+
+## Version bumps and changelogs (local helpers only)
+
+`release.toml` and `cliff.toml` configure optional local helpers
+(`cargo-release`, `git-cliff`) that can draft a workspace version bump or
+changelog entries while preparing a release PR. They are conveniences only —
+they are **not** the release path. Publication happens exclusively through the
+automated flow above, from a tag on `main` whose version equals
+`[workspace.package].version`.
 
 ## See Also
 
-- [cargo-release documentation](https://github.com/crate-ci/cargo-release)
-- [git-cliff documentation](https://git-cliff.org/)
+- [RELEASE_RUNBOOK.md](RELEASE_RUNBOOK.md) — canonical execution runbook
+- [STABILITY_GUARANTEES.md](STABILITY_GUARANTEES.md) — stability commitments
+- [SUPPORT_POLICY.md](SUPPORT_POLICY.md) — support policy
 - [Conventional Commits](https://www.conventionalcommits.org/)
 - [Semantic Versioning](https://semver.org/)
-- [GIT_CLIFF_SETUP.md](../GIT_CLIFF_SETUP.md) - git-cliff configuration details
-- [CHANGELOG_GENERATION.md](CHANGELOG_GENERATION.md) - Changelog generation details
+
 ## License
 
 Licensed under **AGPL-3.0-or-later**. See [LICENSE](LICENSE).

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -93,14 +93,14 @@ git tag -a "${RELEASE_TAG}" -m "copybook-rs ${RELEASE_TAG}"
 git push origin "${RELEASE_TAG}"
 ```
 
-2. Publish via workflow dispatch to the protected `release` environment:
+2. Publish via workflow dispatch to the protected `production` environment:
 
 ```bash
 gh workflow run publish.yml -f tag="${RELEASE_TAG}"
 ```
 
 `publish.yml` uses `tools/xtask` plan output for publish order and count. Keep approval required by the
-GitHub environment guardrails before publishing starts.
+GitHub `production` environment guardrails before publishing starts.
 
 ---
 

--- a/docs/REPORT.md
+++ b/docs/REPORT.md
@@ -55,7 +55,7 @@ responsibilities:
 ### Test Coverage
 
 <!-- TEST_STATUS:BEGIN -->
-**conformance:** 9881/9881 â€¢ **roundtrip:** N/A â€¢ **negative:** N/A â€¢ **skipped:** 0 â€¢ **leaks:** 0  
+**conformance:** 9881/9881 • **roundtrip:** N/A • **negative:** N/A • **skipped:** 0 • **leaks:** 0  
 _Source: CI receipts (nextest/junit). This block is updated automatically._
 <!-- TEST_STATUS:END -->
 


### PR DESCRIPTION
<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
# Pull Request

## Summary

Reconciles the remaining v0.5.0 release/publication documentation with reality (issue #614), as a docs-only change:

- **`docs/RELEASE_PROCESS.md`** rewritten from the obsolete cargo-release/git-cliff step list (with its manual 4-crate publish example) into the release **authority/overview** document: `docs/RELEASE_RUNBOOK.md` is the canonical execution runbook; the generated `xtask publish plan` is the single authority for package set and order (no hand-maintained counts); the hardened `.github/workflows/publish.yml` flow is documented as the only release path — signed `v*` tag push or manual dispatch → tag-identity validation (format, workspace-version match, checked-out commit == tagged commit) → preflight → dependency-order publish with 429 backoff and existing-version resume → **blocking** stable-core registry smoke (default CLI, `copybook` facade, `copybook-rs` redirect, fixed+RDW, single/multi-worker determinism) → **advisory** experimental-adapter (Arrow) smoke → GitHub release only after smoke passes → informational docs.rs links. `copybook` is documented as the canonical facade published after its component dependencies; `copybook-rs` as the redirect-only package published last. Fix-forward / inspect-then-resume recovery; never yank as normal recovery; never overwrite tags. `release.toml`/`cliff.toml` documented as optional local helpers only. Pre-release validation gate table kept and aligned to the justfile recipes.
- **`docs/MIGRATION_GUIDE.md`** Rust examples made facade-first: `copybook = "0.5"` with `use copybook::core::parse_copybook;` / `use copybook::codec::{...}` (both spots verified against `crates/copybook/src/lib.rs` and the underlying crates). Also fixed the previously non-compiling `Codepage::Cp037` → `Codepage::CP037` and `strict:` → `strict_mode:`. A one-line note keeps `copybook-core`/`copybook-codec` as intentional granular crates for advanced users, not the default onboarding path. Java/Python/Scala sections untouched.
- **`docs/API_FREEZE.md`**: stale manual 2-crate `cargo publish -p` release step replaced with a pointer to the automated pipeline and runbook.
- **`CHANGELOG.md`**: added a v0.5.0 **Highlights** paragraph covering the canonical `copybook` facade + `copybook-rs` redirect, threaded decode/encode with worker-count determinism, fixed/RDW/ODO/REDEFINES corrections, the #607 exit-code/codepage fixes (#600/#601/#605), and performance-governance improvements.
- **`docs/REPORT.md`**: fixed mojibake (`â€¢` → `•`) in the auto-generated test-status block; date/status verified current.

## Type of Change

- [x] Documentation (README, docs/, code comments)

## COBOL/Mainframe Context

- **COBOL features affected**: none (docs only)
- **Data processing impact**: none
- **Mainframe compatibility**: N/A

## Workspace Crates Affected

None — docs-only change; no `Cargo.toml`/`Cargo.lock`/source changes.

## Checklist

- [x] Tests added/updated (N/A for docs-only changes)
- [x] Documentation updated
- [x] CHANGELOG.md updated (v0.5.0 Highlights narrative)
- [x] Follows conventional commit format
- [x] No performance impact expected

Validation performed:

- `cargo run -p xtask -- publish plan --check` — **pass** (38 publishable crates validated)
- `cargo run -p xtask -- docs verify-support-matrix` — **pass**
- `cargo run -p xtask -- docs freeze contracts` — **pass**
- `cargo run -p xtask -- docs verify-all` — **not runnable locally**: fails on the known local-artifact precondition `No junit.xml found` (requires a nextest junit receipt); not caused by this change
- `markdownlint -c .markdownlint.json` on changed files — **pass** for rewritten `RELEASE_PROCESS.md`; other touched files carry pre-existing lint debt unchanged by this PR (only my edited lines were kept clean)
- Full diff reviewed: 5 documentation files only

## Testing Instructions

```bash
cargo run -p xtask -- publish plan --check
cargo run -p xtask -- docs verify-support-matrix
markdownlint -c .markdownlint.json docs/RELEASE_PROCESS.md
```

## Performance Impact

- [x] No performance impact expected

## Breaking Changes

- [x] No breaking changes

## Related Issues

Refs #614

## Additional Notes

Documented publish behavior reflects the hardened workflow on `fix/release-publish-hardening` (PR #620), which merges ahead of this PR. Remaining #614 acceptance items not covered here: the #551 issue-tracker reconciliation (handled separately) and any items requiring code or release-execution changes.
