### PR TITLE
docs: make delegated PR operations agentic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,7 @@ Canonical references include:
 | ODO and RENAMES behavior | `docs/design/NESTED_ODO_BEHAVIOR.md`, `docs/design/RENAMES_NESTED_GROUPS.md` |
 | Stability and support | `docs/STABILITY_GUARANTEES.md`, `docs/SUPPORT_POLICY.md` |
 | Release procedure | `docs/RELEASE_RUNBOOK.md` |
+| Agentic PR operations | `docs/design/AGENTIC_PR_OPERATIONS.md` |
 
 ## Build and test commands
 
@@ -272,3 +273,11 @@ are green, and actionable feedback is resolved. After merge, sync the target
 branch and remove only the branch, worktree, and temporary artifacts created by
 the lane. Capture genuine remaining work as a focused issue instead of widening
 the merged concern.
+
+When a maintainer delegates issue-by-issue and PR-by-PR work, addressing and
+resolving actionable review-bot comments is normal lane authority after the
+requested behavior is implemented and proven. Do not stop for per-comment
+authorization. Stop only for ambiguity, material scope expansion, conflicting
+feedback, force-push or direct-main requests, release/deployment actions,
+secrets, or another boundary listed in
+`docs/design/AGENTIC_PR_OPERATIONS.md`.

--- a/docs/MERGE_PROTOCOL.md
+++ b/docs/MERGE_PROTOCOL.md
@@ -8,6 +8,24 @@
 - Make merge behavior reproducible and auditable
 - Provide clear validation evidence for each PR
 
+## Agentic Review Loop
+
+When a maintainer delegates an issue and PR queue, routine review-bot handling
+is part of the normal merge protocol. The agent addresses every actionable
+comment that remains within the selected concern, runs the relevant proof,
+pushes the reviewed head, and resolves the addressed thread. A second
+authorization is not required for those routine operations.
+
+The agent still stops for ambiguous or conflicting feedback, material scope
+expansion, force-push or direct-main requests, release or deployment actions,
+secrets, or missing required checks. Informational, duplicate, outdated, and
+rate-limit bot messages do not block a lane by themselves. The complete state
+machine and authority boundary live in
+[`docs/design/AGENTIC_PR_OPERATIONS.md`](design/AGENTIC_PR_OPERATIONS.md).
+
+The merge decision must use the current GitHub head: required checks are green,
+the PR is mergeable, and no actionable review thread remains unresolved.
+
 ## Local Gates
 
 ### Hard Gate (Required for ALL infra PRs)

--- a/docs/MERGE_PROTOCOL.md
+++ b/docs/MERGE_PROTOCOL.md
@@ -153,14 +153,17 @@ If post-merge validation fails:
 
 ### 5. CI Stability Note
 
-If GitHub Actions are unstable at merge time, add to PR before merging:
+If GitHub Actions are unstable at merge time, do not merge around the required
+checks. Record local evidence in the PR while waiting for the current GitHub
+checks to recover, or stop and request direction if the required check cannot
+be restored:
 
 ```markdown
 ## CI Status
 
 GitHub Actions currently unstable (rustc ICE / environment issues).
-Local semantic validation (`./scripts/ci/offline-semantic.sh`) is the
-gating signal for this merge.
+Local semantic validation (`./scripts/ci/offline-semantic.sh`) is supporting
+evidence only; required GitHub checks must still be green before merge.
 
 Evidence: [paste offline-semantic output]
 ```
@@ -244,18 +247,21 @@ See `docs/VALIDATION_PROTOCOL.md` for more examples.
 # On PR branch
 git checkout <branch-name>
 git fetch origin
-git rebase origin/main
+git merge --no-edit origin/main
 
 # Resolve conflicts
 git add <resolved-files>
-git rebase --continue
+git commit
 
-# Force push (rebased)
-git push --force-with-lease origin <branch-name>
+# Publish the non-rewriting update
+git push origin <branch-name>
 
 # Re-run validation
 ./scripts/ci/offline-semantic.sh
 ```
+
+If resolving the conflict requires a product decision or expands the selected
+concern, stop and request direction rather than rewriting the remote branch.
 
 ## Validation Protocol Reference
 

--- a/docs/MERGE_RUNBOOK_CI_DOWN.md
+++ b/docs/MERGE_RUNBOOK_CI_DOWN.md
@@ -259,12 +259,16 @@ Update `MERGE_STATUS.md`:
 ```bash
 git checkout <branch>
 git fetch origin main
-git rebase origin/main
+git merge --no-edit origin/main
 
 # Resolve conflicts, then:
-git rebase --continue
-git push origin <branch> --force-with-lease
+git add <resolved-files>
+git commit
+git push origin <branch>
 ```
+
+If the conflict cannot be resolved without a product decision or scope
+expansion, stop and request direction. Do not rewrite the remote branch.
 
 ### "Cargo lock contention in WSL"
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,8 @@ Start with **[START_HERE.md](START_HERE.md)** for the hand-maintained navigation
 
 ### Architecture
 - [Architecture Decision Records](adr/) -- ADRs for significant decisions
-- [Design docs](design/) -- ODO, RENAMES, feature contracts
+- [Design docs](design/) -- behavior contracts and agentic PR operations
+- [Agentic PR Operations](design/AGENTIC_PR_OPERATIONS.md) -- delegated lane authority and review-to-merge state machine
 - [Internal feature specs](internal/features/) -- dialect lever, edited PIC
 
 ### Diataxis Framework

--- a/docs/VALIDATION_PROTOCOL.md
+++ b/docs/VALIDATION_PROTOCOL.md
@@ -243,8 +243,10 @@ Compare to tool output in summary.
 
 ### CI Instability
 - GitHub Actions may be temporarily unreliable
-- Local validation via `offline-semantic.sh` is sufficient for merge readiness
-- Full CI validation will happen when Actions stabilizes
+- Local validation via `offline-semantic.sh` is supporting evidence, not a
+  substitute for required GitHub checks
+- Do not merge while a required check is missing, stale, or failing; wait for
+  recovery or request direction
 
 ---
 

--- a/docs/design/AGENTIC_PR_OPERATIONS.md
+++ b/docs/design/AGENTIC_PR_OPERATIONS.md
@@ -1,0 +1,86 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+# Agentic PR Operations
+
+## Intent
+
+When a maintainer delegates an issue and PR queue to an agent, routine PR
+operations are part of the delegated work. The agent should carry a focused
+lane from discovery through merge using current repository and GitHub evidence,
+without stopping for a second authorization for every normal review-bot action.
+
+This design preserves maintainer control at the boundaries that can change
+scope, provenance, release state, or user intent.
+
+## Default authority for a delegated lane
+
+After a maintainer asks an agent to work issue by issue and PR by PR, the agent
+may perform these normal in-scope operations for the selected lane:
+
+- create or reuse an isolated worktree and branch;
+- edit, test, commit, and push the focused change;
+- open, update, mark ready, and merge the corresponding PR when its merge
+  contract is satisfied;
+- inspect every review-bot comment, implement all actionable comments that fit
+  the lane, and resolve each addressed thread;
+- leave informational, duplicate, outdated, or rate-limit notices as
+  non-blocking review metadata.
+
+Resolving a thread is an evidence operation, not a separate product decision,
+when the implementation addresses the exact comment and the relevant proof is
+green. The agent records the addressed behavior and proof in the PR summary or
+handoff.
+
+The agent must stop and request direction for any of the following:
+
+- conflicting or ambiguous review feedback that needs a product decision;
+- a requested change that materially widens the issue or PR concern;
+- force-push, direct mutation of `origin/main`, tag, publish, deploy, or secret
+  handling;
+- a merge decision when required checks are failing, stale, missing, or the
+  current diff has unresolved actionable feedback;
+- an external coordination or permission boundary that cannot be satisfied
+  from the delegated repository workflow.
+
+## Review-to-merge state machine
+
+Each selected lane follows this sequence:
+
+1. Refresh the branch, worktree, issue, PR, checks, and review threads.
+2. Classify comments as actionable, informational, duplicate, outdated, or
+   external. Only actionable comments can change the patch.
+3. Implement each in-scope actionable comment and run the narrowest decisive
+   proof before broader gates.
+4. Push the exact reviewed head. Re-read comments and checks after the push.
+5. Resolve addressed actionable threads. Do not resolve a comment whose
+   requested behavior is not actually proven.
+6. Merge only when the current head is mergeable, required checks are green,
+   and no actionable thread remains unresolved.
+7. Sync the target branch, preserve unrelated worktrees, and select the next
+   bounded lane.
+
+The agent must distinguish local proof, remote publication, and merged state.
+An old green check, a local-only test, or a bot rate-limit notice does not
+prove that the current PR is ready to merge.
+
+## Review-bot handling contract
+
+| Bot result | Agent action |
+| --- | --- |
+| Actionable and in scope | Fix, test, push, and resolve the thread |
+| Actionable but ambiguous or widening scope | Stop and request direction |
+| Informational or approval | Record if useful, no patch required |
+| Duplicate or outdated | Preserve the evidence, no duplicate fix |
+| Rate-limited or unavailable | Continue with repository checks and other review evidence; do not treat availability as approval |
+
+This contract applies equally to inline comments and top-level automated review
+summaries. A review-bot comment is not a reason to abandon a bounded lane, and
+an absent bot review is not a reason to claim review coverage that did not run.
+
+## Invariants
+
+- One issue and one semantic concern remain active at a time.
+- Every code change has a focused witness and a repository-appropriate gate.
+- Every resolved actionable comment maps to a changed line, test, or explicit
+  proof in the PR.
+- No unrelated dirty worktree or neighboring worktree is discarded.
+- Publication and merge are claimed only from live GitHub state.

--- a/docs/diataxis.manifest.yml
+++ b/docs/diataxis.manifest.yml
@@ -150,6 +150,7 @@ categories:
       - docs/archived/  # All archived docs (gate receipts, issue specs, historical content)
       - docs/api/structural-validation.md
       - docs/backlog/benchmark_tooling.md
+      - docs/design/AGENTIC_PR_OPERATIONS.md
       - docs/design/DETERMINISM_CLI.md
       - docs/design/NESTED_ODO_BEHAVIOR.md
       - docs/design/RENAMES_NESTED_GROUPS.md


### PR DESCRIPTION
## What this does

Delegated issue-by-issue PR work had no repository-level rule that routine review-bot feedback could be addressed and resolved as part of normal operations. That ambiguity can stop a validated lane after the implementation and required checks are complete.

**Change:** define a canonical agentic PR operations contract, link it from the repository guide and documentation index, and align the merge protocol with its review-to-merge state machine. The contract grants routine authority for in-scope bot feedback while preserving explicit stops for ambiguity, scope expansion, force-push or direct-main requests, release actions, secrets, and missing required checks. There is no runtime or public API change.

## Verification

| Check | Result |
| --- | --- |
| `git diff --cached --check` | clean |
| `xtask docs verify-support-matrix` | 7 features verified |
| canonical design link and file checks | present |

## Review map

- `docs/design/AGENTIC_PR_OPERATIONS.md`: authority boundary, review classification, evidence state machine, and invariants.
- `AGENTS.md`: repository-level default authority and explicit stop conditions.
- `docs/MERGE_PROTOCOL.md`: merge-loop alignment and current-head requirement.
- `docs/README.md`: discoverability from the architecture documentation index.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for delegated pull request review and merge workflows.
  * Documented how actionable review feedback is handled, verified, and resolved.
  * Clarified stopping conditions, including ambiguous requests, scope changes, permission limits, failing checks, and release or deployment actions.
  * Added a review-to-merge process covering state validation, proof of changes, synchronization, and merge readiness.
  * Updated the documentation index to include the new agentic operations guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->