### PR TITLE
fix(fixed): use framing error identity

### DIFF
--- a/crates/copybook-codec/src/file/fixed.rs
+++ b/crates/copybook-codec/src/file/fixed.rs
@@ -68,14 +68,14 @@ pub fn validate_record_length(
 ) -> Result<()> {
     let lrecl_len = usize::try_from(configured_lrecl).map_err(|_| {
         Error::new(
-            ErrorCode::CBKP001_SYNTAX,
+            ErrorCode::CBKR101_FIXED_RECORD_ERROR,
             "LRECL exceeds platform addressable size",
         )
     })?;
 
     if record_data.len() != lrecl_len {
         return Err(Error::new(
-            ErrorCode::CBKF221_RDW_UNDERFLOW,
+            ErrorCode::CBKR101_FIXED_RECORD_ERROR,
             format!(
                 "Record length mismatch: expected {}, got {}",
                 configured_lrecl,
@@ -148,6 +148,6 @@ mod tests {
 
         validate_record_length(&schema, 8, 1, b"ABCDEFGH").unwrap();
         let error = validate_record_length(&schema, 8, 2, b"SHORT").unwrap_err();
-        assert_eq!(error.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+        assert_eq!(error.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
     }
 }

--- a/crates/copybook-codec/tests/streaming_file_tests.rs
+++ b/crates/copybook-codec/tests/streaming_file_tests.rs
@@ -509,7 +509,7 @@ fn decode_file_partial_record_at_eof() {
             assert_eq!(summary.bytes_processed, 5);
         }
         Err(error) => {
-            assert_eq!(error.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+            assert_eq!(error.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
             assert!(!error.message.is_empty());
         }
     }

--- a/crates/copybook-fixed/src/lib.rs
+++ b/crates/copybook-fixed/src/lib.rs
@@ -91,7 +91,7 @@ impl<R: Read> FixedRecordReader<R> {
                             Ok(Some(buffer))
                         }
                         Err(e) if e.kind() == ErrorKind::UnexpectedEof => Err(Error::new(
-                            ErrorCode::CBKF221_RDW_UNDERFLOW,
+                            ErrorCode::CBKR101_FIXED_RECORD_ERROR,
                             format!(
                                 "Incomplete record at end of file: expected {} bytes",
                                 self.lrecl
@@ -105,7 +105,7 @@ impl<R: Read> FixedRecordReader<R> {
                             details: Some("File ends with partial record".to_string()),
                         })),
                         Err(e) => Err(Error::new(
-                            ErrorCode::CBKF104_RDW_SUSPECT_ASCII,
+                            ErrorCode::CBKR101_FIXED_RECORD_ERROR,
                             format!("I/O error reading record: {e}"),
                         )
                         .with_context(ErrorContext {
@@ -130,7 +130,7 @@ impl<R: Read> FixedRecordReader<R> {
                 Ok(None)
             }
             Err(e) => Err(Error::new(
-                ErrorCode::CBKF104_RDW_SUSPECT_ASCII,
+                ErrorCode::CBKR101_FIXED_RECORD_ERROR,
                 format!("I/O error reading record: {e}"),
             )
             .with_context(ErrorContext {
@@ -161,7 +161,7 @@ impl<R: Read> FixedRecordReader<R> {
     fn lrecl_usize(&self) -> Result<usize> {
         usize::try_from(self.lrecl).map_err(|_| {
             Error::new(
-                ErrorCode::CBKP001_SYNTAX,
+                ErrorCode::CBKR101_FIXED_RECORD_ERROR,
                 "LRECL exceeds platform addressable size",
             )
         })
@@ -231,7 +231,7 @@ impl<W: Write> FixedRecordWriter<W> {
 
         if data_len > lrecl {
             return Err(Error::new(
-                ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
+                ErrorCode::CBKR101_FIXED_RECORD_ERROR,
                 format!("Record too long: {data_len} bytes exceeds LRECL of {lrecl}"),
             )
             .with_context(ErrorContext {
@@ -245,7 +245,7 @@ impl<W: Write> FixedRecordWriter<W> {
 
         self.output.write_all(data).map_err(|e| {
             Error::new(
-                ErrorCode::CBKF104_RDW_SUSPECT_ASCII,
+                ErrorCode::CBKR101_FIXED_RECORD_ERROR,
                 format!("I/O error writing record: {e}"),
             )
             .with_context(ErrorContext {
@@ -261,7 +261,7 @@ impl<W: Write> FixedRecordWriter<W> {
             let padding = vec![0u8; lrecl - data_len];
             self.output.write_all(&padding).map_err(|e| {
                 Error::new(
-                    ErrorCode::CBKF104_RDW_SUSPECT_ASCII,
+                    ErrorCode::CBKR101_FIXED_RECORD_ERROR,
                     format!("I/O error writing padding: {e}"),
                 )
                 .with_context(ErrorContext {
@@ -294,7 +294,7 @@ impl<W: Write> FixedRecordWriter<W> {
     pub fn flush(&mut self) -> Result<()> {
         self.output.flush().map_err(|e| {
             Error::new(
-                ErrorCode::CBKF104_RDW_SUSPECT_ASCII,
+                ErrorCode::CBKR101_FIXED_RECORD_ERROR,
                 format!("I/O error flushing output: {e}"),
             )
         })
@@ -318,7 +318,7 @@ impl<W: Write> FixedRecordWriter<W> {
     fn lrecl_usize(&self) -> Result<usize> {
         usize::try_from(self.lrecl).map_err(|_| {
             Error::new(
-                ErrorCode::CBKP001_SYNTAX,
+                ErrorCode::CBKR101_FIXED_RECORD_ERROR,
                 "LRECL exceeds platform addressable size",
             )
         })
@@ -365,12 +365,12 @@ mod tests {
     }
 
     #[test]
-    fn fixed_record_reader_partial_record_is_underflow() {
+    fn fixed_record_reader_partial_record_is_fixed_record_error() {
         let data = b"ABCD123";
         let mut reader = FixedRecordReader::new(Cursor::new(data), Some(8)).unwrap();
 
         let error = reader.read_record().unwrap_err();
-        assert_eq!(error.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+        assert_eq!(error.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
     }
 
     #[test]
@@ -418,12 +418,12 @@ mod tests {
     }
 
     #[test]
-    fn fixed_record_writer_too_long_is_cbke501() {
+    fn fixed_record_writer_too_long_is_fixed_record_error() {
         let mut output = Vec::new();
         let mut writer = FixedRecordWriter::new(&mut output, Some(4)).unwrap();
 
         let error = writer.write_record(b"ABCDEFGH").unwrap_err();
-        assert_eq!(error.code, ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+        assert_eq!(error.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
     }
 
     #[test]
@@ -469,7 +469,7 @@ mod tests {
             let mut writer = FixedRecordWriter::new(&mut output, Some(u32::from(lrecl))).unwrap();
             let payload = vec![0x41; usize::from(lrecl) + extra];
             let error = writer.write_record(&payload).unwrap_err();
-            prop_assert_eq!(error.code, ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+            prop_assert_eq!(error.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
         }
     }
 

--- a/crates/copybook-fixed/tests/comprehensive.rs
+++ b/crates/copybook-fixed/tests/comprehensive.rs
@@ -135,7 +135,7 @@ fn writer_rejects_record_longer_than_lrecl() {
     let mut output = Vec::new();
     let mut writer = FixedRecordWriter::new(&mut output, Some(4)).unwrap();
     let err = writer.write_record(b"TOOLONG").unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 #[test]
@@ -143,7 +143,7 @@ fn writer_rejects_record_one_byte_over_lrecl() {
     let mut output = Vec::new();
     let mut writer = FixedRecordWriter::new(&mut output, Some(4)).unwrap();
     let err = writer.write_record(b"ABCDE").unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 #[test]
@@ -187,14 +187,14 @@ fn lrecl_accessors() {
 // ====================================================================
 
 #[test]
-fn partial_record_at_eof_is_underflow() {
+fn partial_record_at_eof_is_fixed_record_error() {
     // 7 bytes, LRECL=4: first record OK, second is partial (3 bytes)
     let data = b"ABCDEFG";
     let mut reader = FixedRecordReader::new(Cursor::new(data.as_slice()), Some(4)).unwrap();
     let r1 = reader.read_record().unwrap().unwrap();
     assert_eq!(r1, b"ABCD");
     let err = reader.read_record().unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 #[test]
@@ -204,7 +204,7 @@ fn partial_record_single_byte_remainder() {
     let mut reader = FixedRecordReader::new(Cursor::new(data.as_slice()), Some(4)).unwrap();
     reader.read_record().unwrap().unwrap();
     let err = reader.read_record().unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 #[test]
@@ -213,7 +213,7 @@ fn partial_record_one_less_than_lrecl() {
     let data = vec![0x41u8; 99];
     let mut reader = FixedRecordReader::new(Cursor::new(&data), Some(100)).unwrap();
     let err = reader.read_record().unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 // ====================================================================

--- a/crates/copybook-fixed/tests/fixed_comprehensive.rs
+++ b/crates/copybook-fixed/tests/fixed_comprehensive.rs
@@ -103,7 +103,7 @@ fn partial_last_record_two_bytes_short() {
     let mut reader = FixedRecordReader::new(Cursor::new(&data), Some(8)).unwrap();
     reader.read_record().unwrap().unwrap(); // first full record
     let err = reader.read_record().unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
     assert_eq!(reader.record_count(), 1); // only the successful read counted
 }
 
@@ -113,7 +113,7 @@ fn partial_record_exactly_one_byte() {
     let data = vec![0x42u8];
     let mut reader = FixedRecordReader::new(Cursor::new(&data), Some(10)).unwrap();
     let err = reader.read_record().unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 #[test]
@@ -122,7 +122,7 @@ fn partial_record_lrecl_minus_one() {
     let data = vec![0x43u8; 49];
     let mut reader = FixedRecordReader::new(Cursor::new(&data), Some(50)).unwrap();
     let err = reader.read_record().unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 #[test]
@@ -134,7 +134,7 @@ fn partial_record_after_multiple_good_records() {
         reader.read_record().unwrap().unwrap();
     }
     let err = reader.read_record().unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
     assert_eq!(reader.record_count(), 3);
 }
 
@@ -272,7 +272,7 @@ fn write_rejects_oversized_record() {
     let mut output = Vec::new();
     let mut writer = FixedRecordWriter::new(&mut output, Some(4)).unwrap();
     let err = writer.write_record(b"TOOLONG").unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
     assert_eq!(writer.record_count(), 0);
 }
 
@@ -281,7 +281,7 @@ fn write_rejects_one_byte_over_lrecl() {
     let mut output = Vec::new();
     let mut writer = FixedRecordWriter::new(&mut output, Some(5)).unwrap();
     let err = writer.write_record(b"ABCDEF").unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 #[test]

--- a/crates/copybook-fixed/tests/fixed_deep.rs
+++ b/crates/copybook-fixed/tests/fixed_deep.rs
@@ -261,7 +261,7 @@ fn long_record_rejected_with_error_code() {
     let mut out = Vec::new();
     let mut w = FixedRecordWriter::new(&mut out, Some(4)).unwrap();
     let err = w.write_record(b"TOOLONG").unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 #[test]
@@ -269,7 +269,7 @@ fn long_record_one_byte_over_rejected() {
     let mut out = Vec::new();
     let mut w = FixedRecordWriter::new(&mut out, Some(5)).unwrap();
     let err = w.write_record(b"ABCDEF").unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 #[test]
@@ -311,7 +311,7 @@ fn long_record_various_excess_sizes() {
         let err = w.write_record(&payload).unwrap_err();
         assert_eq!(
             err.code,
-            ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
+            ErrorCode::CBKR101_FIXED_RECORD_ERROR,
             "wrong error for lrecl={lrecl}, excess={excess}"
         );
     }
@@ -668,8 +668,8 @@ fn flush_failure_returns_error() {
     let mut fail_flusher = FlushFailWriter::new();
     let mut w = FixedRecordWriter::new(&mut fail_flusher, Some(4)).unwrap();
     w.write_record(b"DATA").unwrap();
-    let err = w.flush();
-    assert!(err.is_err());
+    let err = w.flush().unwrap_err();
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 #[test]
@@ -757,19 +757,22 @@ fn writer_lrecl_accessor_returns_configured_value() {
 #[test]
 fn read_io_error_propagates() {
     let mut r = FixedRecordReader::new(AlwaysFailReader, Some(10)).unwrap();
-    assert!(r.read_record().is_err());
+    let error = r.read_record().unwrap_err();
+    assert_eq!(error.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 #[test]
 fn write_io_error_propagates() {
     let mut w = FixedRecordWriter::new(AlwaysFailWriter, Some(4)).unwrap();
-    assert!(w.write_record(b"FAIL").is_err());
+    let error = w.write_record(b"FAIL").unwrap_err();
+    assert_eq!(error.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 #[test]
 fn flush_io_error_propagates() {
     let mut w = FixedRecordWriter::new(AlwaysFailWriter, Some(4)).unwrap();
-    assert!(w.flush().is_err());
+    let error = w.flush().unwrap_err();
+    assert_eq!(error.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 // =========================================================================
@@ -777,14 +780,14 @@ fn flush_io_error_propagates() {
 // =========================================================================
 
 #[test]
-fn truncated_single_byte_with_large_lrecl() {
+fn truncated_single_byte_with_large_lrecl_is_fixed_record_error() {
     let mut r = FixedRecordReader::new(Cursor::new(vec![0x42u8]), Some(1000)).unwrap();
     let err = r.read_record().unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 #[test]
-fn truncated_after_good_records_returns_error() {
+fn truncated_after_good_records_is_fixed_record_error() {
     // 3 good records of 4 bytes + 2 leftover bytes
     let data = vec![0x41; 14];
     let mut r = FixedRecordReader::new(Cursor::new(&data), Some(4)).unwrap();
@@ -792,16 +795,16 @@ fn truncated_after_good_records_returns_error() {
         r.read_record().unwrap().unwrap();
     }
     let err = r.read_record().unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
     assert_eq!(r.record_count(), 3);
 }
 
 #[test]
-fn truncated_lrecl_minus_one_bytes() {
+fn truncated_lrecl_minus_one_bytes_is_fixed_record_error() {
     let data = vec![0x43; 79]; // LRECL=80, only 79 bytes
     let mut r = FixedRecordReader::new(Cursor::new(&data), Some(80)).unwrap();
     let err = r.read_record().unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 // =========================================================================

--- a/crates/copybook-fixed/tests/fixed_edge_cases.rs
+++ b/crates/copybook-fixed/tests/fixed_edge_cases.rs
@@ -35,7 +35,7 @@ fn read_input_shorter_than_lrecl_returns_error() {
     let data = b"SHORT";
     let mut reader = FixedRecordReader::new(Cursor::new(data.as_slice()), Some(100)).unwrap();
     let err = reader.read_record().unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 #[test]
@@ -43,7 +43,7 @@ fn read_single_byte_input_with_large_lrecl_returns_error() {
     let data = vec![0x42u8];
     let mut reader = FixedRecordReader::new(Cursor::new(&data), Some(1000)).unwrap();
     let err = reader.read_record().unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 // ====================================================================
@@ -91,7 +91,7 @@ fn read_input_not_divisible_by_lrecl_errors_on_partial() {
     assert_eq!(r2, b"BBBBB");
 
     let err = reader.read_record().unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 #[test]
@@ -103,7 +103,7 @@ fn read_input_one_extra_byte_errors_on_partial() {
     reader.read_record().unwrap().unwrap();
 
     let err = reader.read_record().unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 // ====================================================================

--- a/crates/copybook-fixed/tests/fixed_framing_comprehensive.rs
+++ b/crates/copybook-fixed/tests/fixed_framing_comprehensive.rs
@@ -60,30 +60,30 @@ fn read_exact_lrecl_ten_records() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn read_partial_record_at_end_is_underflow() {
+fn read_partial_record_at_end_is_fixed_record_error() {
     let data = vec![0xBBu8; 83]; // 80 + 3 leftover
     let mut reader = FixedRecordReader::new(Cursor::new(&data), Some(80)).unwrap();
     let _ = reader.read_record().unwrap().unwrap(); // first 80 bytes ok
     let err = reader.read_record().unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 #[test]
-fn read_short_by_one_byte_is_underflow() {
+fn read_short_by_one_byte_is_fixed_record_error() {
     let data = vec![0xCCu8; 79]; // need 80
     let mut reader = FixedRecordReader::new(Cursor::new(&data), Some(80)).unwrap();
     let err = reader.read_record().unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 #[test]
-fn read_one_extra_byte_is_underflow() {
+fn read_one_extra_byte_is_fixed_record_error() {
     let data = vec![0xDDu8; 161]; // two records = 160, one extra
     let mut reader = FixedRecordReader::new(Cursor::new(&data), Some(80)).unwrap();
     reader.read_record().unwrap().unwrap();
     reader.read_record().unwrap().unwrap();
     let err = reader.read_record().unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 // ---------------------------------------------------------------------------
@@ -207,7 +207,7 @@ fn write_oversize_data_is_error() {
     let mut output = Vec::new();
     let mut writer = FixedRecordWriter::new(&mut output, Some(4)).unwrap();
     let err = writer.write_record(b"ABCDE").unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 #[test]

--- a/crates/copybook-record-io/tests/dispatch_deep.rs
+++ b/crates/copybook-record-io/tests/dispatch_deep.rs
@@ -293,7 +293,7 @@ fn error_fixed_read_missing_lrecl() {
 fn error_fixed_read_truncated_record() {
     let mut c = Cursor::new(b"AB".to_vec());
     let err = read_record(&mut c, RecordFormat::Fixed, Some(10)).unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 #[test]
@@ -358,7 +358,7 @@ fn error_fixed_writer_rejects_oversized_data() {
     let mut buf = Vec::new();
     let mut w = FixedRecordWriter::new(&mut buf, Some(4)).unwrap();
     let err = w.write_record(b"TOOLONG").unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 #[test]

--- a/crates/copybook-record-io/tests/record_io_comprehensive.rs
+++ b/crates/copybook-record-io/tests/record_io_comprehensive.rs
@@ -258,7 +258,7 @@ fn reexported_fixed_writer_rejects_oversized() {
     let mut wire = Vec::new();
     let mut writer = FixedRecordWriter::new(&mut wire, Some(4)).unwrap();
     let err = writer.write_record(b"TOOLONG").unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 // ====================================================================

--- a/crates/copybook-record-io/tests/record_io_dispatch_comprehensive.rs
+++ b/crates/copybook-record-io/tests/record_io_dispatch_comprehensive.rs
@@ -140,7 +140,7 @@ fn dispatch_fixed_partial_record_propagates_underflow() {
     let data = b"SHORT"; // 5 bytes, LRECL=10
     let mut cursor = Cursor::new(data.to_vec());
     let err = read_record(&mut cursor, RecordFormat::Fixed, Some(10)).unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+    assert_eq!(err.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 #[test]

--- a/docs/reference/ERROR_CODES.md
+++ b/docs/reference/ERROR_CODES.md
@@ -307,14 +307,18 @@ Resolution: Check field name with `copybook inspect schema.cpy`
 Errors in record framing and I/O processing.
 
 #### CBKR101_FIXED_RECORD_ERROR
-**Description**: Error processing fixed-length record
+**Description**: Error processing fixed-length record framing or I/O
 **Severity**: Fatal
-**Context**: Record number, error details
-**Resolution**: Check record format and data integrity
+**Context**: Record number, byte offset when available, error details
+**Resolution**: Check the configured LRECL, record boundaries, input/output integrity, and available address space
+
+Use this code for fixed-format framing failures such as truncated input,
+oversize output records, and read/write/flush failures. RDW-specific failures
+continue to use the `CBKF*` record-format codes.
 
 ```
 Error: CBKR101_FIXED_RECORD_ERROR at record 75
-Fixed-length record processing failed
+Fixed-length record processing failed: incomplete record at end of file
 ```
 
 #### CBKR201_RDW_READ_ERROR

--- a/docs/reference/ERROR_CODES.md
+++ b/docs/reference/ERROR_CODES.md
@@ -313,10 +313,12 @@ Errors in record framing and I/O processing.
 **Resolution**: Check the configured LRECL, record boundaries, input/output integrity, and available address space
 
 Use this code for fixed-format framing failures such as truncated input,
-oversize output records, and read/write/flush failures. RDW-specific failures
-continue to use the `CBKF*` record-format codes.
+oversize output records, and read/write/flush failures. RDW framing paths that
+use `CBKF*` continue to use those record-format codes; other RDW-specific
+failures, such as `CBKR201_RDW_READ_ERROR` and `CBKR211_RDW_RESERVED_NONZERO`,
+remain separate.
 
-```
+```text
 Error: CBKR101_FIXED_RECORD_ERROR at record 75
 Fixed-length record processing failed: incomplete record at end of file
 ```

--- a/tests/e2e/e2e_cli_error_code_coverage.rs
+++ b/tests/e2e/e2e_cli_error_code_coverage.rs
@@ -850,9 +850,9 @@ fn cli_cbkf104_rdw_suspect_ascii() {
     );
 }
 
-/// CBKF221: Truncated fixed-length record (file shorter than LRECL).
+/// CBKR101: Truncated fixed-length record (file shorter than LRECL).
 #[test]
-fn cli_cbkf221_rdw_underflow_fixed() {
+fn cli_cbkr101_fixed_record_error_for_truncated_fixed_record() {
     // Schema needs 13 bytes per record but data is only 5 bytes
     let dir = setup_decode(
         "       01  REC.\n           05  NAME   PIC X(10).\n           05  AGE    PIC 9(3).\n",
@@ -874,8 +874,8 @@ fn cli_cbkf221_rdw_underflow_fixed() {
     let se = stderr_str(&output);
     assert_no_panic(&se);
     assert!(
-        se.contains("CBKF221_RDW_UNDERFLOW"),
-        "Expected CBKF221 in stderr: {se}"
+        se.contains("CBKR101_FIXED_RECORD_ERROR"),
+        "Expected CBKR101 in stderr: {se}"
     );
 }
 


### PR DESCRIPTION
## Summary

- use `CBKR101_FIXED_RECORD_ERROR` for fixed-record truncation, oversize payloads, framing I/O, and platform-size failures
- keep `CBKF*` identities for RDW-specific paths and update the canonical error reference
- strengthen direct fixed, codec, record-io, and CLI trigger tests so the stable mapping is executable evidence

This is Issue #650 Slice B. Slice A (schema-independent fixed framing) is already merged; Slice C remains separate. The standalone lockfile refresh is a separate CI PR (#679) and is included here only through the updated main base; no dependency ownership changes are part of this diagnostics lane.

## Proof

- `cargo fmt --all -- --check`
- `cargo test -p copybook-fixed`
- `cargo test -p copybook-codec`
- `cargo test -p copybook-codec --test fixed_microcrate_integration`
- `cargo test -p copybook-record-io`
- `cargo build -p copybook-cli`
- `cargo test -p copybook-e2e --test e2e_cli_error_code_coverage cli_cbkr101_fixed_record_error_for_truncated_fixed_record`
- `cargo clippy -p copybook-fixed -p copybook-codec --all-targets -- -D warnings`
- `cargo run -p xtask -- docs verify-all`
- `cargo run -p xtask -- architecture check`
- `just deny` (pass; existing unmatched allowances and duplicate transitive-crate warnings only)

Refs #650
Refs #576

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized errors for invalid fixed-length records, including truncated input, oversized records, and read/write failures.
  * Improved consistency when reporting incomplete records at end of file.

* **Documentation**
  * Expanded fixed-record error guidance with clearer troubleshooting steps and examples.
  * Clarified the distinction between fixed-record and RDW-specific errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->