### PR TITLE
fix(ci): drop --all-features from tarpaulin coverage lane

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -55,6 +55,12 @@ jobs:
       run: cargo install cargo-tarpaulin --version 0.31.5
 
     - name: Run tarpaulin coverage
+      # NOTE: do not pass --all-features here. It enables the opt-in
+      # `comprehensive-tests` feature, whose aspirational tests are known to
+      # fail and are explicitly non-blocking (see ci-comprehensive.yml).
+      # Tarpaulin exits non-zero on any test failure, so --all-features made
+      # this lane fail on every run (#626). Default features match the main
+      # CI test lane (ci.yml) and the llvm-cov lane (coverage.yml).
       run: |
         cargo tarpaulin \
           --workspace \
@@ -73,7 +79,6 @@ jobs:
           --output-dir ./coverage \
           --verbose \
           --timeout 300 \
-          --all-features \
           -- --test-threads 1
 
     - name: Generate coverage summary
@@ -110,7 +115,7 @@ jobs:
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "## Coverage Details" >> $GITHUB_STEP_SUMMARY
         echo "- **Tool**: cargo-tarpaulin 0.31.5" >> $GITHUB_STEP_SUMMARY
-        echo "- **Features**: All features enabled" >> $GITHUB_STEP_SUMMARY
+        echo "- **Features**: Default features (see note on the coverage step)" >> $GITHUB_STEP_SUMMARY
         echo "- **Excluded**: copybook-bench, examples, integration tests" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "View detailed coverage report on [Codecov](https://codecov.io/gh/${{ github.repository }})." >> $GITHUB_STEP_SUMMARY
@@ -159,8 +164,7 @@ jobs:
           --exclude-files 'crates/copybook-arrow/tests/*' \
           --out Xml \
           --output-dir ./coverage-base \
-          --timeout 300 \
-          --all-features
+          --timeout 300
 
         # Get PR branch coverage
         git checkout ${{ github.sha }}
@@ -179,8 +183,7 @@ jobs:
           --exclude-files 'crates/copybook-arrow/tests/*' \
           --out Xml \
           --output-dir ./coverage-pr \
-          --timeout 300 \
-          --all-features
+          --timeout 300
 
         echo "Coverage diff analysis complete"
         echo "Base branch: ${{ github.base_ref }}"


### PR DESCRIPTION
<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
# Pull Request

## Summary

Fixes the perpetually failing tarpaulin coverage lane (`ci-coverage.yml`, workflow "Code Coverage"). The lane invoked `cargo tarpaulin --all-features`, which enables the opt-in `comprehensive-tests` feature in `copybook-core` and `copybook-codec`. The aspirational tests behind that feature are known to fail and are explicitly run as non-blocking in `ci-comprehensive.yml` ("this is expected and non-blocking"), but tarpaulin exits non-zero on any test failure, so the lane failed on every recent main SHA (e.g. runs [30408279627](https://github.com/EffortlessMetrics/copybook-rs/actions/runs/30408279627) and 30364030923) with:

- `test_edited_pic_error_detection` (`crates/copybook-core/tests/parser_fixtures.rs`)
- `test_edited_pic_error_normative` (`crates/copybook-core/tests/comprehensive_parser_tests.rs`)
- `test_missing_counter_field_error` (`crates/copybook-codec/tests/integration_odo_redefines.rs`)
- `test_redefines_declaration_order` (`crates/copybook-codec/tests/comprehensive_redefines_odo_tests.rs`)

The fix drops `--all-features` from both tarpaulin invocations (coverage + coverage-diff jobs) so the lane runs with default features — matching the main CI test lane (`ci.yml`, nextest with no features) and the llvm-cov Codecov lane (`coverage.yml`). An inline comment documents why `--all-features` must not be re-added. The comprehensive tests remain exercised by the non-blocking `ci-comprehensive.yml` workflow.

## Type of Change

- [ ] Feature (new functionality)
- [ ] Bugfix (fixes an issue)
- [ ] Refactor (code improvement without behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (README, docs/, code comments)
- [ ] Tests (test additions or improvements)
- [x] CI/CD (workflow or tooling changes)
- [ ] Chore (dependencies, formatting, etc.)

## COBOL/Mainframe Context

- **COBOL features affected**: None (CI-only change)
- **Data processing impact**: None
- **Mainframe compatibility**: N/A

## Workspace Crates Affected

None — CI workflow only (`.github/workflows/ci-coverage.yml`).

## Checklist

- [x] Tests added/updated (or N/A for docs-only changes) — N/A, CI-only; validated locally (see below)
- [x] Documentation updated (AGENTS.md, tool adapters, docs/, or inline comments if needed) — inline comment added to the workflow
- [x] CHANGELOG.md updated (if user-facing change) — N/A, not user-facing
- [x] `cargo fmt --all` passes — N/A, no Rust code changed
- [x] `cargo clippy --workspace -- -D warnings -W clippy::pedantic` passes — N/A, no Rust code changed
- [x] `cargo test --workspace` passes (or `cargo nextest run --workspace`) — targeted validation only, see below
- [x] `bash scripts/ci/governance-bdd-smoke.sh` passes (if governance or BDD touched) — N/A
- [x] Follows [conventional commit format](https://www.conventionalcommits.org/) (e.g., `feat(core):`, `fix(codec):`)
- [x] MSRV compliance (Rust 1.92+) verified if dependencies changed — N/A
- [x] Golden fixtures updated if applicable — N/A

## Testing Instructions

Reproduce the original failure (pre-fix behavior, on `main`):

```bash
cargo test -p copybook-core -p copybook-codec \
  --features copybook-core/comprehensive-tests,copybook-codec/comprehensive-tests \
  --test comprehensive_parser_tests --test parser_fixtures \
  --test integration_odo_redefines --test comprehensive_redefines_odo_tests
# => test_redefines_declaration_order FAILED (and the other three fail in CI logs)
```

Validate the fixed configuration (default features, as the lane now runs):

```bash
cargo test -p copybook-core -p copybook-codec \
  --test comprehensive_parser_tests --test parser_fixtures \
  --test integration_odo_redefines --test comprehensive_redefines_odo_tests
# => all targets compile to 0 tests, exit 0
```

Workflow syntax: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci-coverage.yml'))"`.

## Performance Impact

- [x] No performance impact expected

## Infrastructure/Tooling Changes (if applicable)

**Areas modified:**
- [x] CI scripts or validation gates

### Validation Evidence (for infrastructure changes)

```bash
# Failing CI run evidence (main @ 4d1ecb90):
gh run view 30408279627 --log-failed
# => 4 known-failing comprehensive-tests failures, then:
#    Error: "Test failed during run" / exit code 1

# Local reproduction of root cause (with comprehensive-tests enabled):
cargo test -p copybook-core -p copybook-codec \
  --features copybook-core/comprehensive-tests,copybook-codec/comprehensive-tests \
  --test comprehensive_redefines_odo_tests
# => FAILED: test_redefines_declaration_order (matches CI)

# Post-fix configuration (default features):
cargo test -p copybook-core -p copybook-codec \
  --test comprehensive_parser_tests --test parser_fixtures \
  --test integration_odo_redefines --test comprehensive_redefines_odo_tests
# => ok, 0 tests in each gated target, exit 0
```

Note: a full local `cargo tarpaulin --workspace` run was not performed (tarpaulin is not installed locally and a full instrumented workspace run is lengthy); the CI run logs show every other test target passed under tarpaulin, and the only failures were the four `comprehensive-tests`-gated tests removed from the run by this change.

## Breaking Changes

- [x] No breaking changes

## Related Issues

Refs #626

## Additional Notes

Coverage of feature-gated code (`audit`, `metrics`, `comp3_unsafe`, `comprehensive-tests`) is intentionally not collected by this lane after the fix, consistent with the llvm-cov Codecov lane (`coverage.yml`) and the main test lane (`ci.yml`), which also run default features. If coverage of those features is wanted later, it should be added via an explicit, curated `--features` list that excludes `comprehensive-tests` (tarpaulin has no `--exclude-features`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage checks to run with default features.
  * Improved coverage workflow summaries to clarify feature settings.
  * Applied the same configuration to pull request coverage comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->