### PR TITLE
ci(soak): repair dataset generator and bench filter in soak lane

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -45,9 +45,7 @@ jobs:
           scripts/gen_dataset.sh "${{ matrix.format }}" "${{ matrix.codepage }}" "${{ matrix.size }}" "${DATASET}"
           echo "DATASET=${DATASET}" >> "$GITHUB_ENV"
 
-      - name: Run benches (BENCH_FILTER=all)
-        env:
-          BENCH_FILTER: all
+      - name: Run benches (BENCH_FILTER=slo_validation)
         run: |
           : "${DATASET:?missing dataset path}"
           BENCH_INPUT="${DATASET}" bash scripts/bench.sh

--- a/scripts/gen_dataset.sh
+++ b/scripts/gen_dataset.sh
@@ -73,7 +73,9 @@ CODEPAGE_CODECS = {
     "cp037": "cp037",
     "cp273": "cp273",
     "cp500": "cp500",
-    "cp1047": "cp1047",
+    # Python's codecs has no cp1047; cp037 is identical to cp1047 for the
+    # characters this generator emits (A-Z, 0-9, space).
+    "cp1047": "cp037",
     "cp1140": "cp1140",
 }
 


### PR DESCRIPTION
<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
# Pull Request

## Summary

Repairs two harness defects in the `soak.yml` lane so the soak matrix can actually run (failing run: https://github.com/EffortlessMetrics/copybook-rs/actions/runs/30406673433):

1. **Dataset generator (`scripts/gen_dataset.sh`)**: the codec-name mapping mapped `cp1047` to a Python codec that does not exist, so every `cp1047` matrix cell died with `LookupError: unknown encoding: cp1047`. Python's `codecs` provides `cp037`, `cp273`, `cp500`, and `cp1140`, but **not** `cp1047`. `cp1047` is now aliased to `cp037`, which is byte-identical to cp1047 for the only characters this generator emits (`A-Z`, `0-9`, space).
2. **Bench step (`.github/workflows/soak.yml`)**: the step ran with `BENCH_FILTER=all`, which `cargo bench` / criterion treat as a benchmark-name *substring* filter. `all` only matches benchmark ids containing "all" (e.g. `parallel_scaling`), so the `slo_validation` group never ran and `scripts/bench.sh` failed reading `target/criterion/slo_validation/display_heavy_slo_80mbps/new/estimates.json`. The override is dropped so `bench.sh` uses its default `slo_validation` filter — the same path `perf.yml` and `just perf` already use. Nothing downstream of the step (receipt builder, `soak-aggregate`, step summary, check-run) consumes any benchmark other than the two `slo_validation` ones, and the benches generate their own data (`BENCH_INPUT` is unused by `copybook-bench`).

## Type of Change

- [ ] Feature (new functionality)
- [ ] Bugfix (fixes an issue)
- [ ] Refactor (code improvement without behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (README, docs/, code comments)
- [ ] Tests (test additions or improvements)
- [x] CI/CD (workflow or tooling changes)
- [ ] Chore (dependencies, formatting, etc.)

## COBOL/Mainframe Context

- **COBOL features affected**: none (CI harness only; generated soak datasets for cp1047 now encode with the cp037 alias, identical for the generator's character set)
- **Data processing impact**: none on product code paths
- **Mainframe compatibility**: cp037/cp1047 differ only outside the invariant EBCDIC subset used by the generator

## Workspace Crates Affected

None — no crate code changed. Only `scripts/gen_dataset.sh` and `.github/workflows/soak.yml`.

## Checklist

- [x] Tests added/updated (or N/A for docs-only changes) — N/A, CI harness; validated locally (see below)
- [x] Documentation updated (AGENTS.md, tool adapters, docs/, or inline comments if needed) — inline comment added at the codec mapping; no convention docs affected
- [x] CHANGELOG.md updated (if user-facing change) — N/A, CI-only
- [x] `cargo fmt --all` passes — N/A, no Rust changes
- [x] `cargo clippy --workspace -- -D warnings -W clippy::pedantic` passes — N/A, no Rust changes
- [x] `cargo test --workspace` passes (or `cargo nextest run --workspace`) — N/A, no Rust changes
- [x] `bash scripts/ci/governance-bdd-smoke.sh` passes (if governance or BDD touched) — N/A
- [x] Follows [conventional commit format](https://www.conventionalcommits.org/) (e.g., `feat(core):`, `fix(codec):`)
- [x] MSRV compliance (Rust 1.92+) verified if dependencies changed — no dependency changes
- [x] Golden fixtures updated if applicable — N/A

## Testing Instructions

```bash
# Generator: every codepage in the soak matrix, both formats
for cp in cp037 cp273 cp500 cp1047 cp1140 ascii; do
  for fmt in fixed rdw; do
    scripts/gen_dataset.sh "$fmt" "$cp" 1MiB "/tmp/soak-${fmt}-${cp}.bin"
  done
done

# Determinism
SOAK_SEED=soak-fixed-mixed-128MiB-cp1047 scripts/gen_dataset.sh fixed cp1047 2MiB /tmp/a.bin
SOAK_SEED=soak-fixed-mixed-128MiB-cp1047 scripts/gen_dataset.sh fixed cp1047 2MiB /tmp/b.bin
cmp /tmp/a.bin /tmp/b.bin

# Bench receipt path now used by the soak step (default filter)
bash scripts/bench.sh
```

## Performance Impact

- [x] No performance impact expected
- [ ] Performance improvement (provide evidence below)
- [ ] Performance regression acceptable (provide justification)
- [ ] Performance tested with baseline comparison

The soak lane now runs only the `slo_validation` bench pair (previously it ran whichever benches substring-matched "all", then failed). Receipt contents are unchanged in kind.

## Infrastructure/Tooling Changes (if applicable)

**Areas modified:**
- [ ] Support matrix registry or CLI
- [ ] Performance receipt parsing or SLO evaluation
- [x] CI scripts or validation gates
- [ ] xtask automation or docs verification tools

### Validation Evidence (for infrastructure changes)

```bash
# Generator across full soak matrix (12 runs) — all OK, ~1 MiB each, exit 0
for cp in cp037 cp273 cp500 cp1047 cp1140 ascii; do for fmt in fixed rdw; do
  scripts/gen_dataset.sh "$fmt" "$cp" 1MiB "/tmp/soak-test-${fmt}-${cp}.bin"; done; done   # ✅ Pass

# cp1047 output byte-identical to cp037 with same seed (alias sanity)        # ✅ Pass (cmp clean)

# Determinism: same seed twice -> identical files                            # ✅ Pass (cmp clean)

# End-to-end: bash scripts/bench.sh (default slo_validation filter, as the
# soak step now invokes it) — benches ran, receipts written, summary and
# p50/p90/p99 appended, exit 0                                               # ✅ Pass

python3 -c "import yaml; yaml.safe_load(open('.github/workflows/soak.yml'))"  # ✅ Pass (YAML valid)
bash -n scripts/gen_dataset.sh                                                # ✅ Pass
```

Could not validate locally: the full GitHub Actions soak matrix itself (scheduled/`workflow_dispatch` lane); the next dispatch should exercise both fixes end to end.

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes with migration path (describe below)

## Enterprise Validation (if applicable)

- [x] Validated against enterprise performance targets (DISPLAY ≥80 MiB/s, COMP-3 ≥40 MiB/s) — local `bench.sh` run: DISPLAY ~1.30 GiB/s, COMP-3 ~10.9 MiB/s on this host (COMP-3 below target here is a host/runner characteristic, unrelated to this harness fix; the soak check-run reports numbers and stays neutral)

## Related Issues

Refs #626

## Additional Notes

Deliberately out of scope (follow-up candidates, not widened into this PR):

- `BENCH_FILTER=all` is still documented in `justfile` (`just perf`) and `docs/PERF_RECEIPTS.md` / `docs/TESTING_COMMANDS.md` as a way to "widen" bench scope, but as a raw criterion substring filter it does not run all benches and still breaks the receipt step in `scripts/bench.sh` / `scripts/bench-enhanced.sh`. Making `all` expand to "no filter" in those scripts would fix the documented semantics; not done here to keep this lane repair minimal.
- The soak workflow generates a dataset per matrix cell and exports it as `BENCH_INPUT`, but no bench target reads `BENCH_INPUT`; benches synthesize their own data. The dataset step is kept as-is (it is part of the lane's design), only its codec bug is fixed.
