### PR TITLE
fix(bench): make BENCH_FILTER=all run all benchmarks as documented

### DIFF
--- a/scripts/bench-enhanced.sh
+++ b/scripts/bench-enhanced.sh
@@ -4,8 +4,15 @@ set -euo pipefail
 
 # Run only the SLO validation benchmarks to capture throughput receipts by default.
 # tripwire: no-op change to trigger perf workflow without affecting behavior.
-# Allow callers to widen scope by exporting BENCH_FILTER.
+# Allow callers to widen scope by exporting BENCH_FILTER. The documented value
+# "all" means every benchmark: criterion treats the filter as a substring
+# match, so passing the literal "all" would skip the slo_validation benches
+# and break the receipt step below. Translate it to an empty filter instead.
 BENCH_FILTER="${BENCH_FILTER:-slo_validation}"
+bench_filter_args=()
+if [ "${BENCH_FILTER}" != "all" ]; then
+  bench_filter_args+=("${BENCH_FILTER}")
+fi
 
 # Capture build profile and target CPU flags. Default is x86-64-v3 (not
 # native): cached CI artifacts compiled for one runner CPU SIGILL when
@@ -13,7 +20,7 @@ BENCH_FILTER="${BENCH_FILTER:-slo_validation}"
 BUILD_PROFILE="${BUILD_PROFILE:-release}"
 TARGET_CPU="${TARGET_CPU:-x86-64-v3}"
 RUSTFLAGS="-C target-cpu=${TARGET_CPU}" PERF=1 \
-  cargo bench -p copybook-bench -- "${BENCH_FILTER}" --quiet
+  cargo bench -p copybook-bench -- "${bench_filter_args[@]}" --quiet
 
 # Function to detect WSL2 environment
 detect_wsl2() {

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -4,14 +4,21 @@ set -euo pipefail
 
 # Run only the SLO validation benchmarks to capture throughput receipts by default.
 # tripwire: no-op change to trigger perf workflow without affecting behavior.
-# Allow callers to widen scope by exporting BENCH_FILTER.
+# Allow callers to widen scope by exporting BENCH_FILTER. The documented value
+# "all" means every benchmark: criterion treats the filter as a substring
+# match, so passing the literal "all" would skip the slo_validation benches
+# and break the receipt step below. Translate it to an empty filter instead.
 BENCH_FILTER="${BENCH_FILTER:-slo_validation}"
+bench_filter_args=()
+if [ "${BENCH_FILTER}" != "all" ]; then
+  bench_filter_args+=("${BENCH_FILTER}")
+fi
 # Pin x86-64-v3 instead of native: CI restores rust-cache artifacts across
 # heterogeneous runner CPUs, and native-compiled cached proc macros/binaries
 # SIGILL when executed on a different CPU generation. v3 (AVX2) is supported
 # by all GitHub-hosted runners and keeps receipts cache-safe and comparable.
 RUSTFLAGS="-C target-cpu=x86-64-v3" PERF=1 \
-  cargo bench -p copybook-bench -- "${BENCH_FILTER}" --quiet
+  cargo bench -p copybook-bench -- "${bench_filter_args[@]}" --quiet
 
 python3 <<'PY'
 import datetime


### PR DESCRIPTION
## Summary

`BENCH_FILTER=all` is advertised in the justfile, `docs/PERF_RECEIPTS.md`, and `docs/TESTING_COMMANDS.md`, but criterion treats the filter as a substring match — the literal `all` only matched benchmark ids containing "all" (e.g. `parallel_scaling`) and skipped `slo_validation` entirely, which crashed the receipt step with a missing `estimates.json` (this was one of the two soak-lane failures in #626, worked around there by removing the env override).

Fix: translate `all` to an empty filter (criterion runs everything) in both `scripts/bench.sh` and `scripts/bench-enhanced.sh`; every other value passes through unchanged, and the receipt step still finds the `slo_validation` outputs because all benches ran.

## Type of Change

- [x] Bugfix (fixes an issue)

## Testing

- [x] `bash -n` both scripts
- [x] Argument construction verified for both modes (filter passed through; zero args for `all`)
- [ ] Full bench run (same code path as the soak fix in #631, proven green in run 30417772671)

Refs #626