### PR TITLE
ci: refresh standalone lockfiles

### DIFF
--- a/examples/kafka_pipeline/Cargo.lock
+++ b/examples/kafka_pipeline/Cargo.lock
@@ -150,11 +150,9 @@ dependencies = [
 name = "copybook-core"
 version = "0.5.0"
 dependencies = [
- "copybook-dialect",
  "copybook-error",
  "copybook-error-reporter",
  "copybook-governance-contracts",
- "copybook-lexer",
  "copybook-overflow",
  "copybook-utils",
  "logos",
@@ -205,13 +203,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "copybook-dialect"
-version = "0.5.0"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "copybook-error"
 version = "0.5.0"
 dependencies = [
@@ -231,7 +222,6 @@ dependencies = [
 name = "copybook-fixed"
 version = "0.5.0"
 dependencies = [
- "copybook-core",
  "copybook-error",
  "tracing",
 ]
@@ -242,13 +232,6 @@ version = "0.5.0"
 dependencies = [
  "copybook-contracts",
  "copybook-support-matrix",
-]
-
-[[package]]
-name = "copybook-lexer"
-version = "0.5.0"
-dependencies = [
- "logos",
 ]
 
 [[package]]

--- a/examples/kafka_streaming/Cargo.lock
+++ b/examples/kafka_streaming/Cargo.lock
@@ -150,11 +150,9 @@ dependencies = [
 name = "copybook-core"
 version = "0.5.0"
 dependencies = [
- "copybook-dialect",
  "copybook-error",
  "copybook-error-reporter",
  "copybook-governance-contracts",
- "copybook-lexer",
  "copybook-overflow",
  "copybook-utils",
  "logos",
@@ -205,13 +203,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "copybook-dialect"
-version = "0.5.0"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "copybook-error"
 version = "0.5.0"
 dependencies = [
@@ -231,7 +222,6 @@ dependencies = [
 name = "copybook-fixed"
 version = "0.5.0"
 dependencies = [
- "copybook-core",
  "copybook-error",
  "tracing",
 ]
@@ -242,13 +232,6 @@ version = "0.5.0"
 dependencies = [
  "copybook-contracts",
  "copybook-support-matrix",
-]
-
-[[package]]
-name = "copybook-lexer"
-version = "0.5.0"
-dependencies = [
- "logos",
 ]
 
 [[package]]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -209,7 +209,6 @@ dependencies = [
 name = "copybook-fixed"
 version = "0.5.0"
 dependencies = [
- "copybook-core",
  "copybook-error",
  "tracing",
 ]


### PR DESCRIPTION
## Summary

- refresh the standalone Kafka example lockfiles after the fixed-framing dependency split
- refresh the fuzz workspace lockfile so its `--locked` CI check is reproducible
- remove stale local dependency edges without changing source manifests or runtime behavior

## Proof

- `cargo check --locked --manifest-path examples/kafka_pipeline/Cargo.toml`
- `cargo check --locked --manifest-path examples/kafka_streaming/Cargo.toml`
- `cargo check --locked --manifest-path fuzz/Cargo.toml`
- `just deny` (pass; existing duplicate and unmatched-allowance warnings only)
- `git diff --check`

This is CI/dependency metadata hygiene only; no production source changes are included.