### PR TITLE
fix(rdw): preserve framing error for oversized payload

### DIFF
--- a/crates/copybook-rdw/src/lib.rs
+++ b/crates/copybook-rdw/src/lib.rs
@@ -274,14 +274,14 @@ mod tests {
     }
 
     #[test]
-    fn rdw_writer_payload_too_large_is_cbke501() {
+    fn rdw_writer_payload_too_large_is_cbkf102() {
         let mut output = Vec::new();
         let mut writer = RDWRecordWriter::new(&mut output);
         let large_payload = vec![0u8; usize::from(u16::MAX) + 1];
         let err = writer
             .write_record_from_payload(&large_payload, None)
             .unwrap_err();
-        assert_eq!(err.code, ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+        assert_eq!(err.code, ErrorCode::CBKF102_RECORD_LENGTH_INVALID);
     }
 
     #[test]

--- a/crates/copybook-rdw/src/writer.rs
+++ b/crates/copybook-rdw/src/writer.rs
@@ -112,7 +112,8 @@ impl<W: Write> RDWRecordWriter<W> {
     /// Write an RDW record directly from payload.
     ///
     /// # Errors
-    /// Returns an error if payload length exceeds `u16::MAX` or I/O fails.
+    /// Returns `CBKF102_RECORD_LENGTH_INVALID` if payload length exceeds
+    /// `u16::MAX`, or an error if writing fails.
     #[inline]
     #[must_use = "Handle the Result or propagate the error"]
     pub fn write_record_from_payload(
@@ -121,23 +122,17 @@ impl<W: Write> RDWRecordWriter<W> {
         preserve_reserved: Option<u16>,
     ) -> Result<()> {
         let length = payload.len();
-        let header =
-            RdwHeader::from_payload_len(length, preserve_reserved.unwrap_or(0)).map_err(|_| {
-                Error::new(
-                    ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
-                    format!(
-                        "RDW payload too large: {length} bytes exceeds maximum of {}",
-                        u16::MAX
-                    ),
-                )
-                .with_context(ErrorContext {
+        let header = RdwHeader::from_payload_len(length, preserve_reserved.unwrap_or(0)).map_err(
+            |error| {
+                error.with_context(ErrorContext {
                     record_index: Some(self.record_count + 1),
                     field_path: None,
                     byte_offset: None,
                     line_number: None,
                     details: Some("RDW length field is 16-bit".to_string()),
                 })
-            })?;
+            },
+        )?;
 
         let record = RDWRecord {
             header: header.bytes(),

--- a/crates/copybook-rdw/tests/rdw_comprehensive.rs
+++ b/crates/copybook-rdw/tests/rdw_comprehensive.rs
@@ -135,7 +135,7 @@ fn writer_rejects_payload_exceeding_u16_max() {
     let err = writer
         .write_record_from_payload(&payload, None)
         .unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+    assert_eq!(err.code, ErrorCode::CBKF102_RECORD_LENGTH_INVALID);
 }
 
 // ====================================================================

--- a/crates/copybook-rdw/tests/rdw_deep.rs
+++ b/crates/copybook-rdw/tests/rdw_deep.rs
@@ -402,11 +402,7 @@ fn writer_oversize_payload_is_error() {
     let mut writer = RDWRecordWriter::new(&mut output);
     let large = vec![0u8; RDW_MAX_PAYLOAD_LEN + 1];
     let err = writer.write_record_from_payload(&large, None).unwrap_err();
-    // Error code for oversized payload from writer
-    assert!(
-        err.code == ErrorCode::CBKE501_JSON_TYPE_MISMATCH
-            || err.code == ErrorCode::CBKF102_RECORD_LENGTH_INVALID
-    );
+    assert_eq!(err.code, ErrorCode::CBKF102_RECORD_LENGTH_INVALID);
 }
 
 #[test]

--- a/crates/copybook-rdw/tests/rdw_edge_cases.rs
+++ b/crates/copybook-rdw/tests/rdw_edge_cases.rs
@@ -393,7 +393,7 @@ fn rdw_payload_exceeding_u16_max_rejected_by_writer() {
     let err = writer
         .write_record_from_payload(&payload, None)
         .unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+    assert_eq!(err.code, ErrorCode::CBKF102_RECORD_LENGTH_INVALID);
 }
 
 // ====================================================================

--- a/crates/copybook-rdw/tests/rdw_framing_comprehensive.rs
+++ b/crates/copybook-rdw/tests/rdw_framing_comprehensive.rs
@@ -283,7 +283,7 @@ fn write_oversize_payload_is_error() {
     let err = writer
         .write_record_from_payload(&payload, None)
         .unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+    assert_eq!(err.code, ErrorCode::CBKF102_RECORD_LENGTH_INVALID);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/copybook-record-io/src/lib.rs
+++ b/crates/copybook-record-io/src/lib.rs
@@ -131,7 +131,7 @@ mod tests {
         let mut output = Vec::new();
         let oversized = vec![0u8; usize::from(u16::MAX) + 1];
         let err = write_record(&mut output, &oversized, RecordFormat::RDW).unwrap_err();
-        assert_eq!(err.code, ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+        assert_eq!(err.code, ErrorCode::CBKF102_RECORD_LENGTH_INVALID);
     }
 
     proptest! {

--- a/crates/copybook-record-io/tests/comprehensive_dispatch_tests.rs
+++ b/crates/copybook-record-io/tests/comprehensive_dispatch_tests.rs
@@ -163,7 +163,7 @@ fn write_rdw_rejects_oversized_payload() {
     let mut out = Vec::new();
     let oversized = vec![0u8; usize::from(u16::MAX) + 1];
     let err = write_record(&mut out, &oversized, RecordFormat::RDW).unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+    assert_eq!(err.code, ErrorCode::CBKF102_RECORD_LENGTH_INVALID);
 }
 
 // ===========================================================================

--- a/crates/copybook-record-io/tests/dispatch_deep.rs
+++ b/crates/copybook-record-io/tests/dispatch_deep.rs
@@ -301,7 +301,7 @@ fn error_rdw_write_oversized_payload() {
     let mut out = Vec::new();
     let big = vec![0u8; usize::from(u16::MAX) + 1];
     let err = write_record(&mut out, &big, RecordFormat::RDW).unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+    assert_eq!(err.code, ErrorCode::CBKF102_RECORD_LENGTH_INVALID);
 }
 
 #[test]

--- a/crates/copybook-record-io/tests/record_io_dispatch_comprehensive.rs
+++ b/crates/copybook-record-io/tests/record_io_dispatch_comprehensive.rs
@@ -157,7 +157,7 @@ fn dispatch_rdw_oversize_write_propagates_error() {
     let oversized = vec![0u8; (u16::MAX as usize) + 1];
     let mut output = Vec::new();
     let err = write_record(&mut output, &oversized, RecordFormat::RDW).unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+    assert_eq!(err.code, ErrorCode::CBKF102_RECORD_LENGTH_INVALID);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/copybook-record-io/tests/record_io_dispatch_tests.rs
+++ b/crates/copybook-record-io/tests/record_io_dispatch_tests.rs
@@ -348,7 +348,7 @@ fn error_rdw_oversized_payload_rejected() {
     let mut out = Vec::new();
     let oversized = vec![0u8; usize::from(u16::MAX) + 1];
     let err = write_record(&mut out, &oversized, RecordFormat::RDW).unwrap_err();
-    assert_eq!(err.code, ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+    assert_eq!(err.code, ErrorCode::CBKF102_RECORD_LENGTH_INVALID);
 }
 
 // ===========================================================================

--- a/examples/kafka_pipeline/Cargo.lock
+++ b/examples/kafka_pipeline/Cargo.lock
@@ -170,7 +170,7 @@ version = "0.5.0"
 dependencies = [
  "copybook-core",
  "copybook-corruption-detectors",
- "copybook-corruption-rdw",
+ "copybook-rdw",
 ]
 
 [[package]]
@@ -184,15 +184,6 @@ dependencies = [
 [[package]]
 name = "copybook-corruption-predicates"
 version = "0.5.0"
-
-[[package]]
-name = "copybook-corruption-rdw"
-version = "0.5.0"
-dependencies = [
- "copybook-core",
- "copybook-corruption-predicates",
- "copybook-rdw-predicates",
-]
 
 [[package]]
 name = "copybook-determinism"
@@ -263,13 +254,8 @@ name = "copybook-rdw"
 version = "0.5.0"
 dependencies = [
  "copybook-error",
- "copybook-rdw-predicates",
  "tracing",
 ]
-
-[[package]]
-name = "copybook-rdw-predicates"
-version = "0.5.0"
 
 [[package]]
 name = "copybook-record-io"

--- a/examples/kafka_streaming/Cargo.lock
+++ b/examples/kafka_streaming/Cargo.lock
@@ -170,7 +170,7 @@ version = "0.5.0"
 dependencies = [
  "copybook-core",
  "copybook-corruption-detectors",
- "copybook-corruption-rdw",
+ "copybook-rdw",
 ]
 
 [[package]]
@@ -184,15 +184,6 @@ dependencies = [
 [[package]]
 name = "copybook-corruption-predicates"
 version = "0.5.0"
-
-[[package]]
-name = "copybook-corruption-rdw"
-version = "0.5.0"
-dependencies = [
- "copybook-core",
- "copybook-corruption-predicates",
- "copybook-rdw-predicates",
-]
 
 [[package]]
 name = "copybook-determinism"
@@ -263,13 +254,8 @@ name = "copybook-rdw"
 version = "0.5.0"
 dependencies = [
  "copybook-error",
- "copybook-rdw-predicates",
  "tracing",
 ]
-
-[[package]]
-name = "copybook-rdw-predicates"
-version = "0.5.0"
 
 [[package]]
 name = "copybook-record-io"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -157,7 +157,7 @@ version = "0.5.0"
 dependencies = [
  "copybook-core",
  "copybook-corruption-detectors",
- "copybook-corruption-rdw",
+ "copybook-rdw",
 ]
 
 [[package]]
@@ -176,9 +176,7 @@ version = "0.5.0"
 name = "copybook-corruption-rdw"
 version = "0.5.0"
 dependencies = [
- "copybook-core",
- "copybook-corruption-predicates",
- "copybook-rdw-predicates",
+ "copybook-rdw",
 ]
 
 [[package]]
@@ -293,13 +291,15 @@ name = "copybook-rdw"
 version = "0.5.0"
 dependencies = [
  "copybook-error",
- "copybook-rdw-predicates",
  "tracing",
 ]
 
 [[package]]
 name = "copybook-rdw-predicates"
 version = "0.5.0"
+dependencies = [
+ "copybook-rdw",
+]
 
 [[package]]
 name = "copybook-record-io"


### PR DESCRIPTION
## Summary

- preserve `CBKF102_RECORD_LENGTH_INVALID` when RDW writer input exceeds the 16-bit payload limit
- retain record context while forwarding the canonical framing error
- tighten all direct oversized-payload evidence, including the `copybook-record-io` facade, to reject the prior `CBKE501` misclassification
- refresh the fuzz and Kafka standalone lockfiles so their `--locked` MSRV checks follow the merged RDW dependency graph

This is Issue #651 Slice C: one stable RDW error-ownership correction plus the required compatibility evidence/lockfile refresh. It does not change valid framing, ODO behavior, or other I/O mappings.

## Proof

- `cargo test -p copybook-rdw`
- `cargo test -p copybook-record-io`
- `cargo clippy -p copybook-rdw --all-targets -- -D warnings`
- `cargo clippy -p copybook-record-io --all-targets -- -D warnings`
- `cargo run -p xtask -- docs verify-all`
- `cargo check --locked --manifest-path fuzz/Cargo.toml`
- `cargo check --locked --manifest-path examples/kafka_pipeline/Cargo.toml`
- `cargo check --locked --manifest-path examples/kafka_streaming/Cargo.toml`
- `cargo fmt --all -- --check`
- `git diff --check`

Refs #651
Refs #576