### PR TITLE
build: add ci profile with thin LTO for faster CI builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,15 @@ lto = true
 codegen-units = 1
 panic = "unwind"
 
+# Lighter release profile for CI runs that need optimization (perf gates,
+# benchmarks, determinism smoke) but don't ship artifacts. Thin LTO + more
+# codegen units cut compile time significantly vs fat LTO + codegen-units=1.
+# Usage: cargo build --profile ci --release
+[profile.ci]
+inherits = "release"
+lto = "thin"
+codegen-units = 16
+
 [profile.dev]
 debug = true
 panic = "unwind"


### PR DESCRIPTION
## Summary

The release profile uses fat LTO + `codegen-units = 1`, which maximizes optimization but significantly slows compilation. Many CI workflows build `--release` for non-shipping purposes (perf gates, benchmarks, determinism smoke, leak detection) where the extra optimization time isn't justified.

### Change
Adds `[profile.ci]` inheriting from `release` but with thin LTO + `codegen-units = 16`:
```toml
[profile.ci]
inherits = "release"
lto = "thin"
codegen-units = 16
```

CI workflows can opt in via `cargo build --profile ci` for near-release performance at a fraction of the compile time. The shipping `release` profile is unchanged.

## Test plan
- [x] `cargo build -p copybook-error --profile ci` compiles clean
- [x] Profile inherits correctly (optimized, panic=unwind from release)
- [x] No code changes — Cargo.toml config only
