### PR TITLE
ci: deny explicit panic macros in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
     - uses: actions/checkout@v7
       with:
         fetch-depth: 2
+        persist-credentials: false
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: rustfmt
@@ -45,6 +46,7 @@ jobs:
     - uses: actions/checkout@v7
       with:
         fetch-depth: 2
+        persist-credentials: false
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+      with:
+        fetch-depth: 2
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: rustfmt
@@ -41,6 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+      with:
+        fetch-depth: 2
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: clippy
@@ -59,6 +63,14 @@ jobs:
           -A clippy::print_stderr \
           -A clippy::duplicated_attributes \
           -A deprecated
+    - name: Fetch PR base for panic policy
+      if: github.event_name == 'pull_request'
+      run: git fetch --no-tags --depth=1 origin ${{ github.event.pull_request.base.sha }}:refs/remotes/origin/panic-policy-base
+    - name: Reject new explicit panic macros
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha || 'HEAD~1' }}
+        HEAD_SHA: HEAD
+      run: bash scripts/check_no_new_test_panic.sh
     - name: Enforce panic prevention lints (shipped targets)
       run: cargo clippy --workspace --lib --bins --examples --all-features -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::unreachable -D clippy::todo -D clippy::unimplemented
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           -- -D warnings \
           -A clippy::unwrap_used \
           -A clippy::expect_used \
-          -A clippy::panic \
+          -D clippy::panic \
           -A clippy::dbg_macro \
           -A clippy::print_stdout \
           -A clippy::print_stderr \

--- a/.github/workflows/feature-flags.yml
+++ b/.github/workflows/feature-flags.yml
@@ -146,7 +146,7 @@ jobs:
           cargo clippy --workspace --tests -- -D warnings \
             -A clippy::unwrap_used \
             -A clippy::expect_used \
-            -A clippy::panic \
+            -D clippy::panic \
             -A clippy::dbg_macro \
             -A clippy::print_stdout \
             -A clippy::print_stderr \

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -63,7 +63,7 @@ jobs:
           cargo clippy --workspace --tests --all-features -- -D warnings \
             -A clippy::unwrap_used \
             -A clippy::expect_used \
-            -A clippy::panic \
+            -D clippy::panic \
             -A clippy::dbg_macro \
             -A clippy::print_stdout \
             -A clippy::print_stderr \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,7 @@ just build-release         # release build
 just test                  # cargo nextest run (excludes bdd + bench crates)
 just test-crate <crate>    # nextest for one crate
 just bdd-smoke             # gated Cucumber smoke suite
-just lint                  # clippy, pedantic; tests get panic-family allows
+just lint                  # clippy, pedantic; tests deny explicit panic macros
 just fmt / just fmt-check  # rustfmt
 just deny                  # cargo-deny (licenses, advisories, bans)
 just docs                  # cargo doc --workspace --no-deps
@@ -179,8 +179,10 @@ sampled locally via `just scheduled`.
 - Keep shipped code safe and fallible: no new `unsafe` (workspace lints forbid
   `unsafe_code`), no panic-family calls (`unwrap`/`expect`/`panic!`/
   `unreachable!`/`todo!`/`unimplemented!`) or unchecked indexing in shipped
-  code without a documented, governed exception. Clippy warns on these; the
-  lint gate allows them only in tests.
+  code without a documented, governed exception. Clippy denies these in
+  shipped targets; test targets retain only the existing unwrap/expect
+  allowances, deny explicit `panic!` macros, and reject newly added panic
+  macros even when an older file-level allow exists.
 - Clippy pedantic compliance is enforced in CI; match idiomatic patterns
   already in the codebase (`div_ceil`, `is_empty`, range `contains`,
   `try_from()` conversions, `Display` for user-facing types).

--- a/docs/TESTING_COMMANDS.md
+++ b/docs/TESTING_COMMANDS.md
@@ -24,6 +24,7 @@ This document provides a canonical reference for all testing commands in copyboo
 | **Format Check** | `cargo fmt --all --check` | PR-gate | < 1 min | None |
 | **Clippy (Libs/Bins/Examples)** | `cargo clippy --workspace --lib --bins --examples --all-features -- -D warnings -W clippy::pedantic` | PR-gate | 2-3 min | None |
 | **Clippy (Tests)** | `cargo clippy --workspace --tests --all-features -- -D warnings -A clippy::unwrap_used -A clippy::expect_used -D clippy::panic -A clippy::dbg_macro -A clippy::print_stdout -A clippy::print_stderr -A clippy::duplicated_attributes` | PR-gate | 1-2 min | None |
+| **New Test Panic Guard** | `BASE_SHA=$(git merge-base origin/main HEAD) HEAD_SHA=$(git rev-parse HEAD) bash scripts/check_no_new_test_panic.sh` | PR-gate | < 1 min | None |
 | **Clippy (Panic Prevention)** | `cargo clippy --workspace --lib --bins --examples --all-features -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::unreachable -D clippy::todo -D clippy::unimplemented` | PR-gate | 2-3 min | None |
 | **Unit Tests (nextest)** | `cargo nextest run --workspace --exclude copybook-bench --profile ci --failure-output=immediate --status-level=fail` | PR-gate | 3-5 min | None |
 | **Doctests** | `RUSTDOCFLAGS="--deny warnings" cargo test --doc --workspace --exclude copybook-bench` | PR-gate | 1-2 min | None |
@@ -129,6 +130,15 @@ cargo clippy --workspace --tests --all-features \
   -A clippy::print_stdout \
   -A clippy::print_stderr \
   -A clippy::duplicated_attributes
+```
+
+Run the diff guard with the PR base and current head to reject newly added
+explicit `panic!` macros, including files with older lint allowances:
+
+```bash
+BASE_SHA=$(git merge-base origin/main HEAD) \
+HEAD_SHA=$(git rev-parse HEAD) \
+bash scripts/check_no_new_test_panic.sh
 ```
 
 **Expected runtime**: 1-2 minutes
@@ -832,7 +842,7 @@ just ci
 ```
 
 **What it does**:
-- Phase 1: Quick gates (fmt → clippy → build → nextest → doctests)
+- Phase 1: Quick gates (fmt → clippy → panic guard → build → nextest → doctests)
 - Phase 2: Security gates (deny + conditional audit)
 
 **Expected runtime**: 5-10 minutes (cold), 2-5 minutes (warm)
@@ -866,6 +876,13 @@ cargo clippy --workspace --tests --all-features \
   -A clippy::print_stdout \
   -A clippy::print_stderr \
   -A clippy::duplicated_attributes
+```
+
+#### New Explicit Test Panic Guard
+```bash
+BASE_SHA=$(git merge-base origin/main HEAD) \
+HEAD_SHA=$(git rev-parse HEAD) \
+bash scripts/check_no_new_test_panic.sh
 ```
 
 #### Unit Tests

--- a/docs/TESTING_COMMANDS.md
+++ b/docs/TESTING_COMMANDS.md
@@ -113,7 +113,9 @@ cargo clippy --workspace --tests --all-features \
 
 **What it validates**:
 - All test code passes clippy lints
-- Common test patterns (unwrap, expect, panic, dbg!, print!) are allowed
+- Unwrap/expect remain allowed for existing test helpers; explicit `panic!`
+  macros are denied, and the panic-policy guard rejects newly added macros
+- Debug and output helpers remain allowed where the test gate permits them
 - All warnings are still treated as errors
 
 **How to run locally**:

--- a/docs/TESTING_COMMANDS.md
+++ b/docs/TESTING_COMMANDS.md
@@ -23,7 +23,7 @@ This document provides a canonical reference for all testing commands in copyboo
 |------------|---------------|----------------|------------------|-------------------|
 | **Format Check** | `cargo fmt --all --check` | PR-gate | < 1 min | None |
 | **Clippy (Libs/Bins/Examples)** | `cargo clippy --workspace --lib --bins --examples --all-features -- -D warnings -W clippy::pedantic` | PR-gate | 2-3 min | None |
-| **Clippy (Tests)** | `cargo clippy --workspace --tests --all-features -- -D warnings -A clippy::unwrap_used -A clippy::expect_used -A clippy::panic -A clippy::dbg_macro -A clippy::print_stdout -A clippy::print_stderr -A clippy::duplicated_attributes` | PR-gate | 1-2 min | None |
+| **Clippy (Tests)** | `cargo clippy --workspace --tests --all-features -- -D warnings -A clippy::unwrap_used -A clippy::expect_used -D clippy::panic -A clippy::dbg_macro -A clippy::print_stdout -A clippy::print_stderr -A clippy::duplicated_attributes` | PR-gate | 1-2 min | None |
 | **Clippy (Panic Prevention)** | `cargo clippy --workspace --lib --bins --examples --all-features -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::unreachable -D clippy::todo -D clippy::unimplemented` | PR-gate | 2-3 min | None |
 | **Unit Tests (nextest)** | `cargo nextest run --workspace --exclude copybook-bench --profile ci --failure-output=immediate --status-level=fail` | PR-gate | 3-5 min | None |
 | **Doctests** | `RUSTDOCFLAGS="--deny warnings" cargo test --doc --workspace --exclude copybook-bench` | PR-gate | 1-2 min | None |
@@ -104,7 +104,7 @@ cargo clippy --workspace --tests --all-features \
   -- -D warnings \
   -A clippy::unwrap_used \
   -A clippy::expect_used \
-  -A clippy::panic \
+  -D clippy::panic \
   -A clippy::dbg_macro \
   -A clippy::print_stdout \
   -A clippy::print_stderr \
@@ -122,7 +122,7 @@ cargo clippy --workspace --tests --all-features \
   -- -D warnings \
   -A clippy::unwrap_used \
   -A clippy::expect_used \
-  -A clippy::panic \
+  -D clippy::panic \
   -A clippy::dbg_macro \
   -A clippy::print_stdout \
   -A clippy::print_stderr \
@@ -859,7 +859,7 @@ cargo clippy --workspace --tests --all-features \
   -- -D warnings \
   -A clippy::unwrap_used \
   -A clippy::expect_used \
-  -A clippy::panic \
+  -D clippy::panic \
   -A clippy::dbg_macro \
   -A clippy::print_stdout \
   -A clippy::print_stderr \

--- a/justfile
+++ b/justfile
@@ -67,7 +67,7 @@ lint:
     cargo clippy --workspace --tests --all-features -- -D warnings \
       -A clippy::unwrap_used \
       -A clippy::expect_used \
-      -A clippy::panic \
+      -D clippy::panic \
       -A clippy::dbg_macro \
       -A clippy::print_stdout \
       -A clippy::print_stderr \

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,6 +11,7 @@ Automation and utility scripts for copybook-rs development and CI/CD.
 ## Repository Checks
 - **check-public-result-docs.sh** - Rust-backed public `Result` API documentation and attribute guard
 - **check_no_unwrap_expect.sh** - Rust-backed panic-call guard
+- **check_no_new_test_panic.sh** - diff-based guard against new `panic!` macros
 - **guard-hotpaths.sh** - Rust-backed hot-path allocation guard
 
 ## Development Automation

--- a/scripts/check_no_new_test_panic.sh
+++ b/scripts/check_no_new_test_panic.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -euo pipefail
+
+base_sha="${BASE_SHA:-$(git merge-base origin/main HEAD 2>/dev/null || echo HEAD~1)}"
+head_sha="${HEAD_SHA:-HEAD}"
+
+if ! git rev-parse --verify "${base_sha}^{commit}" >/dev/null 2>&1; then
+  printf 'error: cannot resolve panic-policy baseline %s\n' "$base_sha" >&2
+  exit 1
+fi
+
+if violations="$(git diff --unified=0 "${base_sha}"..."${head_sha}" -- '*.rs' | awk '
+  /^\+\+\+ b\// { path = substr($0, 7); next }
+  /^\+/ && !/^\+\+\+/ && /panic![[:space:]]*\(/ {
+    print path ":" substr($0, 2)
+    found = 1
+  }
+  END { exit found ? 1 : 0 }
+')"; then
+  exit 0
+fi
+
+printf 'error: new explicit panic macro in test or shipped Rust source:\n%s\n' "$violations" >&2
+exit 1

--- a/scripts/check_no_new_test_panic.sh
+++ b/scripts/check_no_new_test_panic.sh
@@ -15,12 +15,46 @@ if ! git rev-parse --verify "${head_sha}^{commit}" >/dev/null 2>&1; then
 fi
 
 if violations="$(git diff --unified=0 "${base_sha}" "${head_sha}" -- '*.rs' | awk '
-  /^\+\+\+ b\// { path = substr($0, 7); next }
-  /^\+/ && !/^\+\+\+/ && /panic![[:space:]]*\(/ {
-    print path ":" substr($0, 2)
+  function report() {
+    print path ":" pending_line
     found = 1
+    pending = 0
   }
-  END { exit found ? 1 : 0 }
+
+  /^\+\+\+ b\// {
+    if (pending) report()
+    path = substr($0, 7)
+    pending = 0
+    next
+  }
+
+  /^@@/ {
+    if (pending) report()
+    pending = 0
+    next
+  }
+
+  {
+    added = /^\+/ && !/^\+\+\+/
+    line = substr($0, 2)
+
+    if (pending && !/^-/ && line ~ /^[[:space:]]*[({[]/) {
+      report()
+    }
+
+    if (added && line ~ /panic![[:space:]]*[({[]/) {
+      pending_line = line
+      report()
+    } else if (added && line ~ /panic!/) {
+      pending_line = line
+      pending = 1
+    }
+  }
+
+  END {
+    if (pending) report()
+    exit found ? 1 : 0
+  }
 ')"; then
   exit 0
 fi

--- a/scripts/check_no_new_test_panic.sh
+++ b/scripts/check_no_new_test_panic.sh
@@ -10,6 +10,10 @@ if ! git rev-parse --verify "${base_sha}^{commit}" >/dev/null 2>&1; then
   exit 1
 fi
 
+if ! git rev-parse --verify "${head_sha}^{commit}" >/dev/null 2>&1; then
+  head_sha=HEAD
+fi
+
 if violations="$(git diff --unified=0 "${base_sha}"..."${head_sha}" -- '*.rs' | awk '
   /^\+\+\+ b\// { path = substr($0, 7); next }
   /^\+/ && !/^\+\+\+/ && /panic![[:space:]]*\(/ {

--- a/scripts/check_no_new_test_panic.sh
+++ b/scripts/check_no_new_test_panic.sh
@@ -14,7 +14,7 @@ if ! git rev-parse --verify "${head_sha}^{commit}" >/dev/null 2>&1; then
   head_sha=HEAD
 fi
 
-if violations="$(git diff --unified=0 "${base_sha}"..."${head_sha}" -- '*.rs' | awk '
+if violations="$(git diff --unified=0 "${base_sha}" "${head_sha}" -- '*.rs' | awk '
   /^\+\+\+ b\// { path = substr($0, 7); next }
   /^\+/ && !/^\+\+\+/ && /panic![[:space:]]*\(/ {
     print path ":" substr($0, 2)

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -26,7 +26,7 @@ Runs fmt, clippy, build, tests, governance microcrate checks, BDD smoke, and doc
 # What it does:
 # 1. cargo fmt --all --check
 # 2. cargo clippy (pedantic, libs/bins/examples, -D warnings)
-# 3. cargo clippy (tests, allows unwrap/expect/panic/dbg/print, still -D warnings)
+# 3. cargo clippy (tests, denies panic and allows selected test-only lints)
 # 4. cargo build --workspace --release
 # 5. cargo nextest run (bounded parallelism)
 # 6. scripts/ci/governance-bdd-smoke.sh

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -27,10 +27,11 @@ Runs fmt, clippy, build, tests, governance microcrate checks, BDD smoke, and doc
 # 1. cargo fmt --all --check
 # 2. cargo clippy (pedantic, libs/bins/examples, -D warnings)
 # 3. cargo clippy (tests, denies panic and allows selected test-only lints)
-# 4. cargo build --workspace --release
-# 5. cargo nextest run (bounded parallelism)
-# 6. scripts/ci/governance-bdd-smoke.sh
-# 7. cargo test --doc (with warnings denied)
+# 4. scripts/check_no_new_test_panic.sh (rejects new explicit panic! macros)
+# 5. cargo build --workspace --release
+# 6. cargo nextest run (bounded parallelism)
+# 7. scripts/ci/governance-bdd-smoke.sh
+# 8. cargo test --doc (with warnings denied)
 ```
 
 **Expected time**: 5-10 minutes (cold), 2-5 minutes (warm)
@@ -101,13 +102,14 @@ just ci
 #   1. cargo fmt --all --check
 #   2. cargo clippy (pedantic: libs/bins/examples)
 #   3. cargo clippy (tests: denies panic, allows selected test-only lints)
-#   4. cargo build --workspace --release
-#   5. cargo nextest run (bounded parallelism)
-#   6. scripts/ci/governance-bdd-smoke.sh
-#   7. cargo test --doc (deny warnings)
+#   4. scripts/check_no_new_test_panic.sh (rejects new explicit panic! macros)
+#   5. cargo build --workspace --release
+#   6. cargo nextest run (bounded parallelism)
+#   7. scripts/ci/governance-bdd-smoke.sh
+#   8. cargo test --doc (deny warnings)
 # Phase 2: Security gates
-#   8. cargo deny check
-#   9. cargo audit (only if Cargo.lock changed)
+#   9. cargo deny check
+#   10. cargo audit (only if Cargo.lock changed)
 ```
 
 **Expected time**: 5-10 minutes (cold), 2-5 minutes (warm)

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -100,7 +100,7 @@ just ci
 # Phase 1: Quick gates
 #   1. cargo fmt --all --check
 #   2. cargo clippy (pedantic: libs/bins/examples)
-#   3. cargo clippy (tests: allows unwrap/expect/panic)
+#   3. cargo clippy (tests: denies panic, allows selected test-only lints)
 #   4. cargo build --workspace --release
 #   5. cargo nextest run (bounded parallelism)
 #   6. scripts/ci/governance-bdd-smoke.sh

--- a/scripts/ci/quick.sh
+++ b/scripts/ci/quick.sh
@@ -31,6 +31,9 @@ echo "==> Running cargo clippy (tests: deny panic, allow selected test-only lint
   -A clippy::duplicated_attributes \
   -A deprecated
 
+echo "==> Rejecting new explicit panic macros"
+bash scripts/check_no_new_test_panic.sh
+
 echo "==> Running cargo build --workspace --release"
 "$CARGO_BIN" build --workspace --release
 

--- a/scripts/ci/quick.sh
+++ b/scripts/ci/quick.sh
@@ -18,12 +18,12 @@ echo "==> Running cargo clippy (pedantic: libs/bins/examples)"
 "$CARGO_BIN" clippy --workspace --lib --bins --examples --all-features \
   -- -D warnings -W clippy::pedantic
 
-echo "==> Running cargo clippy (tests: allow common test-only lints)"
+echo "==> Running cargo clippy (tests: deny panic, allow selected test-only lints)"
 "$CARGO_BIN" clippy --workspace --tests --all-features \
   -- -D warnings \
   -A clippy::unwrap_used \
   -A clippy::expect_used \
-  -A clippy::panic \
+  -D clippy::panic \
   -A clippy::dbg_macro \
   -A clippy::print_stdout \
   -A clippy::print_stderr \

--- a/tests/e2e/e2e_cli_help_output.rs
+++ b/tests/e2e/e2e_cli_help_output.rs
@@ -35,7 +35,7 @@ fn run_help(args: &[&str]) -> Output {
         .unwrap()
         .args(args)
         .output()
-        .unwrap_or_else(|e| panic!("failed to run copybook {args:?}: {e}"));
+        .unwrap();
     assert_eq!(
         output.status.code(),
         Some(0),


### PR DESCRIPTION
Relates to #643

## What this does

The test-target Clippy gates broadly allowed `clippy::panic`, so new explicit
`panic!` macros in tests were not rejected even though issue #643 requires a
no-new-panic policy. This change makes the test gates deny `clippy::panic`,
adds a diff-based guard that rejects newly added `panic!` macros even when an
older file-level allow exists, and updates the repository guidance to match.
It also removes the one newly exposed panic macro from the CLI help E2E helper.
There is no production behavior or public API change.

The follow-up review fixes disable checkout credential persistence, document the
guard in each local PR-gate recipe, and make the detector handle all Rust macro
delimiters and line breaks.

## Verification

| Check | Result |
| --- | --- |
| `cargo fmt --all -- --check` | pass |
| strict workspace test Clippy with `-D clippy::unwrap_used -D clippy::expect_used -D clippy::panic` | pass |
| exact updated test Clippy gate | pass |
| production pedantic Clippy gate | pass |
| `BASE_SHA=origin/main HEAD_SHA=HEAD bash scripts/check_no_new_test_panic.sh` | pass |
| `bash -n scripts/check_no_new_test_panic.sh scripts/ci/quick.sh` | pass |
| CLI help/version E2E witness with built `copybook` binary | 21 passed |
| `git diff --cached --check` | clean |

## Review map

- `.github/workflows/ci.yml`, `.github/workflows/feature-flags.yml`, `.github/workflows/perf.yml`: deny explicit panic macros in test Clippy gates; CI also runs the baseline diff guard.
- `scripts/check_no_new_test_panic.sh`: rejects newly added `panic!` macros independently of file-level Clippy allows and recognizes `()`, `{}`, `[]`, and split-line forms.
- `justfile`, `scripts/ci/quick.sh`, `scripts/ci/README.md`, `scripts/README.md`, `docs/TESTING_COMMANDS.md`, `AGENTS.md`: align local policy and documentation.
- `tests/e2e/e2e_cli_help_output.rs`: remove the explicit `panic!` fallback exposed by the stricter gate.