### PR TITLE
ci(mutants): build copybook CLI before baseline nextest run

### DIFF
--- a/.github/workflows/ci-mutants.yml
+++ b/.github/workflows/ci-mutants.yml
@@ -157,6 +157,11 @@ jobs:
       - name: Install jq
         run: sudo apt-get install -y jq bc
 
+      # copybook-codec tests invoke the `copybook` CLI via assert_cmd::cargo_bin,
+      # which resolves to target/debug/copybook; build it before the baseline run.
+      - name: Build copybook CLI binary
+        run: cargo build --package copybook-cli
+
       - name: Run baseline tests
         run: |
           cargo nextest run \


### PR DESCRIPTION
<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
# Pull Request

## Summary

Fixes the `ci-mutants.yml` dispatch/scheduled path, where every affected matrix crate's `Run baseline tests` step failed before mutation testing could start. `copybook-codec`'s `binary_roundtrip_fidelity_tests::test_cli_roundtrip_cmp_validation` invokes the `copybook` CLI via `assert_cmd::Command::cargo_bin("copybook")`, which resolves to `target/debug/copybook`. `cargo nextest run --package copybook-codec` never builds that binary (`copybook-cli` is not a dev-dependency of `copybook-codec`), so the test panicked with `assert_cmd::cargo::missing_cargo_bin`. PR-triggered runs were green only because the `mutants` job is skipped unless the PR carries the `mutation-test` label — the baseline step never actually ran on the PR path.

The fix adds a `cargo build --package copybook-cli` step before the baseline nextest run, matching the pattern already used in `ci.yml`, `determinism-smoke.yml`, `metrics-smoke.yml`, and `leak-detection.yml`.

Failing run: https://github.com/EffortlessMetrics/copybook-rs/actions/runs/30406669203

## Type of Change

- [ ] Feature (new functionality)
- [ ] Bugfix (fixes an issue)
- [ ] Refactor (code improvement without behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (README, docs/, code comments)
- [ ] Tests (test additions or improvements)
- [x] CI/CD (workflow or tooling changes)
- [ ] Chore (dependencies, formatting, etc.)

## COBOL/Mainframe Context

- **COBOL features affected**: N/A (CI-only change)
- **Data processing impact**: N/A
- **Mainframe compatibility**: N/A

## Workspace Crates Affected

None — CI workflow only (`.github/workflows/ci-mutants.yml`).

## Checklist

- [x] Tests added/updated (or N/A for docs-only changes) — N/A, CI-only
- [x] Documentation updated (AGENTS.md, tool adapters, docs/, or inline comments if needed) — inline workflow comment added
- [x] CHANGELOG.md updated (if user-facing change) — N/A, not user-facing
- [x] `cargo fmt --all` passes — N/A, no Rust code changed
- [x] `cargo clippy --workspace -- -D warnings -W clippy::pedantic` passes — N/A, no Rust code changed
- [x] `cargo test --workspace` passes (or `cargo nextest run --workspace`) — targeted validation below
- [x] `bash scripts/ci/governance-bdd-smoke.sh` passes (if governance or BDD touched) — N/A
- [x] Follows [conventional commit format](https://www.conventionalcommits.org/) (e.g., `feat(core):`, `fix(codec):`)
- [x] MSRV compliance (Rust 1.92+) verified if dependencies changed — no dependency changes
- [x] Golden fixtures updated if applicable — N/A

## Testing Instructions

Reproduce the CI baseline step locally in a clean checkout:

```bash
# Without target/debug/copybook present, this panics with missing_cargo_bin:
cargo nextest run --package copybook-codec \
  --failure-output=immediate \
  --features comprehensive-tests \
  test_cli_roundtrip_cmp_validation

# With the new step's command run first, it passes:
cargo build --package copybook-cli
cargo nextest run --package copybook-codec \
  --failure-output=immediate \
  --features comprehensive-tests \
  test_cli_roundtrip_cmp_validation
```

## Performance Impact

- [x] No performance impact expected

Adds one `cargo build --package copybook-cli` step per matrix job; artifacts are covered by the existing `Swatinem/rust-cache` per-crate cache.

## Infrastructure/Tooling Changes (if applicable)

**Areas modified:**
- [ ] Support matrix registry or CLI
- [ ] Performance receipt parsing or SLO evaluation
- [x] CI scripts or validation gates
- [ ] xtask automation or docs verification tools

### Validation Evidence (for infrastructure changes)

```bash
# Workflow YAML parses cleanly
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci-mutants.yml'))"  # ✅ Pass

# Exact CI baseline invocation, after building the CLI binary (the new step)
cargo build --package copybook-cli                  # ✅ Pass (dev profile)
cargo nextest run --package copybook-codec \
  --failure-output=immediate \
  --features comprehensive-tests \
  test_cli_roundtrip_cmp_validation                 # ✅ Pass — 1 passed, 2100 skipped
```

Full dispatch-path validation requires a `workflow_dispatch` run on GitHub Actions (not reproducible locally).

## Breaking Changes

- [x] No breaking changes

## Enterprise Validation (if applicable)

N/A — CI-only change.

## Related Issues

Refs #626

## Additional Notes

Out of scope for this PR (observed in the same failing run, left to their own lanes):

- `copybook-error`, `copybook-overflow`, `copybook-overpunch` baseline steps fail because those crates do not define the `comprehensive-tests` feature (`error: the package 'copybook-error' does not contain this feature: comprehensive-tests`).
- `copybook-core` baseline fails on `comprehensive_parser_tests::test_edited_pic_error_normative` (unrelated panic at `crates/copybook-core/tests/comprehensive_parser_tests.rs:109`).
