### PR TITLE
chore: remove dead feature flags (comp3_unsafe, experimental, soak)

### DIFF
--- a/crates/copybook-arrow/Cargo.toml
+++ b/crates/copybook-arrow/Cargo.toml
@@ -42,8 +42,6 @@ tempfile = { workspace = true }
 
 [features]
 default = []
-# Enable experimental features
-experimental = []
 
 [lints]
 workspace = true

--- a/crates/copybook-cli/Cargo.toml
+++ b/crates/copybook-cli/Cargo.toml
@@ -49,7 +49,6 @@ toml.workspace = true
 
 [features]
 default = []
-soak = []
 arrow = ["dep:copybook-arrow"]
 audit = ["copybook-core/audit", "dep:tokio"]
 metrics = [

--- a/crates/copybook-codec/Cargo.toml
+++ b/crates/copybook-codec/Cargo.toml
@@ -56,7 +56,6 @@ default = ["comp3_fast"]
 comprehensive-tests = []
 # COMP-3 fast path optimizations
 comp3_fast = []
-comp3_unsafe = []
 metrics = ["dep:metrics"]
 audit = ["copybook-core/audit"]
 

--- a/docs/stability/surface-registry.json
+++ b/docs/stability/surface-registry.json
@@ -43,19 +43,7 @@
       "source_of_truth": [
         "docs/STABILITY_GUARANTEES.md"
       ],
-      "features": [
-        {
-          "name": "experimental",
-          "class": "experimental",
-          "stability_statement": "Opt-in feature gate that keeps the crate on the experimental track.",
-          "limitations": [
-            "Can change API shape without a major-version-compatible migration."
-          ],
-          "graduation_criteria": [
-            "Feature remains stable through a full compatibility evidence cycle and no public break without migration docs."
-          ]
-        }
-      ],
+      "features": [],
       "boundary": {
         "role": "adapter",
         "seam_type": "adapter",
@@ -235,15 +223,6 @@
           "graduation_criteria": [
             "Metrics contract is documented with a stable output schema and compatibility checks."
           ]
-        },
-        {
-          "name": "soak",
-          "class": "internal-dev-only",
-          "stability_statement": "Soak/benchmarking path not part of the supported CLI contract.",
-          "limitations": [
-            "Used only for sustained-load validation."
-          ],
-          "graduation_criteria": []
         }
       ],
       "boundary": {
@@ -316,15 +295,6 @@
           "stability_statement": "Performance-tuned COMP-3 path; implementation detail for advanced users.",
           "limitations": [
             "Not covered by the v1 stable codec contract."
-          ],
-          "graduation_criteria": []
-        },
-        {
-          "name": "comp3_unsafe",
-          "class": "internal-dev-only",
-          "stability_statement": "Unsafe COMP-3 optimization path.",
-          "limitations": [
-            "May change with implementation and does not carry user-facing stability."
           ],
           "graduation_criteria": []
         },


### PR DESCRIPTION
## Summary

Removes three feature flags that were declared in Cargo.toml but had zero `cfg(feature=...)` gates in source, zero CI references, and zero test references — inert knobs that misled users.

### Removed
- `copybook-codec`: `comp3_unsafe` — never gated, never referenced
- `copybook-arrow`: `experimental` — never gated, never referenced  
- `copybook-cli`: `soak` — never gated, never referenced

### Not removed
- `copybook-codec`: `comp3_fast` — default-on and referenced in the CI matrix (`ci.yml`, `ci-proptest.yml`) though functionally a no-op in source. Removing it requires coordinating CI matrix updates; tracked separately.

## Test plan
- [x] `cargo build -p copybook-codec -p copybook-arrow -p copybook-cli` clean
- [x] Confirmed zero source/CI/test references to the three removed flags
