### PR TITLE
fix(rdw): classify read failures as record errors

### DIFF
--- a/crates/copybook-rdw/src/buffer.rs
+++ b/crates/copybook-rdw/src/buffer.rs
@@ -5,14 +5,14 @@ use std::io::BufRead;
 ///
 /// # Errors
 /// Returns:
-/// - `CBKF104_RDW_SUSPECT_ASCII` for I/O errors while peeking.
+/// - `CBKR201_RDW_READ_ERROR` for I/O errors while peeking.
 /// - `CBKF102_RECORD_LENGTH_INVALID` for incomplete headers.
 #[inline]
 #[must_use = "Handle the Result or propagate the error"]
 pub fn rdw_read_len<R: BufRead>(reader: &mut R) -> Result<u16> {
     let buf = reader.fill_buf().map_err(|e| {
         Error::new(
-            ErrorCode::CBKF104_RDW_SUSPECT_ASCII,
+            ErrorCode::CBKR201_RDW_READ_ERROR,
             format!("I/O error peeking RDW length: {e}"),
         )
     })?;
@@ -36,7 +36,7 @@ pub fn rdw_read_len<R: BufRead>(reader: &mut R) -> Result<u16> {
 ///
 /// # Errors
 /// Returns:
-/// - `CBKF104_RDW_SUSPECT_ASCII` for I/O errors while peeking.
+/// - `CBKR201_RDW_READ_ERROR` for I/O errors while peeking.
 /// - `CBKF102_RECORD_LENGTH_INVALID` when fewer than `len` bytes are available.
 #[inline]
 #[must_use = "Handle the Result or propagate the error"]
@@ -48,7 +48,7 @@ pub fn rdw_slice_body<R: BufRead>(reader: &mut R, len: u16) -> Result<&[u8]> {
 
     let buf = reader.fill_buf().map_err(|e| {
         Error::new(
-            ErrorCode::CBKF104_RDW_SUSPECT_ASCII,
+            ErrorCode::CBKR201_RDW_READ_ERROR,
             format!("I/O error reading RDW payload: {e}"),
         )
     })?;
@@ -80,13 +80,13 @@ pub const fn rdw_validate_and_finish(body: &[u8]) -> &[u8] {
 /// - `>= 2` bytes buffered => `Ok(Some(()))`
 ///
 /// # Errors
-/// Returns `CBKF104_RDW_SUSPECT_ASCII` for I/O errors while peeking.
+/// Returns `CBKR201_RDW_READ_ERROR` for I/O errors while peeking.
 #[inline]
 #[must_use = "Handle the Result or propagate the error"]
 pub fn rdw_try_peek_len<R: BufRead>(reader: &mut R) -> Result<Option<()>> {
     let buf = reader.fill_buf().map_err(|e| {
         Error::new(
-            ErrorCode::CBKF104_RDW_SUSPECT_ASCII,
+            ErrorCode::CBKR201_RDW_READ_ERROR,
             format!("I/O error peeking RDW header: {e}"),
         )
     })?;

--- a/crates/copybook-rdw/src/reader.rs
+++ b/crates/copybook-rdw/src/reader.rs
@@ -46,7 +46,7 @@ impl<R: Read> RDWRecordReader<R> {
 
         let buf = self.input.fill_buf().map_err(|e| {
             Error::new(
-                ErrorCode::CBKF104_RDW_SUSPECT_ASCII,
+                ErrorCode::CBKR201_RDW_READ_ERROR,
                 format!("I/O error reading RDW header: {e}"),
             )
             .with_context(ErrorContext {
@@ -69,7 +69,7 @@ impl<R: Read> RDWRecordReader<R> {
         let context = self.header_context("Unable to read RDW header");
         let buf = self.input.fill_buf().map_err(|e| {
             Error::new(
-                ErrorCode::CBKF104_RDW_SUSPECT_ASCII,
+                ErrorCode::CBKR201_RDW_READ_ERROR,
                 format!("I/O error reading RDW header: {e}"),
             )
             .with_context(context)
@@ -102,7 +102,7 @@ impl<R: Read> RDWRecordReader<R> {
             .fill_buf()
             .map_err(|e| {
                 Error::new(
-                    ErrorCode::CBKF104_RDW_SUSPECT_ASCII,
+                    ErrorCode::CBKR201_RDW_READ_ERROR,
                     format!("I/O error reading RDW header: {e}"),
                 )
                 .with_context(context)

--- a/crates/copybook-rdw/tests/rdw_edge_cases.rs
+++ b/crates/copybook-rdw/tests/rdw_edge_cases.rs
@@ -4,7 +4,22 @@
 
 use copybook_error::ErrorCode;
 use copybook_rdw::{RDW_HEADER_LEN, RDWRecordReader, RDWRecordWriter, RdwHeader};
-use std::io::Cursor;
+use std::io::{self, Cursor, Read};
+
+struct FailingReader;
+
+impl Read for FailingReader {
+    fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+        Err(io::Error::new(io::ErrorKind::BrokenPipe, "read failure"))
+    }
+}
+
+#[test]
+fn rdw_reader_io_failure_is_cbkr201() {
+    let mut reader = RDWRecordReader::new(FailingReader, false);
+    let err = reader.read_record().unwrap_err();
+    assert_eq!(err.code, ErrorCode::CBKR201_RDW_READ_ERROR);
+}
 
 // ====================================================================
 // 1. Valid 4-byte RDW header → correct payload extraction


### PR DESCRIPTION
## Summary

- map RDW buffer and reader I/O failures to `CBKR201_RDW_READ_ERROR`
- keep incomplete bytes as `CBKF102`/underflow errors and suspect ASCII detection as `CBKF104`
- add a direct failing-reader witness for the stable read-error contract

This is Issue #651 Slice C, one RDW read-error ownership row. Writer I/O mapping remains out of scope for a separate contract decision.

## Proof

- `cargo test -p copybook-rdw`
- `cargo clippy -p copybook-rdw --all-targets -- -D warnings`
- `cargo run -p xtask -- docs verify-all`
- `cargo fmt --all -- --check`
- `git diff --check`

Refs #651
Refs #576
Refs #572