### PR TITLE
test(rdw): make framing evidence exact

### DIFF
--- a/crates/copybook-record-io/tests/dispatch_deep.rs
+++ b/crates/copybook-record-io/tests/dispatch_deep.rs
@@ -327,7 +327,8 @@ fn error_fixed_read_io_failure() {
 #[test]
 fn error_rdw_read_io_failure() {
     let mut r = AlwaysFailReader;
-    assert!(read_record(&mut r, RecordFormat::RDW, None).is_err());
+    let err = read_record(&mut r, RecordFormat::RDW, None).unwrap_err();
+    assert_eq!(err.code, ErrorCode::CBKR201_RDW_READ_ERROR);
 }
 
 #[test]
@@ -337,7 +338,8 @@ fn error_rdw_truncated_payload() {
     data.extend_from_slice(&[0x00, 0x0A, 0x00, 0x00]);
     data.extend_from_slice(b"ABC");
     let mut c = Cursor::new(data);
-    assert!(read_record(&mut c, RecordFormat::RDW, None).is_err());
+    let err = read_record(&mut c, RecordFormat::RDW, None).unwrap_err();
+    assert_eq!(err.code, ErrorCode::CBKF102_RECORD_LENGTH_INVALID);
 }
 
 #[test]

--- a/crates/copybook-record-io/tests/record_io_comprehensive.rs
+++ b/crates/copybook-record-io/tests/record_io_comprehensive.rs
@@ -156,7 +156,8 @@ fn fixed_data_read_as_rdw_errors() {
     let mut cursor = Cursor::new(data.to_vec());
     // 'AB' = 0x4142 = 16706 bytes expected, but only 4 remain after header
     let result = read_record(&mut cursor, RecordFormat::RDW, None);
-    assert!(result.is_err(), "ASCII data should fail as RDW");
+    let err = result.unwrap_err();
+    assert_eq!(err.code, ErrorCode::CBKF102_RECORD_LENGTH_INVALID);
 }
 
 #[test]

--- a/tests/e2e/e2e_error_codes.rs
+++ b/tests/e2e/e2e_error_codes.rs
@@ -897,25 +897,16 @@ fn cbkf104_rdw_suspect_ascii() {
     );
 }
 
-/// CBKF221: RDW length underflow (length < 4)
+/// CBKF221: RDW header underflow (fewer than 4 header bytes)
 #[test]
 fn cbkf221_rdw_underflow() {
-    // RDW header with length=2 (minimum is 4 for the header itself)
+    // Truncated RDW header: only the two-byte length prefix is present.
     let data: Vec<u8> = vec![
-        0x00, 0x02, // length = 2 (below 4-byte minimum)
-        0x00, 0x00,
+        0x00, 0x02, // length prefix; reserved bytes are missing
     ];
-    let mut reader = RDWRecordReader::new(Cursor::new(data), false);
-    let result = reader.read_record();
-    assert!(result.is_err());
-    let code = result.unwrap_err().code;
-    assert!(
-        matches!(
-            code,
-            ErrorCode::CBKF221_RDW_UNDERFLOW | ErrorCode::CBKF102_RECORD_LENGTH_INVALID
-        ),
-        "Expected CBKF221 or CBKF102, got {code:?}"
-    );
+    let mut reader = RDWRecordReader::new(Cursor::new(data), true);
+    let err = reader.read_record().unwrap_err();
+    assert_eq!(err.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
 }
 
 // =========================================================================


### PR DESCRIPTION
## Summary

- require the exact `CBKF221_RDW_UNDERFLOW` code for a direct strict RDW-header underflow witness
- tighten record-io facade evidence for RDW read I/O, truncated payload, and fixed-data-as-RDW rejection
- keep #576/#572 direct rejection evidence deterministic instead of accepting generic errors

This is Issue #651 Slice C, one evidence-only contract reconciliation row. No runtime behavior or error ownership changes.

## Proof

- `cargo test -p copybook-record-io`
- `cargo test -p copybook-e2e --test e2e_error_codes`
- `cargo fmt --all -- --check`
- `git diff --check`

Refs #651
Refs #576
Refs #572