### PR TITLE
ci(mutants): give copybook-core/-codec the 6h job cap for full runs

### DIFF
--- a/.github/workflows/ci-mutants.yml
+++ b/.github/workflows/ci-mutants.yml
@@ -99,15 +99,19 @@ jobs:
     needs: check-feature-flag
     if: needs.check-feature-flag.outputs.enabled == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # copybook-core/-codec are too large for a 60-minute full mutation run
+    # (they hit the cap exactly; see #626); give them the 6h job maximum.
+    timeout-minutes: ${{ matrix.timeout || 60 }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - crate: copybook-core
             threshold: 75
+            timeout: 360
           - crate: copybook-codec
             threshold: 75
+            timeout: 360
           - crate: copybook-error
             threshold: 70
           - crate: copybook-overpunch


### PR DESCRIPTION
## Summary

Final piece of the ci-mutants repair (#626): after #630 + #633 fixed the baseline, a full dispatch run proved 11/13 matrix crates green — but `copybook-core` and `copybook-codec` hit the 60-minute job timeout exactly (02:47 → 03:47) because a full cargo-mutants pass over the two largest crates takes longer.

Change: `timeout-minutes: ${{ matrix.timeout || 60 }}` with `timeout: 360` (the GitHub job maximum) on just those two matrix entries. No other behavior change.

Proof of the repaired lane: https://github.com/EffortlessMetrics/copybook-rs/actions/runs/30417771800 (11 crates green incl. all previously failing ones; only the two timeouts remained).

## Type of Change

- [x] CI/CD (workflow or tooling changes)

Refs #626

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mutation-testing workflow time limits.
  * Extended testing time for core and codec components to support longer-running checks.
  * Preserved existing quality thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->