### PR TITLE
refactor(fixed): isolate schema integration in codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,7 +1036,6 @@ dependencies = [
 name = "copybook-fixed"
 version = "0.5.0"
 dependencies = [
- "copybook-core",
  "copybook-error",
  "proptest",
  "tracing",

--- a/crates/copybook-codec/src/file.rs
+++ b/crates/copybook-codec/src/file.rs
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Schema-aware file processing integration.
+
+pub mod fixed;

--- a/crates/copybook-codec/src/file/fixed.rs
+++ b/crates/copybook-codec/src/file/fixed.rs
@@ -1,0 +1,134 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Fixed-LRECL framing integration for schema-backed codec operations.
+//!
+//! `copybook-fixed` owns byte-stream framing and has no dependency on schema
+//! types. This module is the codec boundary that resolves a copybook schema's
+//! fixed LRECL before constructing those framing primitives.
+
+use copybook_core::Schema;
+use copybook_error::{Error, ErrorCode, ErrorContext, Result};
+use copybook_fixed::FixedRecordReader;
+use std::convert::TryFrom;
+use std::io::Read;
+use tracing::{debug, warn};
+
+pub(crate) const FIXED_FORMAT_LRECL_MISSING: &str = "Fixed format requires a fixed record length (LRECL). Set schema.lrecl_fixed or use RecordFormat::Variable.";
+
+/// Resolve the fixed record length required by a schema.
+///
+/// # Errors
+/// Returns `CBKI001_INVALID_STATE` when the schema does not provide a fixed
+/// record length.
+#[inline]
+#[must_use = "Handle the Result or propagate the error"]
+pub fn lrecl(schema: &Schema) -> Result<u32> {
+    schema
+        .lrecl_fixed
+        .ok_or_else(|| Error::new(ErrorCode::CBKI001_INVALID_STATE, FIXED_FORMAT_LRECL_MISSING))
+}
+
+/// Construct a fixed reader after resolving the schema's LRECL in the codec.
+///
+/// The returned framing primitive accepts only the explicit LRECL value; no
+/// schema type crosses into `copybook-fixed`.
+///
+/// # Errors
+/// Returns an error when the schema has no fixed LRECL or its LRECL is invalid.
+#[inline]
+#[must_use = "Handle the Result or propagate the error"]
+pub fn reader<R: Read>(input: R, schema: &Schema) -> Result<FixedRecordReader<R>> {
+    FixedRecordReader::with_lrecl(input, lrecl(schema)?)
+}
+
+/// Validate a fixed record against the codec's schema and framing contract.
+///
+/// This check intentionally lives beside schema-to-framing integration rather
+/// than in `copybook-fixed`, so the framing crate remains schema-independent.
+///
+/// # Errors
+/// Returns an error when the configured LRECL cannot be represented on the
+/// current platform or when the record length does not match it.
+#[inline]
+#[must_use = "Handle the Result or propagate the error"]
+pub fn validate_record_length(
+    schema: &Schema,
+    configured_lrecl: u32,
+    record_index: u64,
+    record_data: &[u8],
+) -> Result<()> {
+    let lrecl_len = usize::try_from(configured_lrecl).map_err(|_| {
+        Error::new(
+            ErrorCode::CBKP001_SYNTAX,
+            "LRECL exceeds platform addressable size",
+        )
+    })?;
+
+    if record_data.len() != lrecl_len {
+        return Err(Error::new(
+            ErrorCode::CBKF221_RDW_UNDERFLOW,
+            format!(
+                "Record length mismatch: expected {}, got {}",
+                configured_lrecl,
+                record_data.len()
+            ),
+        )
+        .with_context(ErrorContext {
+            record_index: Some(record_index),
+            field_path: None,
+            byte_offset: None,
+            line_number: None,
+            details: Some("Fixed record length validation failed".to_string()),
+        }));
+    }
+
+    if let Some(schema_lrecl) = schema.lrecl_fixed
+        && configured_lrecl != schema_lrecl
+    {
+        warn!(
+            "LRECL mismatch: codec configured for {}, schema expects {}",
+            configured_lrecl, schema_lrecl
+        );
+    }
+
+    if schema.tail_odo.is_some() {
+        debug!("Record has ODO tail, variable length within fixed LRECL is expected");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn resolves_schema_lrecl_at_codec_boundary() {
+        let mut schema = Schema::new();
+        schema.lrecl_fixed = Some(8);
+
+        assert_eq!(lrecl(&schema).unwrap(), 8);
+        let mut reader = reader(Cursor::new(b"ABCDEFGH"), &schema).unwrap();
+        assert_eq!(reader.read_record().unwrap().unwrap(), b"ABCDEFGH");
+    }
+
+    #[test]
+    fn rejects_schema_without_fixed_lrecl_at_codec_boundary() {
+        let schema = Schema::new();
+
+        let error = lrecl(&schema).unwrap_err();
+        assert_eq!(error.code, ErrorCode::CBKI001_INVALID_STATE);
+    }
+
+    #[test]
+    fn validates_record_length_at_codec_boundary() {
+        let mut schema = Schema::new();
+        schema.lrecl_fixed = Some(8);
+
+        validate_record_length(&schema, 8, 1, b"ABCDEFGH").unwrap();
+        let error = validate_record_length(&schema, 8, 2, b"SHORT").unwrap_err();
+        assert_eq!(error.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+    }
+}

--- a/crates/copybook-codec/src/file/fixed.rs
+++ b/crates/copybook-codec/src/file/fixed.rs
@@ -23,9 +23,18 @@ pub(crate) const FIXED_FORMAT_LRECL_MISSING: &str = "Fixed format requires a fix
 #[inline]
 #[must_use = "Handle the Result or propagate the error"]
 pub fn lrecl(schema: &Schema) -> Result<u32> {
-    schema
+    let lrecl = schema
         .lrecl_fixed
-        .ok_or_else(|| Error::new(ErrorCode::CBKI001_INVALID_STATE, FIXED_FORMAT_LRECL_MISSING))
+        .ok_or_else(|| Error::new(ErrorCode::CBKI001_INVALID_STATE, FIXED_FORMAT_LRECL_MISSING))?;
+
+    if lrecl == 0 {
+        return Err(Error::new(
+            ErrorCode::CBKI001_INVALID_STATE,
+            "LRECL must be greater than zero",
+        ));
+    }
+
+    Ok(lrecl)
 }
 
 /// Construct a fixed reader after resolving the schema's LRECL in the codec.
@@ -120,6 +129,16 @@ mod tests {
 
         let error = lrecl(&schema).unwrap_err();
         assert_eq!(error.code, ErrorCode::CBKI001_INVALID_STATE);
+    }
+
+    #[test]
+    fn rejects_zero_schema_lrecl_at_codec_boundary() {
+        let mut schema = Schema::new();
+        schema.lrecl_fixed = Some(0);
+
+        let error = lrecl(&schema).unwrap_err();
+        assert_eq!(error.code, ErrorCode::CBKI001_INVALID_STATE);
+        assert_eq!(error.message, "LRECL must be greater than zero");
     }
 
     #[test]

--- a/crates/copybook-codec/src/iterator.rs
+++ b/crates/copybook-codec/src/iterator.rs
@@ -826,6 +826,24 @@ mod tests {
     }
 
     #[test]
+    fn test_iterator_fixed_format_zero_lrecl_errors_on_next() {
+        let copybook_text = "01 SOME-GROUP. 05 SOME-FIELD PIC X(1).";
+        let mut schema = parse_copybook(copybook_text).unwrap();
+        schema.lrecl_fixed = Some(0);
+
+        let options = DecodeOptions {
+            format: RecordFormat::Fixed,
+            ..DecodeOptions::default()
+        };
+
+        let mut iterator = RecordIterator::new(Cursor::new(b"DATA"), &schema, &options).unwrap();
+
+        let error = iterator.next().unwrap().unwrap_err();
+        assert_eq!(error.code, ErrorCode::CBKI001_INVALID_STATE);
+        assert_eq!(error.message, "LRECL must be greater than zero");
+    }
+
+    #[test]
     fn test_iterator_schema_and_options_accessors() {
         let copybook_text = r"
             01 RECORD.

--- a/crates/copybook-codec/src/iterator.rs
+++ b/crates/copybook-codec/src/iterator.rs
@@ -217,9 +217,6 @@ use copybook_rdw::RdwHeader;
 use serde_json::Value;
 use std::io::{BufReader, Read};
 
-const FIXED_FORMAT_LRECL_MISSING: &str = "Fixed format requires a fixed record length (LRECL). \
-     Set `schema.lrecl_fixed` or use `RecordFormat::Variable`.";
-
 /// Iterator over records in a data file, yielding decoded JSON values
 ///
 /// This iterator provides streaming access to records, processing them one at a time
@@ -386,9 +383,7 @@ impl<R: Read> RecordIterator<R> {
 
         let record_data = match self.options.format {
             RecordFormat::Fixed => {
-                let lrecl = self.schema.lrecl_fixed.ok_or_else(|| {
-                    Error::new(ErrorCode::CBKI001_INVALID_STATE, FIXED_FORMAT_LRECL_MISSING)
-                })? as usize;
+                let lrecl = crate::file::fixed::lrecl(&self.schema)? as usize;
                 self.buffer.resize(lrecl, 0);
 
                 match self.reader.read_exact(&mut self.buffer) {
@@ -826,7 +821,7 @@ mod tests {
         assert!(first.is_err());
         if let Err(e) = first {
             assert_eq!(e.code, ErrorCode::CBKI001_INVALID_STATE);
-            assert_eq!(e.message, FIXED_FORMAT_LRECL_MISSING);
+            assert_eq!(e.message, crate::file::fixed::FIXED_FORMAT_LRECL_MISSING);
         }
     }
 

--- a/crates/copybook-codec/src/lib.rs
+++ b/crates/copybook-codec/src/lib.rs
@@ -21,6 +21,8 @@ pub mod determinism;
 /// Edited PIC (numeric editing) decode and encode support.
 pub mod edited_pic;
 mod fidelity;
+/// Schema-aware file framing integration.
+pub mod file;
 /// Streaming record iterator for file-level decoding.
 pub mod iterator;
 /// Core library API: record decode/encode and file-level processing.

--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -2542,12 +2542,18 @@ fn process_fixed_records<R: Read, W: Write>(
         return process_fixed_records_parallel(schema, reader, output, options, summary);
     }
 
-    let mut reader = crate::record::FixedRecordReader::new(reader, schema.lrecl_fixed)?;
+    let mut reader = crate::file::fixed::reader(reader, schema)?;
     let mut scratch = crate::memory::ScratchBuffers::new();
     let mut record_index = 0u64;
 
     while let Some(record_data) = reader.read_record()? {
         record_index += 1;
+        crate::file::fixed::validate_record_length(
+            schema,
+            reader.lrecl(),
+            reader.record_count(),
+            &record_data,
+        )?;
         summary.bytes_processed += record_data.len() as u64;
         telemetry::record_read(record_data.len(), options);
 
@@ -2681,7 +2687,7 @@ fn process_fixed_records_parallel<R: Read, W: Write>(
     options: &DecodeOptions,
     summary: &mut RunSummary,
 ) -> Result<()> {
-    let mut reader = crate::record::FixedRecordReader::new(reader, schema.lrecl_fixed)?;
+    let mut reader = crate::file::fixed::reader(reader, schema)?;
     let workers = effective_worker_count(options.threads);
     let batch_capacity = workers.saturating_mul(4).max(1);
     let mut pool = decode_worker_pool(schema, options);
@@ -2705,6 +2711,12 @@ fn process_fixed_records_parallel<R: Read, W: Write>(
         let Some(record_data) = record else { break };
 
         record_index += 1;
+        crate::file::fixed::validate_record_length(
+            schema,
+            reader.lrecl(),
+            reader.record_count(),
+            &record_data,
+        )?;
         summary.bytes_processed += record_data.len() as u64;
         telemetry::record_read(record_data.len(), options);
         let raw_data = match options.emit_raw {

--- a/crates/copybook-fixed/Cargo.toml
+++ b/crates/copybook-fixed/Cargo.toml
@@ -21,7 +21,6 @@ all-features = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-copybook-core.workspace = true
 copybook-error.workspace = true
 tracing.workspace = true
 

--- a/crates/copybook-fixed/README.md
+++ b/crates/copybook-fixed/README.md
@@ -16,12 +16,12 @@ use std::io::Cursor;
 
 // Write fixed-length records (LRECL = 8)
 let mut output = Vec::new();
-let mut writer = FixedRecordWriter::new(&mut output, Some(8)).unwrap();
+let mut writer = FixedRecordWriter::with_lrecl(&mut output, 8).unwrap();
 writer.write_record(b"ABCD").unwrap(); // padded to 8 bytes
 writer.flush().unwrap();
 
 // Read fixed-length records
-let mut reader = FixedRecordReader::new(Cursor::new(&output), Some(8)).unwrap();
+let mut reader = FixedRecordReader::with_lrecl(Cursor::new(&output), 8).unwrap();
 let record = reader.read_record().unwrap().unwrap();
 assert_eq!(&record[..4], b"ABCD");
 ```
@@ -30,6 +30,10 @@ assert_eq!(&record[..4], b"ABCD");
 
 - `FixedRecordReader<R>` — Streaming reader for fixed-length records
 - `FixedRecordWriter<W>` — Streaming writer with automatic padding
+
+The `with_lrecl` constructors are the canonical schema-independent framing
+surface. Copybook schema compatibility is validated by `copybook-codec` before
+it constructs these framing primitives.
 
 ## License
 

--- a/crates/copybook-fixed/README.md
+++ b/crates/copybook-fixed/README.md
@@ -35,6 +35,15 @@ The `with_lrecl` constructors are the canonical schema-independent framing
 surface. Copybook schema compatibility is validated by `copybook-codec` before
 it constructs these framing primitives.
 
+## Migration from the 0.5 schema-aware helper
+
+The former `FixedRecordReader::validate_record_length` method was schema-aware
+and is not part of the schema-independent framing API. Callers that need that
+compatibility check should use
+`copybook_codec::file::fixed::validate_record_length` with the parsed schema,
+configured LRECL, record index, and record bytes; callers that only need
+framing should use `with_lrecl`.
+
 ## License
 
 AGPL-3.0-or-later

--- a/crates/copybook-fixed/src/lib.rs
+++ b/crates/copybook-fixed/src/lib.rs
@@ -358,6 +358,13 @@ mod tests {
     }
 
     #[test]
+    fn explicit_lrecl_reader_constructor_rejects_zero() {
+        let error = FixedRecordReader::with_lrecl(Cursor::new(b"ABCD"), 0).unwrap_err();
+
+        assert_eq!(error.code, ErrorCode::CBKI001_INVALID_STATE);
+    }
+
+    #[test]
     fn fixed_record_reader_partial_record_is_underflow() {
         let data = b"ABCD123";
         let mut reader = FixedRecordReader::new(Cursor::new(data), Some(8)).unwrap();
@@ -400,6 +407,14 @@ mod tests {
 
         writer.write_record(b"AB").unwrap();
         assert_eq!(output, b"AB\x00\x00");
+    }
+
+    #[test]
+    fn explicit_lrecl_writer_constructor_rejects_zero() {
+        let mut output = Vec::new();
+        let error = FixedRecordWriter::with_lrecl(&mut output, 0).unwrap_err();
+
+        assert_eq!(error.code, ErrorCode::CBKI001_INVALID_STATE);
     }
 
     #[test]

--- a/crates/copybook-fixed/src/lib.rs
+++ b/crates/copybook-fixed/src/lib.rs
@@ -9,11 +9,10 @@
 //! Use [`FixedRecordReader`] to consume fixed-length records from a byte stream
 //! and [`FixedRecordWriter`] to produce them with automatic null-byte padding.
 
-use copybook_core::Schema;
 use copybook_error::{Error, ErrorCode, ErrorContext, Result};
 use std::convert::TryFrom;
 use std::io::{ErrorKind, Read, Write};
-use tracing::{debug, warn};
+use tracing::debug;
 
 /// Fixed record reader for processing fixed-length records.
 #[derive(Debug)]
@@ -24,6 +23,20 @@ pub struct FixedRecordReader<R: Read> {
 }
 
 impl<R: Read> FixedRecordReader<R> {
+    /// Create a reader for an explicit fixed-record length.
+    ///
+    /// This is the canonical schema-independent constructor. Schema
+    /// compatibility belongs to the codec integration layer, not this
+    /// framing crate.
+    ///
+    /// # Errors
+    /// Returns an error if `lrecl` is zero.
+    #[inline]
+    #[must_use = "Handle the Result or propagate the error"]
+    pub fn with_lrecl(input: R, lrecl: u32) -> Result<Self> {
+        Self::new(input, Some(lrecl))
+    }
+
     /// Create a new fixed record reader.
     ///
     /// # Errors
@@ -130,48 +143,6 @@ impl<R: Read> FixedRecordReader<R> {
         }
     }
 
-    /// Validate record length against schema expectations.
-    ///
-    /// # Errors
-    /// Returns an error if the record length does not match configured LRECL.
-    #[inline]
-    #[must_use = "Handle the Result or propagate the error"]
-    pub fn validate_record_length(&self, schema: &Schema, record_data: &[u8]) -> Result<()> {
-        let lrecl_len = self.lrecl_usize()?;
-        if record_data.len() != lrecl_len {
-            return Err(Error::new(
-                ErrorCode::CBKF221_RDW_UNDERFLOW,
-                format!(
-                    "Record length mismatch: expected {}, got {}",
-                    self.lrecl,
-                    record_data.len()
-                ),
-            )
-            .with_context(ErrorContext {
-                record_index: Some(self.record_count),
-                field_path: None,
-                byte_offset: None,
-                line_number: None,
-                details: Some("Fixed record length validation failed".to_string()),
-            }));
-        }
-
-        if let Some(schema_lrecl) = schema.lrecl_fixed
-            && self.lrecl != schema_lrecl
-        {
-            warn!(
-                "LRECL mismatch: reader configured for {}, schema expects {}",
-                self.lrecl, schema_lrecl
-            );
-        }
-
-        if schema.tail_odo.is_some() {
-            debug!("Record has ODO tail, variable length within fixed LRECL is expected");
-        }
-
-        Ok(())
-    }
-
     /// Get the current record count.
     #[must_use]
     #[inline]
@@ -206,6 +177,20 @@ pub struct FixedRecordWriter<W: Write> {
 }
 
 impl<W: Write> FixedRecordWriter<W> {
+    /// Create a writer for an explicit fixed-record length.
+    ///
+    /// This is the canonical schema-independent constructor. Schema
+    /// compatibility belongs to the codec integration layer, not this
+    /// framing crate.
+    ///
+    /// # Errors
+    /// Returns an error if `lrecl` is zero.
+    #[inline]
+    #[must_use = "Handle the Result or propagate the error"]
+    pub fn with_lrecl(output: W, lrecl: u32) -> Result<Self> {
+        Self::new(output, Some(lrecl))
+    }
+
     /// Create a new fixed record writer.
     ///
     /// # Errors
@@ -366,6 +351,13 @@ mod tests {
     }
 
     #[test]
+    fn explicit_lrecl_reader_constructor() {
+        let mut reader = FixedRecordReader::with_lrecl(Cursor::new(b"ABCD"), 4).unwrap();
+
+        assert_eq!(reader.read_record().unwrap().unwrap(), b"ABCD");
+    }
+
+    #[test]
     fn fixed_record_reader_partial_record_is_underflow() {
         let data = b"ABCD123";
         let mut reader = FixedRecordReader::new(Cursor::new(data), Some(8)).unwrap();
@@ -402,6 +394,15 @@ mod tests {
     }
 
     #[test]
+    fn explicit_lrecl_writer_constructor() {
+        let mut output = Vec::new();
+        let mut writer = FixedRecordWriter::with_lrecl(&mut output, 4).unwrap();
+
+        writer.write_record(b"AB").unwrap();
+        assert_eq!(output, b"AB\x00\x00");
+    }
+
+    #[test]
     fn fixed_record_writer_too_long_is_cbke501() {
         let mut output = Vec::new();
         let mut writer = FixedRecordWriter::new(&mut output, Some(4)).unwrap();
@@ -422,27 +423,6 @@ mod tests {
         let mut output = Vec::new();
         let error = FixedRecordWriter::new(&mut output, None).unwrap_err();
         assert_eq!(error.code, ErrorCode::CBKI001_INVALID_STATE);
-    }
-
-    #[test]
-    fn validate_record_length_ok() {
-        let data = b"ABCD1234";
-        let mut reader = FixedRecordReader::new(Cursor::new(data), Some(8)).unwrap();
-        let record = reader.read_record().unwrap().unwrap();
-
-        let schema = Schema::new();
-        reader.validate_record_length(&schema, &record).unwrap();
-    }
-
-    #[test]
-    fn validate_record_length_mismatch_is_underflow() {
-        let data = b"ABCD1234";
-        let mut reader = FixedRecordReader::new(Cursor::new(data), Some(8)).unwrap();
-        let _ = reader.read_record().unwrap().unwrap();
-
-        let schema = Schema::new();
-        let error = reader.validate_record_length(&schema, b"ABC").unwrap_err();
-        assert_eq!(error.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
     }
 
     proptest! {

--- a/crates/copybook-fixed/tests/fixed_comprehensive.rs
+++ b/crates/copybook-fixed/tests/fixed_comprehensive.rs
@@ -532,32 +532,7 @@ fn repeated_reads_after_eof_always_return_none() {
 }
 
 // ====================================================================
-// 13. Validate record length
-// ====================================================================
-
-#[test]
-fn validate_record_length_matching() {
-    let data = b"ABCDEFGH";
-    let mut reader = FixedRecordReader::new(Cursor::new(data.as_slice()), Some(8)).unwrap();
-    let record = reader.read_record().unwrap().unwrap();
-    let schema = copybook_core::Schema::new();
-    reader.validate_record_length(&schema, &record).unwrap();
-}
-
-#[test]
-fn validate_record_length_mismatch() {
-    let data = b"ABCDEFGH";
-    let mut reader = FixedRecordReader::new(Cursor::new(data.as_slice()), Some(8)).unwrap();
-    let _ = reader.read_record().unwrap().unwrap();
-    let schema = copybook_core::Schema::new();
-    let err = reader
-        .validate_record_length(&schema, b"SHORT")
-        .unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
-}
-
-// ====================================================================
-// 14. Writer output size always equals N * LRECL
+// 13. Writer output size always equals N * LRECL
 // ====================================================================
 
 #[test]

--- a/crates/copybook-fixed/tests/fixed_deep.rs
+++ b/crates/copybook-fixed/tests/fixed_deep.rs
@@ -828,30 +828,7 @@ fn ebcdic_content_roundtrip() {
 }
 
 // =========================================================================
-// 14. Validate record length
-// =========================================================================
-
-#[test]
-fn validate_record_length_matching_ok() {
-    let data = b"ABCDEFGH";
-    let mut r = FixedRecordReader::new(Cursor::new(data.as_slice()), Some(8)).unwrap();
-    let rec = r.read_record().unwrap().unwrap();
-    let schema = copybook_core::Schema::new();
-    r.validate_record_length(&schema, &rec).unwrap();
-}
-
-#[test]
-fn validate_record_length_mismatch_errors() {
-    let data = b"ABCDEFGH";
-    let mut r = FixedRecordReader::new(Cursor::new(data.as_slice()), Some(8)).unwrap();
-    let _ = r.read_record().unwrap().unwrap();
-    let schema = copybook_core::Schema::new();
-    let err = r.validate_record_length(&schema, b"SHORT").unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
-}
-
-// =========================================================================
-// 15. Streaming 10,000 records
+// 14. Streaming 10,000 records
 // =========================================================================
 
 #[test]

--- a/docs/architecture/package-boundary-debt.json
+++ b/docs/architecture/package-boundary-debt.json
@@ -6,10 +6,6 @@
       "owner_issue": 656
     },
     {
-      "id": "edge-upward:copybook-fixed->copybook-core",
-      "owner_issue": 650
-    },
-    {
       "id": "edge-upward:copybook-rdw->copybook-core",
       "owner_issue": 651
     },


### PR DESCRIPTION
## Summary

Closes #650 (Slice A) by making fixed framing schema-independent and moving schema/LRECL integration into `copybook-codec::file::fixed`.

- `copybook-fixed` no longer depends on `copybook-core`.
- Added explicit `with_lrecl` reader/writer constructors; framing owns byte boundaries, padding, state, and I/O.
- Moved schema LRECL resolution and record-length compatibility validation into codec-owned fixed-file integration.
- Updated sequential, parallel, and iterator fixed paths to use the codec boundary.
- Removed schema-aware validation tests from the framing crate and added codec-boundary witnesses.
- Removed the resolved `copybook-fixed -> copybook-core` architecture debt entry.
- Slice B stable diagnostic corrections and Slice C retain/demote decision remain separate.

## Proof

- `cargo test -p copybook-fixed` — passed
- `cargo test -p copybook-codec` — 100 unit tests and all integration/doctests passed
- `cargo test -p copybook-record-io` — passed
- `cargo test -p copybook-codec --test fixed_microcrate_integration` — passed
- `cargo clippy -p copybook-fixed -p copybook-codec --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `cargo metadata --locked --no-deps --format-version 1` — passed
- `cargo run -p xtask -- docs verify-all` — passed
- `cargo run -p xtask -- architecture check` — passed, 23 tracked violations
- `just deny` — passed with existing duplicate/unmatched-allowance warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added schema-aware fixed-record framing for decoding.
  - Fixed-record readers and writers now support explicit record lengths.
  - Added validation for missing, invalid, and mismatched record lengths.

- **Bug Fixes**
  - Fixed-record decoding now consistently validates each record before processing.

- **Documentation**
  - Updated framing examples and API guidance for explicit record-length configuration.

- **Tests**
  - Added coverage for fixed-length configuration and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->