### PR TITLE
ci(mutants): run mutation baseline on the stable test suite

### DIFF
--- a/.github/workflows/ci-mutants.yml
+++ b/.github/workflows/ci-mutants.yml
@@ -161,8 +161,7 @@ jobs:
         run: |
           cargo nextest run \
             --package ${{ matrix.crate }} \
-            --failure-output=immediate \
-            --features comprehensive-tests
+            --failure-output=immediate
 
       - name: Run mutation testing
         id: mutants

--- a/mutants.toml
+++ b/mutants.toml
@@ -21,8 +21,11 @@ build_timeout_multiplier = 2.0
 cap_lints = true
 
 # --- Feature activation ---
-# Enable comprehensive-tests feature so all code paths are exercised
-features = ["comprehensive-tests"]
+# Default features only. The comprehensive-tests feature is defined only by
+# copybook-core and copybook-codec and includes aspirational known-failing
+# tests (see ci-comprehensive.yml), so enabling it here broke the baseline
+# for every other matrix crate (#626). Mutation runs against the same stable
+# test suite that gates main.
 
 # --- Source file targeting ---
 # Focus mutation testing on production-critical crates


### PR DESCRIPTION
## Summary

Follow-up to #630 completing the ci-mutants dispatch/schedule repair (#626):

- The baseline step and `mutants.toml` both forced `--features comprehensive-tests`.
- Only `copybook-core` and `copybook-codec` define that feature, and their comprehensive suites contain aspirational **known-failing** tests (`test_edited_pic_error_normative`, `test_edited_pic_error_detection`, `test_missing_counter_field_error`, `test_redefines_declaration_order`) that `ci-comprehensive.yml` treats as expected/non-blocking.
- Result: every other matrix crate died at feature resolution, and `copybook-core` died at its baseline — the lane could never pass on dispatch/schedule (run 30406669203).

Change: run the baseline and cargo-mutants on the same default-feature test suite that gates main (mirrors the tarpaulin fix in #629).

## Type of Change

- [x] CI/CD (workflow or tooling changes)

## Testing

- [x] `cargo nextest run --package copybook-error/-overpunch/-overflow` — green (previously failing at feature resolution)
- [x] `cargo mutants --package copybook-error --config mutants.toml --list` — discovers mutants with updated config
- [ ] End-to-end dispatch run after merge (tracked in #626)

Refs #626