### PR TITLE
ci(coverage): exclude copybook-bdd and copybook-bench from llvm-cov nextest run

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -85,6 +85,8 @@ jobs:
 
           cargo llvm-cov nextest \
             --workspace \
+            --exclude copybook-bench \
+            --exclude copybook-bdd \
             --locked \
             --no-report
 


### PR DESCRIPTION
# Pull Request

## Summary

The Codecov Coverage lane (`.github/workflows/coverage.yml`) fails on main with
`error: creating test list failed` because `cargo llvm-cov nextest --workspace`
tries to list the `copybook-bdd::bdd_smoke` target. That target is a custom
cucumber harness (`harness = false` in `tests/bdd/Cargo.toml`), so its `--list`
output is Gherkin scenario text (`  Scenario: Parse single-character
alphanumeric field`) rather than libtest entries ending in `: test` /
`: benchmark`, and nextest aborts before running anything.

Failing run: https://github.com/EffortlessMetrics/copybook-rs/actions/runs/30408279617

Fix: add `--exclude copybook-bench --exclude copybook-bdd` to the
`cargo llvm-cov nextest` invocation — the same exclusion already used by every
other nextest lane (`ci.yml`, `pr-insights.yml`, `docs-truth.yml`, `perf.yml`)
and by the existing llvm-cov invocation in `ci.yml` and the justfile coverage
recipe. BDD scenario output is not unit-test coverage, so nothing of value is
lost from the report.

Refs #626

## Type of Change

- [ ] Feature (new functionality)
- [ ] Bugfix (fixes an issue)
- [ ] Refactor (code improvement without behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (README, docs/, code comments)
- [ ] Tests (test additions or improvements)
- [x] CI/CD (workflow or tooling changes)
- [ ] Chore (dependencies, formatting, etc.)

## COBOL/Mainframe Context

- **COBOL features affected**: none
- **Data processing impact**: none
- **Mainframe compatibility**: none

## Workspace Crates Affected

None — workflow-only change (`.github/workflows/coverage.yml`).

## Checklist

- [x] Tests added/updated (or N/A for docs-only changes) — N/A, CI-only
- [x] Documentation updated — N/A (no behavior/API change)
- [x] CHANGELOG.md updated (if user-facing change) — N/A, CI-only
- [x] `cargo fmt --all` passes — N/A, no Rust changes
- [x] `cargo clippy --workspace -- -D warnings -W clippy::pedantic` passes — N/A, no Rust changes
- [x] `cargo test --workspace` passes (or `cargo nextest run --workspace`) — validated via the exact coverage command below
- [x] `bash scripts/ci/governance-bdd-smoke.sh` passes — N/A, governance/BDD behavior untouched
- [x] Follows [conventional commit format](https://www.conventionalcommits.org/)
- [x] MSRV compliance (Rust 1.92+) verified if dependencies changed — no dependency changes
- [x] Golden fixtures updated if applicable — N/A

## Testing Instructions

```bash
# Reproduce the original failure (pre-fix command scope):
cargo nextest list -p copybook-bdd
# => error: creating test list failed
#    for `copybook-bdd::bdd_smoke`, line "  Scenario: Parse single-character
#    alphanumeric field" did not end with the string ": test" or ": benchmark"

# Run the exact fixed lane command:
cargo llvm-cov clean --workspace
cargo llvm-cov nextest \
  --workspace \
  --exclude copybook-bench \
  --exclude copybook-bdd \
  --locked \
  --no-report

# Report steps from the workflow:
cargo llvm-cov report --json --output-path coverage.json
cargo llvm-cov report --lcov --output-path lcov.info
cargo llvm-cov report --text | tee coverage.txt
```

## Performance Impact

- [x] No performance impact expected

## Infrastructure/Tooling Changes (if applicable)

**Areas modified:**
- [x] CI scripts or validation gates

### Validation Evidence (for infrastructure changes)

Local run of the exact fixed command (Ubuntu, 32-core, cargo-llvm-cov 0.8.7,
cargo-nextest 0.9.132):

```text
$ cargo nextest list -p copybook-bdd          # pre-fix failure reproduction
error: creating test list failed
Caused by:
  for `copybook-bdd::bdd_smoke`, line "  Scenario: Parse single-character alphanumeric field" did not end with the string ": test" or ": benchmark"
(exit 104)

$ cargo llvm-cov clean --workspace && cargo llvm-cov nextest --workspace \
    --exclude copybook-bench --exclude copybook-bdd --locked --no-report
     Summary [ 113.718s] 9989 tests run: 9989 passed (85 leaky), 6 skipped
(exit 0)

$ cargo llvm-cov report --json/--lcov/--text   # workflow report steps
all three outputs non-empty  ✅
```

Caveat: validated locally on stable 1.97.1; the lane pins toolchain 1.92 in CI.
The exclusion mechanism is nextest/llvm-cov package selection, which is
toolchain-independent.
