### PR TITLE
refactor(rdw): own transfer diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,7 +951,7 @@ version = "0.5.0"
 dependencies = [
  "copybook-core",
  "copybook-corruption-detectors",
- "copybook-corruption-rdw",
+ "copybook-rdw",
 ]
 
 [[package]]
@@ -971,10 +971,9 @@ version = "0.5.0"
 name = "copybook-corruption-rdw"
 version = "0.5.0"
 dependencies = [
- "copybook-core",
  "copybook-corruption",
- "copybook-corruption-predicates",
- "copybook-rdw-predicates",
+ "copybook-error",
+ "copybook-rdw",
  "proptest",
 ]
 
@@ -1162,7 +1161,6 @@ name = "copybook-rdw"
 version = "0.5.0"
 dependencies = [
  "copybook-error",
- "copybook-rdw-predicates",
  "proptest",
  "tracing",
 ]

--- a/crates/copybook-corruption-rdw/Cargo.toml
+++ b/crates/copybook-corruption-rdw/Cargo.toml
@@ -21,12 +21,11 @@ all-features = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-copybook-core.workspace = true
-copybook-rdw-predicates.workspace = true
-copybook-corruption-predicates.workspace = true
+copybook-rdw.workspace = true
 
 [dev-dependencies]
 copybook-corruption = { path = "../copybook-corruption" }
+copybook-error.workspace = true
 proptest.workspace = true
 
 [lints]

--- a/crates/copybook-corruption-rdw/README.md
+++ b/crates/copybook-corruption-rdw/README.md
@@ -1,8 +1,7 @@
 # copybook-corruption-rdw
 
-Small, single-purpose crate for RDW ASCII-transfer corruption heuristics.
+Small 0.5 compatibility crate forwarding RDW ASCII-transfer corruption
+heuristics to `copybook_rdw::diagnostics`.
 
-This crate isolates the RDW header corruption decision logic from
-`copybook-corruption` so it can be exercised independently by unit tests,
-property tests, and fuzzing while keeping the existing API surface in
-`copybook-corruption` stable.
+The canonical implementation lives with the RDW framing owner; this package
+remains available for existing 0.5 call sites while primary consumers migrate.

--- a/crates/copybook-corruption-rdw/src/lib.rs
+++ b/crates/copybook-corruption-rdw/src/lib.rs
@@ -2,89 +2,21 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! RDW corruption heuristics.
 //!
-//! This crate owns only RDW ASCII-corruption detection.
+//! This 0.5 compatibility crate forwards to [`copybook_rdw::diagnostics`].
 
-use copybook_core::{Error, ErrorCode};
-use copybook_corruption_predicates::is_ascii_printable;
-use copybook_rdw_predicates::rdw_is_suspect_ascii_corruption_slice;
-
-/// Heuristics for detecting ASCII transfer corruption in RDW headers.
-///
-/// This function implements the `CBKF104_RDW_SUSPECT_ASCII` detection logic by
-/// checking for patterns that suggest binary data was converted through ASCII
-/// transfer by mistake (for example, EBCDIC/ASCII confusion around the length
-/// field).
-#[inline]
-#[must_use = "Handle the returned error when corruption is detected"]
-pub fn detect_rdw_ascii_corruption(rdw_bytes: &[u8]) -> Option<Error> {
-    if rdw_bytes.len() < 4 {
-        return None;
-    }
-
-    // Extract the length field (first 2 bytes, big-endian).
-    let length_bytes = [rdw_bytes[0], rdw_bytes[1]];
-    let length = u16::from_be_bytes(length_bytes);
-
-    // Heuristic 1: Length field contains ASCII digits.
-    if rdw_is_suspect_ascii_corruption_slice(rdw_bytes) {
-        return Some(Error::new(
-            ErrorCode::CBKF104_RDW_SUSPECT_ASCII,
-            format!(
-                "RDW length field appears to contain ASCII digits: 0x{:02X}{:02X} ('{}{}')",
-                rdw_bytes[0],
-                rdw_bytes[1],
-                ascii_char_or_dot(rdw_bytes[0]),
-                ascii_char_or_dot(rdw_bytes[1])
-            ),
-        ));
-    }
-
-    // Heuristic 2: Unreasonably large length values that could be ASCII.
-    if length > 0x3030 && length <= 0x3939 {
-        // Range covers ASCII '00'..='99' when interpreted as binary.
-        return Some(Error::new(
-            ErrorCode::CBKF104_RDW_SUSPECT_ASCII,
-            format!(
-                "RDW length field suspiciously large ({length}), may be ASCII-corrupted: 0x{length:04X}"
-            ),
-        ));
-    }
-
-    // Heuristic 3: Reserved bytes contain ASCII-like printable bytes.
-    if is_ascii_printable(rdw_bytes[2])
-        && is_ascii_printable(rdw_bytes[3])
-        && rdw_bytes[2..4] != [0x00, 0x00]
-    {
-        return Some(Error::new(
-            ErrorCode::CBKF104_RDW_SUSPECT_ASCII,
-            format!(
-                "RDW reserved bytes contain ASCII-like data: 0x{:02X}{:02X} ('{}{}')",
-                rdw_bytes[2],
-                rdw_bytes[3],
-                ascii_char_or_dot(rdw_bytes[2]),
-                ascii_char_or_dot(rdw_bytes[3])
-            ),
-        ));
-    }
-
-    None
-}
-
-fn ascii_char_or_dot(byte: u8) -> char {
-    if is_ascii_printable(byte) {
-        byte as char
-    } else {
-        '.'
-    }
-}
+pub use copybook_rdw::diagnostics::detect_rdw_ascii_corruption;
 
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use copybook_core::ErrorCode;
-    use copybook_rdw_predicates::rdw_is_suspect_ascii_corruption_slice;
+    use copybook_error::ErrorCode;
+    use copybook_rdw::diagnostics::rdw_is_suspect_ascii_corruption_slice;
     use proptest::prelude::*;
+
+    const fn is_ascii_printable(byte: u8) -> bool {
+        byte >= 0x20 && byte <= 0x7E
+    }
 
     fn expected_corruption_present(data: &[u8]) -> bool {
         if data.len() < 4 {

--- a/crates/copybook-corruption-rdw/tests/comprehensive_rdw_corruption_tests.rs
+++ b/crates/copybook-corruption-rdw/tests/comprehensive_rdw_corruption_tests.rs
@@ -3,8 +3,8 @@
 
 //! Comprehensive tests for RDW-specific corruption detection heuristics.
 
-use copybook_core::ErrorCode;
 use copybook_corruption_rdw::detect_rdw_ascii_corruption;
+use copybook_error::ErrorCode;
 
 // ===========================================================================
 // Short/empty input handling

--- a/crates/copybook-corruption-rdw/tests/rdw_corruption_comprehensive.rs
+++ b/crates/copybook-corruption-rdw/tests/rdw_corruption_comprehensive.rs
@@ -5,8 +5,8 @@
 //! file, length exceeds max record size, non-zero reserved bytes, truncated
 //! RDW at end of file, and multiple sequential corruptions.
 
-use copybook_core::ErrorCode;
 use copybook_corruption_rdw::detect_rdw_ascii_corruption;
+use copybook_error::ErrorCode;
 
 // ===========================================================================
 // Invalid RDW header length (0, 1, 2, 3 bytes)

--- a/crates/copybook-corruption-rdw/tests/rdw_corruption_deep.rs
+++ b/crates/copybook-corruption-rdw/tests/rdw_corruption_deep.rs
@@ -5,8 +5,8 @@
 //! length overflow detection, sequence validation across records,
 //! mixed valid/corrupt records, and recovery after corruption.
 
-use copybook_core::ErrorCode;
 use copybook_corruption_rdw::detect_rdw_ascii_corruption;
+use copybook_error::ErrorCode;
 
 // ===========================================================================
 // Corrupted RDW headers — various byte patterns

--- a/crates/copybook-corruption-rdw/tests/rdw_corruption_tests.rs
+++ b/crates/copybook-corruption-rdw/tests/rdw_corruption_tests.rs
@@ -4,8 +4,8 @@
 //! Tests for RDW-specific corruption detection: valid headers, length
 //! mismatches, reserved byte corruption, and truncated headers.
 
-use copybook_core::ErrorCode;
 use copybook_corruption_rdw::detect_rdw_ascii_corruption;
+use copybook_error::ErrorCode;
 
 // ===========================================================================
 // Valid RDW passes — no corruption detected

--- a/crates/copybook-corruption/Cargo.toml
+++ b/crates/copybook-corruption/Cargo.toml
@@ -22,8 +22,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 copybook-core.workspace = true
-copybook-corruption-rdw.workspace = true
 copybook-corruption-detectors.workspace = true
+copybook-rdw.workspace = true
 
 [dev-dependencies]
 copybook-corruption-detectors = { path = "../copybook-corruption-detectors" }

--- a/crates/copybook-corruption/README.md
+++ b/crates/copybook-corruption/README.md
@@ -6,7 +6,10 @@ This crate re-exports the focused detector microcrates used by higher-level code
 logic:
 
 - `copybook-corruption-detectors` for packed-decimal and EBCDIC detector bodies.
-- `copybook-corruption-rdw` for RDW ASCII corruption heuristics.
+- `copybook_rdw::diagnostics` for RDW ASCII corruption heuristics.
+
+The former `copybook-corruption-rdw` package remains a 0.5 compatibility
+surface while primary consumers use the RDW owner directly.
 
 It keeps a compact public API while preserving existing callsites that depend on
 `copybook-corruption` directly.

--- a/crates/copybook-corruption/src/lib.rs
+++ b/crates/copybook-corruption/src/lib.rs
@@ -6,7 +6,7 @@
 //! delegated to dedicated microcrates and re-exported here for stable call sites.
 
 pub use copybook_corruption_detectors::{detect_ebcdic_corruption, detect_packed_corruption};
-pub use copybook_corruption_rdw::detect_rdw_ascii_corruption;
+pub use copybook_rdw::diagnostics::detect_rdw_ascii_corruption;
 
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]

--- a/crates/copybook-rdw-predicates/Cargo.toml
+++ b/crates/copybook-rdw-predicates/Cargo.toml
@@ -23,7 +23,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 [lints]
 workspace = true
 
+[dependencies]
+copybook-rdw.workspace = true
+
 [dev-dependencies]
 copybook-corruption = { path = "../copybook-corruption" }
 copybook-corruption-rdw = { path = "../copybook-corruption-rdw" }
-copybook-rdw = { path = "../copybook-rdw" }

--- a/crates/copybook-rdw-predicates/README.md
+++ b/crates/copybook-rdw-predicates/README.md
@@ -2,8 +2,8 @@
 
 Single-responsibility microcrate for the RDW ASCII-digit header heuristic.
 
-This crate contains the shared byte-level predicate used to quickly detect
-length-byte corruption patterns in RDW headers. It intentionally stays narrow:
+This 0.5 compatibility crate forwards the byte-level predicate owned by
+`copybook_rdw::diagnostics`. It intentionally stays narrow:
 
 - `rdw_is_suspect_ascii_corruption` checks whether RDW length bytes look like
   ASCII digits.

--- a/crates/copybook-rdw-predicates/src/lib.rs
+++ b/crates/copybook-rdw-predicates/src/lib.rs
@@ -1,36 +1,14 @@
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // SPDX-License-Identifier: AGPL-3.0-or-later
-//! RDW header ASCII-digit detection helper.
+//! 0.5 compatibility wrapper for the RDW diagnostic predicate.
 //!
-//! This crate owns exactly one predicate: whether RDW length bytes look like ASCII
-//! digits and therefore likely represent ASCII-transfer corruption.
+//! The implementation is owned by `copybook_rdw::diagnostics`; this package
+//! preserves the published predicate paths while primary consumers migrate.
 
-/// RDW header size in bytes.
-pub const RDW_HEADER_LEN: usize = 4;
-
-/// Returns `true` if the first two RDW header bytes are ASCII digits, indicating likely ASCII-transfer corruption.
-#[inline]
-#[must_use]
-pub const fn rdw_is_suspect_ascii_corruption(rdw_header: [u8; RDW_HEADER_LEN]) -> bool {
-    let b0 = rdw_header[0];
-    let b1 = rdw_header[1];
-
-    is_ascii_digit(b0) && is_ascii_digit(b1)
-}
-
-/// Slice-based variant of [`rdw_is_suspect_ascii_corruption`] that checks at least 4 bytes.
-#[inline]
-#[must_use]
-pub fn rdw_is_suspect_ascii_corruption_slice(rdw_bytes: &[u8]) -> bool {
-    rdw_bytes.len() >= RDW_HEADER_LEN
-        && rdw_is_suspect_ascii_corruption([rdw_bytes[0], rdw_bytes[1], rdw_bytes[2], rdw_bytes[3]])
-}
-
-#[inline]
-#[must_use]
-const fn is_ascii_digit(byte: u8) -> bool {
-    byte >= b'0' && byte <= b'9'
-}
+pub use copybook_rdw::RDW_HEADER_LEN;
+pub use copybook_rdw::diagnostics::{
+    rdw_is_suspect_ascii_corruption, rdw_is_suspect_ascii_corruption_slice,
+};
 
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]

--- a/crates/copybook-rdw/Cargo.toml
+++ b/crates/copybook-rdw/Cargo.toml
@@ -22,7 +22,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 copybook-error.workspace = true
-copybook-rdw-predicates.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/copybook-rdw/README.md
+++ b/crates/copybook-rdw/README.md
@@ -12,6 +12,11 @@ helpers for custom framing scenarios.
 The framing crate is schema-independent. Schema-derived minimum payload and ODO compatibility
 checks belong to `copybook-codec::file::rdw`; this package does not depend on `copybook-core`.
 
+RDW transfer-corruption diagnostics are owned by `copybook_rdw::diagnostics`.
+The former `copybook-rdw-predicates` and `copybook-corruption-rdw` packages
+remain 0.5 compatibility surfaces, but primary packages use this module
+directly.
+
 ## Usage
 
 ```rust
@@ -35,6 +40,7 @@ assert_eq!(record.payload, b"HELLO");
 - `RDWRecordReader<R>` — Streaming reader for RDW-framed records
 - `RDWRecordWriter<W>` — Streaming writer for RDW-framed records
 - `rdw_read_len`, `rdw_slice_body`, `rdw_try_peek_len` — Low-level helpers
+- `diagnostics` — ASCII-transfer heuristics and `CBKF104` detection
 
 ## License
 

--- a/crates/copybook-rdw/src/diagnostics.rs
+++ b/crates/copybook-rdw/src/diagnostics.rs
@@ -1,0 +1,146 @@
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! RDW-specific diagnostics.
+//!
+//! This module owns byte-level RDW transfer-corruption heuristics. It does not
+//! interpret copybook schemas or codec layout semantics.
+
+use copybook_error::{Error, ErrorCode};
+
+/// Returns `true` when the first two RDW bytes look like ASCII digits.
+///
+/// This is a transfer-corruption heuristic, not a complete validity check for
+/// an RDW header.
+#[inline]
+#[must_use]
+pub const fn rdw_is_suspect_ascii_corruption(rdw_header: [u8; crate::RDW_HEADER_LEN]) -> bool {
+    is_ascii_digit(rdw_header[0]) && is_ascii_digit(rdw_header[1])
+}
+
+/// Slice-based variant of [`rdw_is_suspect_ascii_corruption`].
+#[inline]
+#[must_use]
+pub fn rdw_is_suspect_ascii_corruption_slice(rdw_bytes: &[u8]) -> bool {
+    rdw_bytes.len() >= crate::RDW_HEADER_LEN
+        && rdw_is_suspect_ascii_corruption([rdw_bytes[0], rdw_bytes[1], rdw_bytes[2], rdw_bytes[3]])
+}
+
+/// Detect likely ASCII-transfer corruption in an RDW header.
+///
+/// The returned stable error includes the observed header bytes and the
+/// suspected remediation: verify that the source was transferred in binary
+/// mode and that the RDW header was not passed through text conversion.
+#[inline]
+#[must_use = "Handle the returned error when corruption is detected"]
+pub fn detect_rdw_ascii_corruption(rdw_bytes: &[u8]) -> Option<Error> {
+    if rdw_bytes.len() < crate::RDW_HEADER_LEN {
+        return None;
+    }
+
+    let length = u16::from_be_bytes([rdw_bytes[0], rdw_bytes[1]]);
+
+    if rdw_is_suspect_ascii_corruption_slice(rdw_bytes) {
+        return Some(ascii_corruption_error(format!(
+            "RDW length field appears to contain ASCII digits: 0x{:02X}{:02X} ('{}{}')",
+            rdw_bytes[0],
+            rdw_bytes[1],
+            ascii_char_or_dot(rdw_bytes[0]),
+            ascii_char_or_dot(rdw_bytes[1])
+        )));
+    }
+
+    if (0x3030..=0x3939).contains(&length) {
+        return Some(ascii_corruption_error(format!(
+            "RDW length field suspiciously large ({length}), may be ASCII-corrupted: 0x{length:04X}"
+        )));
+    }
+
+    if is_ascii_printable(rdw_bytes[2])
+        && is_ascii_printable(rdw_bytes[3])
+        && rdw_bytes[2..4] != [0x00, 0x00]
+    {
+        return Some(ascii_corruption_error(format!(
+            "RDW reserved bytes contain ASCII-like data: 0x{:02X}{:02X} ('{}{}')",
+            rdw_bytes[2],
+            rdw_bytes[3],
+            ascii_char_or_dot(rdw_bytes[2]),
+            ascii_char_or_dot(rdw_bytes[3])
+        )));
+    }
+
+    None
+}
+
+#[inline]
+fn ascii_corruption_error(detail: String) -> Error {
+    Error::new(
+        ErrorCode::CBKF104_RDW_SUSPECT_ASCII,
+        format!("{detail}; verify binary transfer mode and preserve the RDW header bytes"),
+    )
+}
+
+#[inline]
+#[must_use]
+const fn is_ascii_digit(byte: u8) -> bool {
+    byte >= b'0' && byte <= b'9'
+}
+
+#[inline]
+#[must_use]
+const fn is_ascii_printable(byte: u8) -> bool {
+    byte >= 0x20 && byte <= 0x7E
+}
+
+#[inline]
+fn ascii_char_or_dot(byte: u8) -> char {
+    if is_ascii_printable(byte) {
+        byte as char
+    } else {
+        '.'
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn digit_length_bytes_are_suspect() {
+        assert!(rdw_is_suspect_ascii_corruption([b'1', b'2', 0, 0]));
+        assert!(!rdw_is_suspect_ascii_corruption([0, 0x50, 0, 0]));
+    }
+
+    #[test]
+    fn slice_requires_a_complete_header() {
+        assert!(!rdw_is_suspect_ascii_corruption_slice(b"12"));
+        assert!(rdw_is_suspect_ascii_corruption_slice(b"12\0\0"));
+    }
+
+    #[test]
+    fn detects_ascii_digit_length_with_remediation() {
+        let error = detect_rdw_ascii_corruption(b"12\0\0").expect("digits should be detected");
+
+        assert_eq!(error.code, ErrorCode::CBKF104_RDW_SUSPECT_ASCII);
+        assert!(error.message.contains("binary transfer mode"));
+    }
+
+    #[test]
+    fn detects_printable_reserved_bytes() {
+        let error = detect_rdw_ascii_corruption(&[0x00, 0x50, b'A', b'B'])
+            .expect("printable reserved bytes should be detected");
+
+        assert_eq!(error.code, ErrorCode::CBKF104_RDW_SUSPECT_ASCII);
+        assert!(error.message.contains("reserved bytes"));
+    }
+
+    #[test]
+    fn clean_binary_header_is_not_corrupt() {
+        assert!(detect_rdw_ascii_corruption(&[0x00, 0x50, 0x00, 0x00]).is_none());
+    }
+
+    #[test]
+    fn short_input_is_not_corrupt() {
+        assert!(detect_rdw_ascii_corruption(&[b'1', b'2', 0]).is_none());
+    }
+}

--- a/crates/copybook-rdw/src/diagnostics.rs
+++ b/crates/copybook-rdw/src/diagnostics.rs
@@ -72,7 +72,8 @@ pub fn detect_rdw_ascii_corruption(rdw_bytes: &[u8]) -> Option<Error> {
 }
 
 #[inline]
-fn ascii_corruption_error(detail: String) -> Error {
+fn ascii_corruption_error(detail: impl Into<String>) -> Error {
+    let detail = detail.into();
     Error::new(
         ErrorCode::CBKF104_RDW_SUSPECT_ASCII,
         format!("{detail}; verify binary transfer mode and preserve the RDW header bytes"),

--- a/crates/copybook-rdw/src/header.rs
+++ b/crates/copybook-rdw/src/header.rs
@@ -1,4 +1,4 @@
-use crate::RDW_HEADER_LEN;
+use crate::{RDW_HEADER_LEN, diagnostics::rdw_is_suspect_ascii_corruption};
 use copybook_error::{Error, ErrorCode, Result};
 
 /// Parsed RDW header (`length + reserved`).
@@ -96,13 +96,4 @@ pub fn rdw_payload_len_to_u16(len: usize) -> Result<u16> {
             ),
         )
     })
-}
-
-/// Heuristic to detect ASCII-corrupted RDW headers.
-///
-/// Returns `true` when both RDW length bytes are ASCII digits (`0x30..=0x39`).
-#[must_use]
-#[inline]
-pub const fn rdw_is_suspect_ascii_corruption(rdw_header: [u8; RDW_HEADER_LEN]) -> bool {
-    copybook_rdw_predicates::rdw_is_suspect_ascii_corruption(rdw_header)
 }

--- a/crates/copybook-rdw/src/lib.rs
+++ b/crates/copybook-rdw/src/lib.rs
@@ -11,13 +11,15 @@
 //! ([`rdw_read_len`], [`rdw_slice_body`]) for custom framing.
 
 mod buffer;
+pub mod diagnostics;
 mod header;
 mod reader;
 mod record;
 mod writer;
 
 pub use buffer::{rdw_read_len, rdw_slice_body, rdw_try_peek_len, rdw_validate_and_finish};
-pub use header::{RdwHeader, rdw_is_suspect_ascii_corruption, rdw_payload_len_to_u16};
+pub use diagnostics::{detect_rdw_ascii_corruption, rdw_is_suspect_ascii_corruption};
+pub use header::{RdwHeader, rdw_payload_len_to_u16};
 pub use reader::RDWRecordReader;
 pub use record::RDWRecord;
 pub use writer::RDWRecordWriter;

--- a/docs/architecture/package-boundary-debt.json
+++ b/docs/architecture/package-boundary-debt.json
@@ -84,10 +84,6 @@
     {
       "id": "primary-dep:copybook-core->copybook-utils",
       "owner_issue": 655
-    },
-    {
-      "id": "primary-dep:copybook-rdw->copybook-rdw-predicates",
-      "owner_issue": 651
     }
   ]
 }


### PR DESCRIPTION
## Summary

- add `copybook_rdw::diagnostics` as the owner of RDW ASCII-transfer detection
- move the predicate and `CBKF104_RDW_SUSPECT_ASCII` detector out of the retiring RDW utility packages
- preserve `copybook-rdw-predicates` and `copybook-corruption-rdw` as 0.5 compatibility forwarders
- retarget `copybook-corruption` and remove both retiring packages from primary dependency paths
- preserve existing detector behavior while adding binary-transfer remediation context

This is Issue #651 Slice B only. Stable diagnostic ownership/code-contract changes remain Slice C.

## Proof

- `cargo test -p copybook-rdw`
- `cargo test -p copybook-rdw-predicates`
- `cargo test -p copybook-corruption-rdw`
- `cargo test -p copybook-corruption`
- `cargo test -p copybook-codec --lib file::rdw`
- `cargo test -p copybook-codec --test rdw_microcrate_integration`
- `cargo clippy -p copybook-rdw -p copybook-rdw-predicates -p copybook-corruption-rdw -p copybook-corruption --all-targets -- -D warnings`
- `cargo run -p xtask -- docs verify-all`
- `cargo run -p xtask -- architecture check`
- `just deny`
- `cargo fmt --all -- --check`
- `git diff --check`

The primary `copybook-rdw` tree contains only `copybook-error` and `tracing`; the codec tree no longer reaches `copybook-rdw-predicates` or `copybook-corruption-rdw`.

Refs #651
Refs #641

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RDW diagnostics for detecting likely ASCII-transfer corruption, including stable error reporting and remediation guidance.
  * Exposed RDW corruption checks through the primary RDW package.

* **Bug Fixes**
  * Preserved existing compatibility interfaces while redirecting detection to the centralized RDW diagnostics.

* **Documentation**
  * Updated package documentation to clarify RDW diagnostic ownership and compatibility support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->