### PR TITLE
docs(status): regenerate frozen test-status block from current junit receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Rust toolkit for COBOL copybook parsing and fixed-record data conversion. Determ
 Engineering Preview (v0.5.0). Stable CLI and library APIs; feature completeness is preview-level. See [ROADMAP.md](docs/ROADMAP.md) for adoption guidance and known limitations.
 
 <!-- TEST_STATUS:BEGIN -->
-**conformance:** 9881/9881 â€¢ **roundtrip:** N/A â€¢ **negative:** N/A â€¢ **skipped:** 0 â€¢ **leaks:** 0  
+**conformance:** 9989/9989  • **roundtrip:** N/A  • **negative:** N/A  • **skipped:** 0  • **leaks:** 0  
 _Source: CI receipts (nextest/junit). This block is updated automatically._
 <!-- TEST_STATUS:END -->
 

--- a/docs/REPORT.md
+++ b/docs/REPORT.md
@@ -55,7 +55,7 @@ responsibilities:
 ### Test Coverage
 
 <!-- TEST_STATUS:BEGIN -->
-**conformance:** 9881/9881 • **roundtrip:** N/A • **negative:** N/A • **skipped:** 0 • **leaks:** 0  
+**conformance:** 9989/9989  • **roundtrip:** N/A  • **negative:** N/A  • **skipped:** 0  • **leaks:** 0  
 _Source: CI receipts (nextest/junit). This block is updated automatically._
 <!-- TEST_STATUS:END -->
 


### PR DESCRIPTION
## Summary

`cargo run -p xtask -- docs verify-all` on the v0.5.0 candidate failed with `README.md test-status out of sync`. The frozen block was stale (9881 → 9989 tests) and README.md's block carried mojibake bullets (`â€¢`). Regenerated via the sanctioned command:

```bash
cargo run -p xtask -- docs sync-tests
```

No narrative content changed — only the generated TEST_STATUS block in `README.md` and `docs/REPORT.md`.

Note: `docs-truth.yml` runs `docs sync-tests` before `docs verify-all` in CI, so it cannot catch this drift; the candidate-proof local run (verify without prior sync) did.

## Type of Change

- [x] Documentation (README, docs/, code comments)

## Testing

- [x] `cargo run -p xtask -- docs verify-all` passes with the regenerated block and a current junit receipt

Refs #616