### PR TITLE
fix(cli): describe the program in --help instead of the feature-flag struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **cli**: `copybook --help` opened with "Feature flag options for the CLI" —
+  the doc comment of the flattened `FeatureFlagOpts` struct, which clap promotes
+  to the program description when the command declares `about` but no
+  `long_about`. Both help forms now describe the tool, and carry worked examples
+  plus a note that `--format` is never auto-detected and `--codepage` defaults to
+  `cp037`.
+
 ## [0.5.0] — 2026-07-28
 
 **Highlights**: v0.5.0 makes the canonical `copybook` facade crate the default

--- a/crates/copybook-cli/src/main.rs
+++ b/crates/copybook-cli/src/main.rs
@@ -67,9 +67,53 @@ fn invocation_id() -> &'static str {
     })
 }
 
+/// Long description for `--help`.
+///
+/// Declared explicitly because `Cli` flattens [`FeatureFlagOpts`]; without an
+/// explicit `long_about`, clap promotes the flattened struct's doc comment to
+/// the program description and `--help` opens with "Feature flag options for
+/// the CLI".
+const LONG_ABOUT: &str = "\
+Modern COBOL copybook parser and data converter.
+
+Parses COBOL copybooks into a record layout, then decodes fixed-length or RDW \
+data files to JSONL and encodes them back byte-for-byte.";
+
+/// Worked examples appended to `--help` and `-h`.
+const AFTER_HELP: &str = "\
+Getting started:
+  copybook inspect customer.cpy
+      Show the record layout: field paths, byte offsets, and PIC clauses.
+
+  copybook decode customer.cpy data.bin -o records.jsonl --format fixed
+      Decode a fixed-length EBCDIC file to one JSON object per line.
+
+  copybook encode customer.cpy records.jsonl -o data.bin --format fixed
+      Encode JSONL back to the binary layout.
+
+  copybook verify customer.cpy data.bin --format fixed
+      Check a data file against the copybook without writing output.
+
+  copybook support --check occurs-depending
+      Ask whether a COBOL construct is supported before you rely on it.
+
+Two settings are never guessed and are worth getting right first:
+  --format    fixed | rdw. There is no auto-detection; the wrong choice
+              reports record-framing errors (CBKF*), not a useful diff.
+  --codepage  cp037 (default), cp273, cp500, cp1047, cp1140, or ascii. A
+              mismatch decodes without error but yields mojibake text.
+
+Exit codes: 0 success, 2 data errors (CBKD), 3 encode/schema errors (CBKE),
+4 record-format errors (CBKF), 5 internal errors (CBKI), 1 otherwise.
+
+Error codes: docs/reference/ERROR_CODES.md
+Full CLI reference: docs/CLI_REFERENCE.md";
+
 #[derive(Parser)]
 #[command(name = "copybook", color = ColorChoice::Never)]
 #[command(about = "Modern COBOL copybook parser and data converter")]
+#[command(long_about = LONG_ABOUT)]
+#[command(after_help = AFTER_HELP)]
 #[command(version)]
 struct Cli {
     #[command(subcommand)]

--- a/tests/e2e/e2e_cli_help_output.rs
+++ b/tests/e2e/e2e_cli_help_output.rs
@@ -363,3 +363,44 @@ fn short_version_flag_works() {
     let has_version = regex::Regex::new(r"\d+\.\d+\.\d+").unwrap().is_match(&text);
     assert!(has_version, "-V should produce version number, got: {text}");
 }
+
+// =========================================================================
+// 22. Both help forms describe the program, not the flattened flag struct
+// =========================================================================
+
+#[test]
+fn help_describes_the_program_not_the_feature_flag_struct() {
+    // `Cli` flattens `FeatureFlagOpts`. Without an explicit `long_about`, clap
+    // promotes the flattened struct's doc comment and `--help` opens with
+    // "Feature flag options for the CLI".
+    for flag in ["-h", "--help"] {
+        let text = help_text(&run_help(&[flag]));
+        assert!(
+            text.starts_with("Modern COBOL copybook parser and data converter"),
+            "{flag} should open with the program description, got:\n{text}"
+        );
+        assert!(
+            !text.contains("Feature flag options for the CLI"),
+            "{flag} leaked the flattened flag struct's description:\n{text}"
+        );
+    }
+}
+
+// =========================================================================
+// 23. Help points at the two settings that are never auto-detected
+// =========================================================================
+
+#[test]
+fn help_documents_format_and_codepage_defaults() {
+    let text = help_text(&run_help(&["--help"]));
+    assert!(
+        text.contains("Getting started:"),
+        "help should carry worked examples, got:\n{text}"
+    );
+    for expected in ["--format", "--codepage", "cp037", "Exit codes:"] {
+        assert!(
+            text.contains(expected),
+            "help should mention {expected}, got:\n{text}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`copybook --help` — the first thing a new user runs — opened with the wrong text:

```
Feature flag options for the CLI

These options allow runtime control over experimental features, enterprise
features, performance optimizations, debug capabilities, and testing hooks.

Usage: copybook [OPTIONS] <COMMAND>
```

`Cli` flattens `FeatureFlagOpts`, and clap promotes a flattened struct's doc comment to the command's long description when the command declares `about` but no `long_about`. `-h` was unaffected, which is why this survived: the short and long help forms disagreed about what the program is.

This declares `long_about` explicitly and adds worked examples to both forms:

```
Getting started:
  copybook inspect customer.cpy
      Show the record layout: field paths, byte offsets, and PIC clauses.

  copybook decode customer.cpy data.bin -o records.jsonl --format fixed
      Decode a fixed-length EBCDIC file to one JSON object per line.
  ...

Two settings are never guessed and are worth getting right first:
  --format    fixed | rdw. There is no auto-detection; the wrong choice
              reports record-framing errors (CBKF*), not a useful diff.
  --codepage  cp037 (default), cp273, cp500, cp1047, cp1140, or ascii. A
              mismatch decodes without error but yields mojibake text.

Exit codes: 0 success, 2 data errors (CBKD), 3 encode/schema errors (CBKE),
4 record-format errors (CBKF), 5 internal errors (CBKI), 1 otherwise.
```

Both claims in that block were verified against the built CLI rather than assumed:

- decoding a fixed-length file with `--format rdw` exits 4 with `CBKF102_RECORD_LENGTH_INVALID`
- decoding a cp037 file with `--codepage ascii` exits 0 and emits `"NAME":"\u{fffd}\u{fffd}\u{fffd}\u{fffd}@\u{fffd}\u{fffd}@"`

The exit codes match `ExitCode` in `crates/copybook-cli/src/exit_codes.rs`, and `occurs-depending` is a real feature ID in the support matrix.

## Type of Change

- [x] Bugfix (fixes an issue)

## COBOL/Mainframe Context

- **COBOL features affected**: none
- **Data processing impact**: none — help text only
- **Mainframe compatibility**: n/a

## Workspace Crates Affected

- [x] copybook-cli (CLI commands and options)

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (help text is the documentation here)
- [x] CHANGELOG.md updated (if user-facing change)
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace -- -D warnings -W clippy::pedantic` passes
- [x] `cargo test --workspace` passes
- [x] Follows conventional commit format

## Testing Instructions

```bash
cargo test -p copybook-e2e --test e2e_cli_help_output
cargo run --bin copybook -- --help
cargo run --bin copybook -- -h
```

Two regression tests are added: one asserts both `-h` and `--help` open with the program description and never contain `Feature flag options for the CLI`; the other asserts the examples block and the `--format`/`--codepage`/exit-code notes are present.

## Performance Impact

- [x] No performance impact expected

## Breaking Changes

- [x] No breaking changes

## Related Issues

Relates to #552

---
_Generated by [Claude Code](https://claude.ai/code/session_014WgexC5kRkpPuRddZqiySu)_