### PR TITLE
feat(xtask): make publish plans role-aware

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -76,7 +76,7 @@ jobs:
 
         with open(sys.argv[1], encoding="utf-8") as handle:
             for crate in json.load(handle):
-                print(crate)
+                print(crate["package"])
         PY
         )
 
@@ -103,7 +103,7 @@ jobs:
 
         with open(sys.argv[1], encoding="utf-8") as handle:
             for crate in json.load(handle):
-                print(crate)
+                print(crate["package"])
         PY
         )
 
@@ -125,7 +125,7 @@ jobs:
 
         with open(sys.argv[1], encoding="utf-8") as handle:
             for crate in json.load(handle):
-                print(crate)
+                print(crate["package"])
         PY
         )
         for crate in "${PUBLISH_CRATES[@]}"; do

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -274,7 +274,7 @@ jobs:
 
         with open(sys.argv[1], encoding="utf-8") as handle:
             for crate in json.load(handle):
-                print(crate)
+                print(crate["package"])
         PY
         )
 
@@ -381,7 +381,8 @@ jobs:
         print("| Crate | crates.io | docs.rs |")
         print("|-------|-----------|---------|")
         for crate in crates:
-            print(f"| {crate} | [{version}](https://crates.io/crates/{crate}/{version}) | [docs](https://docs.rs/{crate}/{version}) |")
+            package = crate["package"]
+            print(f"| {package} | [{version}](https://crates.io/crates/{package}/{version}) | [docs](https://docs.rs/{package}/{version}) |")
         print("")
         print(f"See [CHANGELOG.md]({repo_url}/blob/{tag}/CHANGELOG.md) for details.")
         PY

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -17,19 +17,35 @@ the generated publish plan win.
 | What the post-publish smoke proves | `scripts/ci/release_smoke.sh` |
 | Versioning and compatibility policy | [STABILITY_GUARANTEES.md](STABILITY_GUARANTEES.md) |
 
-The publish plan is generated from workspace metadata at release time. The
-number of publishable packages and their dependency order come from the plan
-output — never from a hand-maintained list in documentation. If documentation
-and the plan disagree, the plan is correct and the documentation is stale.
+The publish plan is generated from workspace metadata and
+`docs/stability/surface-registry.json` at release time. The number of
+publishable packages, their roles, compatibility status, and dependency order
+come from the plan output — never from a hand-maintained list in documentation.
+If documentation and the plan disagree, the plan is correct and the
+documentation is stale.
 
 Package roles in the plan:
 
-- Component crates (`copybook-core`, `copybook-codec`, and the rest of the
-  publishable workspace) publish first, in generated dependency order.
+- Primary crates publish in generated dependency order. Conditional primary,
+  adapter, and contract packages are omitted until their registry disposition
+  selects them.
+- Active compatibility packages publish only while their recorded 0.6
+  migration window remains active; retiring and internal-tool packages are
+  excluded.
 - `copybook` is the canonical facade crate: it re-exports the component crates
   and publishes after all of its component dependencies.
 - `copybook-rs` is a redirect-only compatibility package that points users at
   the `copybook` facade. It publishes last.
+
+The JSON form is a machine-readable array of objects containing `package`,
+`version`, `role`, `dependency_reason`, and `compatibility_status`. Workflow
+consumers extract `package` for publication while preserving the metadata for
+audit, release notes, and resumable recovery.
+
+The strict planner rejects a primary package that still depends on a
+compatibility or retiring package. This is an intentional release precondition:
+until the corresponding ownership PRs converge, `publish plan --check` reports
+the owning package and publication must not proceed.
 
 ## Pre-Release Validation Gates
 

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -24,6 +24,11 @@ come from the plan output — never from a hand-maintained list in documentation
 If documentation and the plan disagree, the plan is correct and the
 documentation is stale.
 
+For the current 0.5.x patch and security-release line, the planner preserves
+the established manifest-driven package set and dependency order. The
+role-aware registry policy is applied to the 0.6 target line, so convergence
+preconditions cannot block a supported 0.5.x release.
+
 Package roles in the plan:
 
 - Primary crates publish in generated dependency order. Conditional primary,
@@ -32,6 +37,9 @@ Package roles in the plan:
 - Active compatibility packages publish only while their recorded 0.6
   migration window remains active; retiring and internal-tool packages are
   excluded.
+- Compatibility windows are selected from explicit registry dispositions and
+  exact active/deprecated plan tokens; arbitrary version-like text does not
+  activate publication.
 - `copybook` is the canonical facade crate: it re-exports the component crates
   and publishes after all of its component dependencies.
 - `copybook-rs` is a redirect-only compatibility package that points users at
@@ -46,6 +54,8 @@ The strict planner rejects a primary package that still depends on a
 compatibility or retiring package. This is an intentional release precondition:
 until the corresponding ownership PRs converge, `publish plan --check` reports
 the owning package and publication must not proceed.
+It also rejects a selected 0.6 package with a required dependency on any
+workspace package omitted by the registry policy.
 
 ## Pre-Release Validation Gates
 

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -66,10 +66,12 @@ If any step fails, do not proceed.
 
 ## 3) Capture release plan and evidence
 
-The runbook now uses the xtask-generated, role-aware publish plan as the single
-publishable crate source of truth. Its JSON entries retain package role,
+The runbook uses the xtask-generated publish plan as the single publishable
+crate source of truth. For 0.6 releases, its JSON entries retain package role,
 version, dependency reason, and compatibility status for recovery and audit;
-the workflow publishes the `package` field from each entry.
+the workflow publishes the `package` field from each entry. The planner keeps
+the established manifest-driven package set for supported 0.5.x patch and
+security releases.
 
 ```bash
 RELEASE_TAG="vX.Y.Z" # no leading whitespace

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -66,7 +66,10 @@ If any step fails, do not proceed.
 
 ## 3) Capture release plan and evidence
 
-The runbook now uses the xtask-generated publish plan as the single publishable crate source of truth.
+The runbook now uses the xtask-generated, role-aware publish plan as the single
+publishable crate source of truth. Its JSON entries retain package role,
+version, dependency reason, and compatibility status for recovery and audit;
+the workflow publishes the `package` field from each entry.
 
 ```bash
 RELEASE_TAG="vX.Y.Z" # no leading whitespace

--- a/tools/xtask/src/docs_verify.rs
+++ b/tools/xtask/src/docs_verify.rs
@@ -1575,6 +1575,7 @@ fn verify_publish_workflow_inventory() -> Result<()> {
     for line in [
         "mapfile -t PUBLISH_CRATES < <(python - \"$PLAN_JSON\" <<'PY'",
         "PLAN_COUNT=$(python - \"${PLAN_JSON}\" <<'PY'",
+        "print(crate[\"package\"])",
         "if [ \"${PLAN_COUNT}\" -le 0 ]; then",
     ] {
         if !publish_workflow.contains(line) {

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -93,7 +93,7 @@ fn usage() {
          perf --enforce                      Run perf with SLO enforcement\n\
          perf --out-dir <path>               Run perf with custom output directory\n\
          perf --summarize-last               Summarize latest perf.json with SLO comparison\n\
-         publish plan [--format <plain|json>] [--check]  Print and validate publish order\n\
+         publish plan [--format <plain|json>] [--check]  Print and validate the role-aware publish plan\n\
          pr-insights                         Generate PR insights report (nextest + perf)"
     );
 }

--- a/tools/xtask/src/publish.rs
+++ b/tools/xtask/src/publish.rs
@@ -1,11 +1,15 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 use anyhow::{Context, Result, bail};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
+    fs,
     process::Command,
 };
+
+const REGISTRY_PATH: &str = "docs/stability/surface-registry.json";
+const RELEASE_LINE: &str = "0.6";
 
 #[derive(Debug, Deserialize)]
 struct Metadata {
@@ -17,10 +21,40 @@ struct Metadata {
 struct Package {
     id: String,
     name: String,
+    #[serde(default = "default_version")]
+    version: String,
     #[serde(default)]
     publish: Option<Value>,
     #[serde(default)]
     dependencies: Vec<Dependency>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SurfaceRegistry {
+    packages: Vec<RegistryPackage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegistryPackage {
+    name: String,
+    publish: bool,
+    boundary: RegistryBoundary,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegistryBoundary {
+    role: String,
+    target_disposition: String,
+    compatibility_plan: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct PlanPackage {
+    package: String,
+    version: String,
+    role: String,
+    dependency_reason: String,
+    compatibility_status: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -59,8 +93,8 @@ pub fn run_plan(format: PlanFormat, check_only: bool) -> Result<()> {
 
     match format {
         PlanFormat::Plain => {
-            for crate_name in plan {
-                println!("{crate_name}");
+            for package in plan {
+                println!("{}", package.package);
             }
         }
         PlanFormat::Json => {
@@ -72,7 +106,7 @@ pub fn run_plan(format: PlanFormat, check_only: bool) -> Result<()> {
     Ok(())
 }
 
-fn build_publish_plan() -> Result<Vec<String>> {
+fn build_publish_plan() -> Result<Vec<PlanPackage>> {
     let output = Command::new("cargo")
         .args(["metadata", "--format-version", "1", "--no-deps"])
         .output()
@@ -86,24 +120,79 @@ fn build_publish_plan() -> Result<Vec<String>> {
         String::from_utf8(output.stdout).context("cargo metadata output not valid UTF-8")?;
     let metadata: Metadata =
         serde_json::from_str(&metadata_text).context("failed to parse cargo metadata output")?;
+    let registry_text =
+        fs::read_to_string(REGISTRY_PATH).with_context(|| format!("loading {REGISTRY_PATH}"))?;
+    let registry: SurfaceRegistry =
+        serde_json::from_str(&registry_text).with_context(|| format!("parsing {REGISTRY_PATH}"))?;
 
-    let plan = ordered_publish_plan(metadata)?;
+    let plan = ordered_publish_plan(metadata, registry)?;
     Ok(plan)
 }
 
-fn ordered_publish_plan(metadata: Metadata) -> Result<Vec<String>> {
+fn ordered_publish_plan(metadata: Metadata, registry: SurfaceRegistry) -> Result<Vec<PlanPackage>> {
     let workspace_members = metadata
         .workspace_members
         .into_iter()
         .collect::<HashSet<_>>();
 
+    let registry_package_count = registry.packages.len();
+    let registry_by_name = registry
+        .packages
+        .into_iter()
+        .map(|package| (package.name.clone(), package))
+        .collect::<BTreeMap<_, _>>();
+    if registry_by_name.len() != registry_package_count {
+        bail!("{REGISTRY_PATH} contains duplicate package names");
+    }
+
+    let metadata_names = metadata
+        .packages
+        .iter()
+        .map(|package| package.name.as_str())
+        .collect::<HashSet<_>>();
+    if let Some(name) = registry_by_name
+        .keys()
+        .find(|name| !metadata_names.contains(name.as_str()))
+    {
+        bail!("{REGISTRY_PATH} names package {name}, which is absent from cargo metadata");
+    }
+
+    let all_id_to_name = metadata
+        .packages
+        .iter()
+        .map(|package| (package.id.clone(), package.name.clone()))
+        .collect::<HashMap<_, _>>();
+    let mut package_roles = HashMap::new();
+    let mut package_plans = HashMap::new();
+    for package in &metadata.packages {
+        if !workspace_members.contains(&package.id) {
+            continue;
+        }
+        let Some(registry_package) = registry_by_name.get(&package.name) else {
+            bail!(
+                "{REGISTRY_PATH} is missing workspace package {}",
+                package.name
+            );
+        };
+        let manifest_publishable = is_publishable_package(package.publish.as_ref());
+        if manifest_publishable != registry_package.publish {
+            bail!(
+                "package {} publishability ({manifest_publishable}) disagrees with {REGISTRY_PATH} ({})",
+                package.name,
+                registry_package.publish
+            );
+        }
+        validate_role(&package.name, &registry_package.boundary.role)?;
+        package_roles.insert(package.name.clone(), registry_package.boundary.role.clone());
+        if let Some(plan) = plan_package(package, registry_package)? {
+            package_plans.insert(package.name.clone(), plan);
+        }
+    }
+
     let publishable_packages = metadata
         .packages
         .into_iter()
-        .filter(|package| {
-            workspace_members.contains(&package.id)
-                && is_publishable_package(package.publish.as_ref())
-        })
+        .filter(|package| package_plans.contains_key(&package.name))
         .collect::<Vec<_>>();
 
     if publishable_packages.is_empty() {
@@ -133,6 +222,36 @@ fn ordered_publish_plan(metadata: Metadata) -> Result<Vec<String>> {
             .iter()
             .filter(|dep| matches!(dep.kind.as_deref(), None | Some("normal")))
         {
+            let workspace_dependency_name = dependency
+                .name
+                .as_ref()
+                .filter(|name| package_roles.contains_key(name.as_str()))
+                .cloned()
+                .or_else(|| {
+                    dependency
+                        .package
+                        .as_ref()
+                        .and_then(|id| all_id_to_name.get(id))
+                        .filter(|name| package_roles.contains_key(name.as_str()))
+                        .cloned()
+                });
+            if let Some(dep_name) = workspace_dependency_name.as_ref() {
+                let package_role = package_roles
+                    .get(&package.name)
+                    .map(String::as_str)
+                    .unwrap_or_default();
+                let dependency_role = package_roles
+                    .get(dep_name)
+                    .map(String::as_str)
+                    .unwrap_or_default();
+                if package_role == "primary" && matches!(dependency_role, "compat" | "retiring") {
+                    bail!(
+                        "primary package {} depends on {dependency_role} package {dep_name}; converge the owner before publishing",
+                        package.name
+                    );
+                }
+            }
+
             let Some(dep_id) = dependency.package.as_ref().or_else(|| {
                 dependency
                     .name
@@ -170,7 +289,10 @@ fn ordered_publish_plan(metadata: Metadata) -> Result<Vec<String>> {
     let mut ordered = Vec::new();
     while let Some(crate_name) = ready.first().cloned() {
         ready.remove(0);
-        ordered.push(crate_name.clone());
+        let Some(package) = package_plans.remove(&crate_name) else {
+            bail!("publish plan metadata missing for package {crate_name}");
+        };
+        ordered.push(package);
 
         if let Some(children) = dependents.get(&crate_name) {
             for child in children {
@@ -196,10 +318,10 @@ fn ordered_publish_plan(metadata: Metadata) -> Result<Vec<String>> {
     Ok(ordered)
 }
 
-fn validate_publish_plan(plan: &[String]) -> Result<()> {
+fn validate_publish_plan(plan: &[PlanPackage]) -> Result<()> {
     let mut cursor = HashMap::<String, usize>::new();
-    for (index, name) in plan.iter().enumerate() {
-        cursor.insert(name.clone(), index);
+    for (index, package) in plan.iter().enumerate() {
+        cursor.insert(package.package.clone(), index);
     }
 
     if !cursor.contains_key("copybook") {
@@ -225,13 +347,106 @@ fn validate_publish_plan(plan: &[String]) -> Result<()> {
     }
 
     let mut unique = HashSet::new();
-    for crate_name in plan {
-        if !unique.insert(crate_name) {
-            bail!("duplicate crate in publish plan: {crate_name}");
+    for package in plan {
+        if !unique.insert(&package.package) {
+            bail!("duplicate crate in publish plan: {}", package.package);
         }
     }
 
     Ok(())
+}
+
+fn default_version() -> String {
+    "0.0.0".to_string()
+}
+
+fn validate_role(name: &str, role: &str) -> Result<()> {
+    if matches!(
+        role,
+        "primary" | "alias" | "adapter" | "compat" | "retiring" | "internal-tool" | "contract"
+    ) {
+        return Ok(());
+    }
+    bail!("package {name} has unsupported publish role {role}")
+}
+
+fn plan_package(
+    package: &Package,
+    registry_package: &RegistryPackage,
+) -> Result<Option<PlanPackage>> {
+    let role = registry_package.boundary.role.as_str();
+    let (selected, compatibility_status, dependency_reason) = match role {
+        "primary" => match registry_package.boundary.target_disposition.as_str() {
+            "keep" => (true, "not-applicable", "required primary package"),
+            "conditional" => return Ok(None),
+            disposition => {
+                bail!(
+                    "primary package {} has unsupported target disposition {disposition}",
+                    package.name
+                );
+            }
+        },
+        "alias" => {
+            if registry_package.boundary.target_disposition != "keep" {
+                bail!(
+                    "alias package {} must have target disposition keep, found {}",
+                    package.name,
+                    registry_package.boundary.target_disposition
+                );
+            }
+            (
+                true,
+                "permanent-alias",
+                "permanent alias after canonical facade",
+            )
+        }
+        "adapter" => {
+            let selected = registry_package.boundary.target_disposition == "keep";
+            (
+                selected,
+                if selected { "selected" } else { "conditional" },
+                "selected retained adapter",
+            )
+        }
+        "contract" => {
+            let selected = registry_package.boundary.target_disposition == "keep";
+            (
+                selected,
+                if selected { "selected" } else { "conditional" },
+                "selected external contract",
+            )
+        }
+        "compat" => {
+            let selected =
+                compatibility_window_active(&registry_package.boundary.compatibility_plan);
+            (
+                selected,
+                if selected {
+                    "active-through-0.6"
+                } else {
+                    "expired"
+                },
+                "active 0.6 compatibility window",
+            )
+        }
+        "retiring" | "internal-tool" => return Ok(None),
+        _ => bail!(
+            "package {} has unsupported publish role {role}",
+            package.name
+        ),
+    };
+
+    Ok(selected.then(|| PlanPackage {
+        package: package.name.clone(),
+        version: package.version.clone(),
+        role: role.to_string(),
+        dependency_reason: dependency_reason.to_string(),
+        compatibility_status: compatibility_status.to_string(),
+    }))
+}
+
+fn compatibility_window_active(plan: &str) -> bool {
+    plan.contains(RELEASE_LINE) && !plan.contains("not-published")
 }
 
 fn is_publishable_package(publish: Option<&Value>) -> bool {
@@ -246,9 +461,168 @@ fn is_publishable_package(publish: Option<&Value>) -> bool {
 mod tests {
     use super::*;
 
+    fn test_registry(metadata: &Metadata) -> SurfaceRegistry {
+        SurfaceRegistry {
+            packages: metadata
+                .packages
+                .iter()
+                .map(|package| {
+                    let role = if package.name == "copybook-rs" {
+                        "alias"
+                    } else if !is_publishable_package(package.publish.as_ref()) {
+                        "internal-tool"
+                    } else {
+                        "primary"
+                    };
+                    RegistryPackage {
+                        name: package.name.clone(),
+                        publish: is_publishable_package(package.publish.as_ref()),
+                        boundary: RegistryBoundary {
+                            role: role.to_string(),
+                            target_disposition: "keep".to_string(),
+                            compatibility_plan: "retained-primary-package".to_string(),
+                        },
+                    }
+                })
+                .collect(),
+        }
+    }
+
     fn parse_plan(metadata_json: &str) -> Result<Vec<String>> {
         let metadata: Metadata = serde_json::from_str(metadata_json).unwrap();
-        ordered_publish_plan(metadata)
+        let registry = test_registry(&metadata);
+        Ok(ordered_publish_plan(metadata, registry)?
+            .into_iter()
+            .map(|package| package.package)
+            .collect())
+    }
+
+    fn test_entry(package: &str) -> PlanPackage {
+        PlanPackage {
+            package: package.to_string(),
+            version: "0.5.0".to_string(),
+            role: "primary".to_string(),
+            dependency_reason: "required primary package".to_string(),
+            compatibility_status: "not-applicable".to_string(),
+        }
+    }
+
+    fn test_package(name: &str) -> Package {
+        Package {
+            id: format!("id-{name}"),
+            name: name.to_string(),
+            version: "0.5.0".to_string(),
+            publish: Some(Value::Array(vec![Value::String("crates-io".to_string())])),
+            dependencies: Vec::new(),
+        }
+    }
+
+    fn test_registry_package(
+        name: &str,
+        role: &str,
+        disposition: &str,
+        compatibility: &str,
+    ) -> RegistryPackage {
+        RegistryPackage {
+            name: name.to_string(),
+            publish: true,
+            boundary: RegistryBoundary {
+                role: role.to_string(),
+                target_disposition: disposition.to_string(),
+                compatibility_plan: compatibility.to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn role_policy_selects_active_compat_and_omits_conditional_or_retiring_packages() {
+        let primary = test_package("copybook-core");
+        let compat = test_package("copybook-dialect");
+        let conditional = test_package("copybook-fixed");
+        let retiring = test_package("copybook-utils");
+
+        assert!(
+            plan_package(
+                &primary,
+                &test_registry_package(
+                    "copybook-core",
+                    "primary",
+                    "keep",
+                    "retained-primary-package"
+                )
+            )
+            .unwrap()
+            .is_some()
+        );
+        let compat_plan = plan_package(
+            &compat,
+            &test_registry_package(
+                "copybook-dialect",
+                "compat",
+                "collapse",
+                "implementation-free-forwarder-through-0.6-with-finite-window",
+            ),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(compat_plan.compatibility_status, "active-through-0.6");
+        assert!(
+            plan_package(
+                &conditional,
+                &test_registry_package("copybook-fixed", "primary", "conditional", "conditional")
+            )
+            .unwrap()
+            .is_none()
+        );
+        assert!(
+            plan_package(
+                &retiring,
+                &test_registry_package(
+                    "copybook-utils",
+                    "retiring",
+                    "collapse",
+                    "leave-0.5.0-available-and-stop-publishing-after-primary-consumers-move",
+                )
+            )
+            .unwrap()
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn role_policy_rejects_unknown_roles() {
+        let package = test_package("copybook-core");
+        assert!(validate_role("copybook-core", "unknown").is_err());
+        assert!(
+            plan_package(
+                &package,
+                &test_registry_package("copybook-core", "unknown", "keep", "")
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn role_policy_rejects_primary_dependency_on_compatibility_package() {
+        let metadata: Metadata = serde_json::from_str(
+            r#"{
+                "workspace_members":["id-facade", "id-compat"],
+                "packages":[
+                    {"id":"id-facade","name":"copybook","dependencies":[{"name":"copybook-codepage","package":"id-compat"}]},
+                    {"id":"id-compat","name":"copybook-codepage","dependencies":[]}
+                ]
+            }"#,
+        )
+        .unwrap();
+        let mut registry = test_registry(&metadata);
+        registry
+            .packages
+            .iter_mut()
+            .find(|package| package.name == "copybook-codepage")
+            .unwrap()
+            .boundary
+            .role = "compat".to_string();
+        assert!(ordered_publish_plan(metadata, registry).is_err());
     }
 
     #[test]
@@ -349,9 +723,9 @@ mod tests {
     #[test]
     fn validate_publish_plan_enforces_facade_order() {
         let plan = vec![
-            "copybook-core".to_string(),
-            "copybook".to_string(),
-            "copybook-rs".to_string(),
+            test_entry("copybook-core"),
+            test_entry("copybook"),
+            test_entry("copybook-rs"),
         ];
         assert!(validate_publish_plan(&plan).is_ok());
     }
@@ -359,16 +733,16 @@ mod tests {
     #[test]
     fn validate_publish_plan_rejects_duplicate_crates() {
         let plan = vec![
-            "copybook-core".to_string(),
-            "copybook".to_string(),
-            "copybook".to_string(),
+            test_entry("copybook-core"),
+            test_entry("copybook"),
+            test_entry("copybook"),
         ];
         assert!(validate_publish_plan(&plan).is_err());
     }
 
     #[test]
     fn validate_publish_plan_requires_facades() {
-        let plan = vec!["copybook-core".to_string(), "copybook-codec".to_string()];
+        let plan = vec![test_entry("copybook-core"), test_entry("copybook-codec")];
         assert!(validate_publish_plan(&plan).is_err());
     }
 }

--- a/tools/xtask/src/publish.rs
+++ b/tools/xtask/src/publish.rs
@@ -140,7 +140,7 @@ fn build_publish_plan() -> Result<Vec<PlanPackage>> {
 
 fn ordered_publish_plan(metadata: Metadata, registry: SurfaceRegistry) -> Result<Vec<PlanPackage>> {
     if workspace_release_line(&metadata).as_deref() == Some("0.5") {
-        return ordered_legacy_publish_plan(metadata, registry);
+        return ordered_legacy_publish_plan(&metadata, registry);
     }
 
     let workspace_members = metadata
@@ -180,7 +180,7 @@ fn ordered_publish_plan(metadata: Metadata, registry: SurfaceRegistry) -> Result
         &id_to_name,
         true,
     )?;
-    topological_order(package_plans, in_degree, dependents)
+    topological_order(package_plans, in_degree, &dependents)
 }
 
 fn workspace_release_line(metadata: &Metadata) -> Option<String> {
@@ -202,7 +202,7 @@ fn workspace_release_line(metadata: &Metadata) -> Option<String> {
 }
 
 fn ordered_legacy_publish_plan(
-    metadata: Metadata,
+    metadata: &Metadata,
     registry: SurfaceRegistry,
 ) -> Result<Vec<PlanPackage>> {
     let workspace_members = metadata
@@ -276,7 +276,7 @@ fn ordered_legacy_publish_plan(
         &id_to_name,
         false,
     )?;
-    topological_order(package_plans, in_degree, dependents)
+    topological_order(package_plans, in_degree, &dependents)
 }
 
 fn index_role_registry(
@@ -444,7 +444,7 @@ fn build_dependency_graph(
 fn topological_order(
     mut package_plans: HashMap<String, PlanPackage>,
     mut in_degree: HashMap<String, usize>,
-    dependents: HashMap<String, Vec<String>>,
+    dependents: &HashMap<String, Vec<String>>,
 ) -> Result<Vec<PlanPackage>> {
     let mut ready = in_degree
         .iter()
@@ -618,7 +618,7 @@ fn plan_package(
         version: package.version.clone(),
         role: role.to_string(),
         dependency_reason: dependency_reason.to_string(),
-        compatibility_status: compatibility_status.to_string(),
+        compatibility_status: compatibility_status.clone(),
     }))
 }
 

--- a/tools/xtask/src/publish.rs
+++ b/tools/xtask/src/publish.rs
@@ -134,13 +134,16 @@ fn build_publish_plan() -> Result<Vec<PlanPackage>> {
     let registry: SurfaceRegistry =
         serde_json::from_str(&registry_text).with_context(|| format!("parsing {REGISTRY_PATH}"))?;
 
-    let plan = ordered_publish_plan(metadata, registry)?;
+    let plan = ordered_publish_plan(&metadata, registry)?;
     Ok(plan)
 }
 
-fn ordered_publish_plan(metadata: Metadata, registry: SurfaceRegistry) -> Result<Vec<PlanPackage>> {
-    if workspace_release_line(&metadata).as_deref() == Some("0.5") {
-        return ordered_legacy_publish_plan(&metadata, registry);
+fn ordered_publish_plan(
+    metadata: &Metadata,
+    registry: SurfaceRegistry,
+) -> Result<Vec<PlanPackage>> {
+    if workspace_release_line(metadata).as_deref() == Some("0.5") {
+        return ordered_legacy_publish_plan(metadata, registry);
     }
 
     let workspace_members = metadata
@@ -149,7 +152,7 @@ fn ordered_publish_plan(metadata: Metadata, registry: SurfaceRegistry) -> Result
         .cloned()
         .collect::<HashSet<_>>();
     let (package_roles, package_plans, all_id_to_name) =
-        index_role_registry(&metadata, registry, &workspace_members)?;
+        index_role_registry(metadata, registry, &workspace_members)?;
     let all_name_to_id = all_id_to_name
         .iter()
         .map(|(id, name)| (name.clone(), id.clone()))
@@ -673,7 +676,7 @@ mod tests {
     fn parse_plan(metadata_json: &str) -> Result<Vec<String>> {
         let metadata: Metadata = serde_json::from_str(metadata_json).unwrap();
         let registry = test_registry(&metadata);
-        Ok(ordered_publish_plan(metadata, registry)?
+        Ok(ordered_publish_plan(&metadata, registry)?
             .into_iter()
             .map(|package| package.package)
             .collect())
@@ -766,7 +769,7 @@ mod tests {
             .role = "compat".to_string();
 
         assert_eq!(workspace_release_line(&metadata), Some("0.5".to_string()));
-        let plan = ordered_publish_plan(metadata, registry).unwrap();
+        let plan = ordered_publish_plan(&metadata, registry).unwrap();
         assert_eq!(
             plan.into_iter()
                 .map(|package| package.package)
@@ -801,7 +804,7 @@ mod tests {
             .boundary
             .target_disposition = "conditional".to_string();
 
-        let error = ordered_publish_plan(metadata, registry).unwrap_err();
+        let error = ordered_publish_plan(&metadata, registry).unwrap_err();
         assert!(
             error
                 .to_string()
@@ -897,7 +900,7 @@ mod tests {
             .unwrap()
             .boundary
             .role = "compat".to_string();
-        assert!(ordered_publish_plan(metadata, registry).is_err());
+        assert!(ordered_publish_plan(&metadata, registry).is_err());
     }
 
     #[test]

--- a/tools/xtask/src/publish.rs
+++ b/tools/xtask/src/publish.rs
@@ -57,6 +57,13 @@ struct PlanPackage {
     compatibility_status: String,
 }
 
+type RoleRegistryIndex = (
+    HashMap<String, String>,
+    HashMap<String, PlanPackage>,
+    HashMap<String, String>,
+);
+type DependencyGraph = (HashMap<String, usize>, HashMap<String, Vec<String>>);
+
 #[derive(Debug, Deserialize)]
 struct Dependency {
     #[serde(default)]
@@ -132,9 +139,46 @@ fn build_publish_plan() -> Result<Vec<PlanPackage>> {
 fn ordered_publish_plan(metadata: Metadata, registry: SurfaceRegistry) -> Result<Vec<PlanPackage>> {
     let workspace_members = metadata
         .workspace_members
-        .into_iter()
+        .iter()
+        .cloned()
         .collect::<HashSet<_>>();
+    let (package_roles, package_plans, all_id_to_name) =
+        index_role_registry(&metadata, registry, &workspace_members)?;
+    let publishable_packages = metadata
+        .packages
+        .into_iter()
+        .filter(|package| package_plans.contains_key(&package.name))
+        .collect::<Vec<_>>();
 
+    if publishable_packages.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut publishable_ids = HashSet::new();
+    let mut id_to_name = HashMap::new();
+    let mut name_to_id = HashMap::new();
+    for package in &publishable_packages {
+        publishable_ids.insert(package.id.clone());
+        id_to_name.insert(package.id.clone(), package.name.clone());
+        name_to_id.insert(package.name.clone(), package.id.clone());
+    }
+
+    let (in_degree, dependents) = build_dependency_graph(
+        &publishable_packages,
+        &package_roles,
+        &all_id_to_name,
+        &publishable_ids,
+        &id_to_name,
+        &name_to_id,
+    )?;
+    topological_order(package_plans, in_degree, dependents)
+}
+
+fn index_role_registry(
+    metadata: &Metadata,
+    registry: SurfaceRegistry,
+    workspace_members: &HashSet<String>,
+) -> Result<RoleRegistryIndex> {
     let registry_package_count = registry.packages.len();
     let registry_by_name = registry
         .packages
@@ -188,35 +232,26 @@ fn ordered_publish_plan(metadata: Metadata, registry: SurfaceRegistry) -> Result
             package_plans.insert(package.name.clone(), plan);
         }
     }
+    Ok((package_roles, package_plans, all_id_to_name))
+}
 
-    let publishable_packages = metadata
-        .packages
-        .into_iter()
-        .filter(|package| package_plans.contains_key(&package.name))
-        .collect::<Vec<_>>();
-
-    if publishable_packages.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let mut publishable_ids = HashSet::new();
-    let mut id_to_name = HashMap::new();
-    let mut name_to_id = HashMap::new();
-    for package in &publishable_packages {
-        publishable_ids.insert(package.id.clone());
-        id_to_name.insert(package.id.clone(), package.name.clone());
-        name_to_id.insert(package.name.clone(), package.id.clone());
-    }
-
+fn build_dependency_graph(
+    packages: &[Package],
+    package_roles: &HashMap<String, String>,
+    all_id_to_name: &HashMap<String, String>,
+    publishable_ids: &HashSet<String>,
+    id_to_name: &HashMap<String, String>,
+    name_to_id: &HashMap<String, String>,
+) -> Result<DependencyGraph> {
     let mut in_degree: HashMap<String, usize> = HashMap::new();
     let mut dependents: HashMap<String, Vec<String>> = HashMap::new();
     let mut seen_edges = HashSet::new();
 
-    for package in &publishable_packages {
+    for package in packages {
         in_degree.entry(package.name.clone()).or_insert(0);
     }
 
-    for package in &publishable_packages {
+    for package in packages {
         for dependency in package
             .dependencies
             .iter()
@@ -280,6 +315,14 @@ fn ordered_publish_plan(metadata: Metadata, registry: SurfaceRegistry) -> Result
         }
     }
 
+    Ok((in_degree, dependents))
+}
+
+fn topological_order(
+    mut package_plans: HashMap<String, PlanPackage>,
+    mut in_degree: HashMap<String, usize>,
+    dependents: HashMap<String, Vec<String>>,
+) -> Result<Vec<PlanPackage>> {
     let mut ready = in_degree
         .iter()
         .filter_map(|(name, degree)| (*degree == 0).then_some(name.clone()))

--- a/tools/xtask/src/publish.rs
+++ b/tools/xtask/src/publish.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 const REGISTRY_PATH: &str = "docs/stability/surface-registry.json";
-const RELEASE_LINE: &str = "0.6";
+const TARGET_RELEASE_LINE: &str = "0.6";
 
 #[derive(Debug, Deserialize)]
 struct Metadata {
@@ -68,6 +68,8 @@ type DependencyGraph = (HashMap<String, usize>, HashMap<String, Vec<String>>);
 struct Dependency {
     #[serde(default)]
     kind: Option<String>,
+    #[serde(default)]
+    optional: bool,
     #[serde(default)]
     name: Option<String>,
     #[serde(default)]
@@ -137,6 +139,10 @@ fn build_publish_plan() -> Result<Vec<PlanPackage>> {
 }
 
 fn ordered_publish_plan(metadata: Metadata, registry: SurfaceRegistry) -> Result<Vec<PlanPackage>> {
+    if workspace_release_line(&metadata).as_deref() == Some("0.5") {
+        return ordered_legacy_publish_plan(metadata, registry);
+    }
+
     let workspace_members = metadata
         .workspace_members
         .iter()
@@ -144,9 +150,13 @@ fn ordered_publish_plan(metadata: Metadata, registry: SurfaceRegistry) -> Result
         .collect::<HashSet<_>>();
     let (package_roles, package_plans, all_id_to_name) =
         index_role_registry(&metadata, registry, &workspace_members)?;
+    let all_name_to_id = all_id_to_name
+        .iter()
+        .map(|(id, name)| (name.clone(), id.clone()))
+        .collect::<HashMap<_, _>>();
     let publishable_packages = metadata
         .packages
-        .into_iter()
+        .iter()
         .filter(|package| package_plans.contains_key(&package.name))
         .collect::<Vec<_>>();
 
@@ -156,20 +166,115 @@ fn ordered_publish_plan(metadata: Metadata, registry: SurfaceRegistry) -> Result
 
     let mut publishable_ids = HashSet::new();
     let mut id_to_name = HashMap::new();
-    let mut name_to_id = HashMap::new();
     for package in &publishable_packages {
         publishable_ids.insert(package.id.clone());
         id_to_name.insert(package.id.clone(), package.name.clone());
-        name_to_id.insert(package.name.clone(), package.id.clone());
     }
 
     let (in_degree, dependents) = build_dependency_graph(
         &publishable_packages,
         &package_roles,
         &all_id_to_name,
+        &all_name_to_id,
         &publishable_ids,
         &id_to_name,
-        &name_to_id,
+        true,
+    )?;
+    topological_order(package_plans, in_degree, dependents)
+}
+
+fn workspace_release_line(metadata: &Metadata) -> Option<String> {
+    let workspace_members = metadata
+        .workspace_members
+        .iter()
+        .cloned()
+        .collect::<HashSet<_>>();
+    let version = metadata
+        .packages
+        .iter()
+        .find(|package| package.name == "copybook" && workspace_members.contains(&package.id))?
+        .version
+        .as_str();
+    let mut components = version.split('.');
+    let major = components.next()?;
+    let minor = components.next()?;
+    Some(format!("{major}.{minor}"))
+}
+
+fn ordered_legacy_publish_plan(
+    metadata: Metadata,
+    registry: SurfaceRegistry,
+) -> Result<Vec<PlanPackage>> {
+    let workspace_members = metadata
+        .workspace_members
+        .iter()
+        .cloned()
+        .collect::<HashSet<_>>();
+    let registry_by_name = registry
+        .packages
+        .into_iter()
+        .map(|package| (package.name.clone(), package))
+        .collect::<HashMap<_, _>>();
+    let publishable_packages = metadata
+        .packages
+        .iter()
+        .filter(|package| {
+            workspace_members.contains(&package.id)
+                && is_publishable_package(package.publish.as_ref())
+        })
+        .collect::<Vec<_>>();
+
+    if publishable_packages.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut package_roles = HashMap::new();
+    let mut package_plans = HashMap::new();
+    for package in &publishable_packages {
+        let Some(registry_package) = registry_by_name.get(&package.name) else {
+            bail!(
+                "{REGISTRY_PATH} is missing workspace package {}",
+                package.name
+            );
+        };
+        package_roles.insert(package.name.clone(), registry_package.boundary.role.clone());
+        package_plans.insert(
+            package.name.clone(),
+            PlanPackage {
+                package: package.name.clone(),
+                version: package.version.clone(),
+                role: registry_package.boundary.role.clone(),
+                dependency_reason: "manifest publishable package".to_string(),
+                compatibility_status: "legacy-release-line".to_string(),
+            },
+        );
+    }
+
+    let all_id_to_name = metadata
+        .packages
+        .iter()
+        .map(|package| (package.id.clone(), package.name.clone()))
+        .collect::<HashMap<_, _>>();
+    let all_name_to_id = all_id_to_name
+        .iter()
+        .map(|(id, name)| (name.clone(), id.clone()))
+        .collect::<HashMap<_, _>>();
+    let publishable_ids = publishable_packages
+        .iter()
+        .map(|package| package.id.clone())
+        .collect::<HashSet<_>>();
+    let id_to_name = publishable_packages
+        .iter()
+        .map(|package| (package.id.clone(), package.name.clone()))
+        .collect::<HashMap<_, _>>();
+    let (in_degree, dependents) = build_dependency_graph(
+        &publishable_packages,
+        &package_roles,
+        &all_id_to_name,
+        &all_name_to_id,
+        &publishable_ids,
+        &id_to_name,
+        false,
     )?;
     topological_order(package_plans, in_degree, dependents)
 }
@@ -236,12 +341,13 @@ fn index_role_registry(
 }
 
 fn build_dependency_graph(
-    packages: &[Package],
+    packages: &[&Package],
     package_roles: &HashMap<String, String>,
     all_id_to_name: &HashMap<String, String>,
+    all_name_to_id: &HashMap<String, String>,
     publishable_ids: &HashSet<String>,
     id_to_name: &HashMap<String, String>,
-    name_to_id: &HashMap<String, String>,
+    enforce_role_policy: bool,
 ) -> Result<DependencyGraph> {
     let mut in_degree: HashMap<String, usize> = HashMap::new();
     let mut dependents: HashMap<String, Vec<String>> = HashMap::new();
@@ -279,7 +385,10 @@ fn build_dependency_graph(
                     .get(dep_name)
                     .map(String::as_str)
                     .unwrap_or_default();
-                if package_role == "primary" && matches!(dependency_role, "compat" | "retiring") {
+                if enforce_role_policy
+                    && package_role == "primary"
+                    && matches!(dependency_role, "compat" | "retiring")
+                {
                     bail!(
                         "primary package {} depends on {dependency_role} package {dep_name}; converge the owner before publishing",
                         package.name
@@ -291,10 +400,24 @@ fn build_dependency_graph(
                 dependency
                     .name
                     .as_ref()
-                    .and_then(|dep_name| name_to_id.get(dep_name))
+                    .and_then(|dep_name| all_name_to_id.get(dep_name))
             }) else {
                 continue;
             };
+
+            if enforce_role_policy
+                && workspace_dependency_name.is_some()
+                && !publishable_ids.contains(dep_id)
+                && !dependency.optional
+            {
+                let dep_name = workspace_dependency_name
+                    .as_deref()
+                    .unwrap_or("unknown workspace package");
+                bail!(
+                    "selected package {} depends on omitted workspace package {dep_name}; include it in the publish plan or make the dependency optional",
+                    package.name
+                );
+            }
 
             if !publishable_ids.contains(dep_id) {
                 continue;
@@ -418,9 +541,13 @@ fn plan_package(
     registry_package: &RegistryPackage,
 ) -> Result<Option<PlanPackage>> {
     let role = registry_package.boundary.role.as_str();
-    let (selected, compatibility_status, dependency_reason) = match role {
+    let (selected, compatibility_status, dependency_reason): (bool, String, &str) = match role {
         "primary" => match registry_package.boundary.target_disposition.as_str() {
-            "keep" => (true, "not-applicable", "required primary package"),
+            "keep" => (
+                true,
+                "not-applicable".to_string(),
+                "required primary package",
+            ),
             "conditional" => return Ok(None),
             disposition => {
                 bail!(
@@ -439,7 +566,7 @@ fn plan_package(
             }
             (
                 true,
-                "permanent-alias",
+                "permanent-alias".to_string(),
                 "permanent alias after canonical facade",
             )
         }
@@ -447,7 +574,11 @@ fn plan_package(
             let selected = registry_package.boundary.target_disposition == "keep";
             (
                 selected,
-                if selected { "selected" } else { "conditional" },
+                if selected {
+                    "selected".to_string()
+                } else {
+                    "conditional".to_string()
+                },
                 "selected retained adapter",
             )
         }
@@ -455,19 +586,22 @@ fn plan_package(
             let selected = registry_package.boundary.target_disposition == "keep";
             (
                 selected,
-                if selected { "selected" } else { "conditional" },
+                if selected {
+                    "selected".to_string()
+                } else {
+                    "conditional".to_string()
+                },
                 "selected external contract",
             )
         }
         "compat" => {
-            let selected =
-                compatibility_window_active(&registry_package.boundary.compatibility_plan);
+            let selected = compatibility_window_active(&registry_package.boundary);
             (
                 selected,
                 if selected {
-                    "active-through-0.6"
+                    format!("active-through-{TARGET_RELEASE_LINE}")
                 } else {
-                    "expired"
+                    "expired".to_string()
                 },
                 "active 0.6 compatibility window",
             )
@@ -488,8 +622,13 @@ fn plan_package(
     }))
 }
 
-fn compatibility_window_active(plan: &str) -> bool {
-    plan.contains(RELEASE_LINE) && !plan.contains("not-published")
+fn compatibility_window_active(boundary: &RegistryBoundary) -> bool {
+    boundary.target_disposition == "collapse"
+        && matches!(
+            boundary.compatibility_plan.as_str(),
+            "implementation-free-forwarder-through-0.6-with-finite-window"
+                | "deprecated-through-0.6"
+        )
 }
 
 fn is_publishable_package(publish: Option<&Value>) -> bool {
@@ -575,6 +714,99 @@ mod tests {
                 compatibility_plan: compatibility.to_string(),
             },
         }
+    }
+
+    #[test]
+    fn compatibility_window_requires_active_exact_registry_token() {
+        let mut boundary = RegistryBoundary {
+            role: "compat".to_string(),
+            target_disposition: "collapse".to_string(),
+            compatibility_plan: "implementation-free-forwarder-through-0.6-with-finite-window"
+                .to_string(),
+        };
+        assert!(compatibility_window_active(&boundary));
+
+        boundary.compatibility_plan = "deprecated-through-0.6".to_string();
+        assert!(compatibility_window_active(&boundary));
+
+        boundary.compatibility_plan = "removed-in-0.6".to_string();
+        assert!(!compatibility_window_active(&boundary));
+        boundary.compatibility_plan = "forwarder-through-10.6".to_string();
+        assert!(!compatibility_window_active(&boundary));
+        boundary.target_disposition = "conditional".to_string();
+        boundary.compatibility_plan =
+            "implementation-free-forwarder-through-0.6-with-finite-window".to_string();
+        assert!(!compatibility_window_active(&boundary));
+    }
+
+    #[test]
+    fn legacy_release_line_keeps_manifest_publish_plan() {
+        let metadata: Metadata = serde_json::from_str(
+            r#"{
+                "workspace_members":["id-facade", "id-compat", "id-rs"],
+                "packages":[
+                    {"id":"id-facade","name":"copybook","version":"0.5.1","dependencies":[
+                        {"name":"copybook-codepage","package":"id-compat"}
+                    ]},
+                    {"id":"id-compat","name":"copybook-codepage","version":"0.5.1","dependencies":[]},
+                    {"id":"id-rs","name":"copybook-rs","version":"0.5.1","dependencies":[
+                        {"name":"copybook","package":"id-facade"}
+                    ]}
+                ]
+            }"#,
+        )
+        .unwrap();
+        let mut registry = test_registry(&metadata);
+        registry
+            .packages
+            .iter_mut()
+            .find(|package| package.name == "copybook-codepage")
+            .unwrap()
+            .boundary
+            .role = "compat".to_string();
+
+        assert_eq!(workspace_release_line(&metadata), Some("0.5".to_string()));
+        let plan = ordered_publish_plan(metadata, registry).unwrap();
+        assert_eq!(
+            plan.into_iter()
+                .map(|package| package.package)
+                .collect::<Vec<_>>(),
+            ["copybook-codepage", "copybook", "copybook-rs"]
+        );
+    }
+
+    #[test]
+    fn role_policy_rejects_required_dependency_on_omitted_package() {
+        let metadata: Metadata = serde_json::from_str(
+            r#"{
+                "workspace_members":["id-facade", "id-conditional", "id-rs"],
+                "packages":[
+                    {"id":"id-facade","name":"copybook","version":"0.6.0","dependencies":[
+                        {"name":"copybook-fixed","package":"id-conditional"}
+                    ]},
+                    {"id":"id-conditional","name":"copybook-fixed","version":"0.6.0","dependencies":[]},
+                    {"id":"id-rs","name":"copybook-rs","version":"0.6.0","dependencies":[
+                        {"name":"copybook","package":"id-facade"}
+                    ]}
+                ]
+            }"#,
+        )
+        .unwrap();
+        let mut registry = test_registry(&metadata);
+        registry
+            .packages
+            .iter_mut()
+            .find(|package| package.name == "copybook-fixed")
+            .unwrap()
+            .boundary
+            .target_disposition = "conditional".to_string();
+
+        let error = ordered_publish_plan(metadata, registry).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("omitted workspace package copybook-fixed")
+        );
     }
 
     #[test]


### PR DESCRIPTION
Relates to #645

## What this does

Makes `xtask publish plan` consume both Cargo metadata and
`docs/stability/surface-registry.json`, so the v0.6 release plan is driven by
package roles and compatibility policy instead of the manifest `publish` bit
alone.

The JSON plan now records `package`, `version`, `role`,
`dependency_reason`, and `compatibility_status`. Plain output remains one
package name per line. Release and dry-run workflows extract the `package`
field while preserving the metadata artifact for audit and resumable recovery.

The planner includes required primary/alias packages and active compatibility
windows, selects retained adapters/contracts, omits conditional/retiring/internal
packages, rejects registry/manifest publish mismatches, rejects unknown roles,
rejects selected packages with required dependencies on omitted workspace
packages, and rejects primary dependencies on compatibility or retiring packages.

For the supported 0.5.x patch/security line, it preserves the established
manifest-driven package set and dependency order. The v0.6 role policy is
selected from the actual workspace release line, so v0.6 convergence
preconditions cannot block a 0.5.x release. Compatibility selection uses exact
active/deprecated registry tokens and an explicit target disposition.

## Verification

| Check | Result |
| --- | --- |
| `cargo fmt --all -- --check` | pass |
| `git diff --check` | pass |
| `cargo test -p xtask --lib -- --nocapture` | 36 passed |
| `cargo nextest run -p xtask --profile ci --failure-output=immediate` | 113 passed |
| `cargo clippy -p xtask --all-targets -- -D warnings` | pass |
| `cargo run -p xtask -- publish plan --check` | pass: 38 publishable crates on current 0.5.0 workspace |
| `cargo run -p xtask -- docs verify-support-matrix` | pass |
| `cargo run -p xtask -- architecture check` | pass |
| `cargo run -p xtask -- docs verify-all` | blocked by pre-existing `README.md test-status out of sync` |

Focused tests cover the 0.6 role policy, exact compatibility tokens, legacy
0.5.x planning, primary-to-compatibility rejection, and required
dependency-to-omitted-package rejection.

## Review map

- `tools/xtask/src/publish.rs`: release-line routing, role-aware selection, compatibility-window metadata, deterministic ordering, contradiction and dependency guards, focused tests.
- `.github/workflows/publish.yml`, `.github/workflows/publish-dry-run.yml`: consume object-shaped plan entries through `entry["package"]`.
- `docs/RELEASE_PROCESS.md`, `docs/RELEASE_RUNBOOK.md`: document release-line and role-aware plan semantics and JSON evidence.
- `tools/xtask/src/docs_verify.rs`, `tools/xtask/src/main.rs`: keep workflow inventory and CLI help aligned.