### PR TITLE
test(codec): bound numeric roundtrip proptest to PIC 9(15)V99 capacity

### DIFF
--- a/crates/copybook-codec/tests/property_invariants_advanced.rs
+++ b/crates/copybook-codec/tests/property_invariants_advanced.rs
@@ -137,7 +137,11 @@ mod numeric_preservation {
     proptest! {
         #[test]
         fn prop_numeric_roundtrip_preserves_value(
-            value in -999999999999999999i64..999999999999999999i64,
+            // PIC 9(15)V99 holds at most 15 integer digits plus 2 fractional
+            // digits, i.e. |value| <= 99_999_999_999_999_999 cents. Drawing
+            // from a wider i64 range makes almost every case unrepresentable
+            // and the test aborts on global rejects at high case counts.
+            value in -99_999_999_999_999_999i64..=99_999_999_999_999_999i64,
             signed in proptest::bool::ANY,
         ) {
             // Unsigned fields cannot represent negatives.


### PR DESCRIPTION
## Summary

The extended ci-fuzz lane (`PROPTEST_CASES=10000`) failed on the v0.5.0 candidate: `numeric_preservation::prop_numeric_roundtrip_preserves_value` aborted with `Too many global rejects` (1024 rejects at `!decoded.is_empty()` after only 493 successes).

Root cause is the test, not the codec: the generator drew `i64` values up to 18 digits, but `PIC 9(15)V99` represents at most 17 (15 integer + 2 fractional). ~90% of cases were unrepresentable, so at high case counts the global reject limit tripped before the property was exercised. The default 256-case local run rarely notices.

Fix: bound the generator to the representable range (`±99_999_999_999_999_999` cents). Test-only change.

## Type of Change

- [x] Tests (test additions or improvements)

## Testing

- [x] Exact failing lane invocation now passes: `PROPTEST_CASES=10000 PROPTEST_MAX_SHRINK_ITERS=1000 cargo test -p copybook-codec --test property_invariants_advanced --all-features` (2 passed; previously 1 failed)
- [ ] ci-fuzz workflow re-dispatch after merge (tracked in #616)

Refs #616

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined numeric test input ranges for encode/decode roundtrip validation.
  * Focused property testing on a bounded set of supported numeric values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->