### PR TITLE
fix(cli): map CBKR record-framing errors to exit 4 instead of 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **cli**: Map `CBKR*` record-framing errors to exit code 4 (`CBKF`) instead of
+  5 (`CBKI`). `CBKR` was absent from the family-prefix table, so it fell through
+  to the unmapped default and every fixed-record or RDW framing failure — a
+  truncated input file being the common case — was reported as an internal
+  orchestration error. The documented meaning of exit 4 ("Record format/RDW
+  failure") now holds for the record-format family itself.
+
 ## [0.5.0] — 2026-07-28
 
 **Highlights**: v0.5.0 makes the canonical `copybook` facade crate the default

--- a/crates/copybook-cli/src/exit_codes.rs
+++ b/crates/copybook-cli/src/exit_codes.rs
@@ -137,7 +137,11 @@ impl ExitCode {
             "CBKE" | "CBKP" | "CBKS" => Some(ExitCode::Encode),
             // Parse/schema rejections (syntax + validation families).
             // Map to Encode/validation at the process boundary for stable CLI UX.
-            "CBKF" => Some(ExitCode::Format),
+            //
+            // CBKR is the record-framing family (fixed-record and RDW read/write
+            // failures); it belongs with CBKF at the process boundary, otherwise a
+            // truncated input file is reported as an internal error.
+            "CBKF" | "CBKR" => Some(ExitCode::Format),
             "CBKI" => Some(ExitCode::Internal),
             _ => None,
         }

--- a/crates/copybook-cli/tests/exit_code_mapping.rs
+++ b/crates/copybook-cli/tests/exit_code_mapping.rs
@@ -65,6 +65,45 @@ fn exit_code_cbkf_is_4() -> TestResult<()> {
 
 #[test]
 #[serial]
+fn exit_code_cbkr_is_4() -> TestResult<()> {
+    // A fixed-length file whose size is not a multiple of LRECL raises
+    // CBKR101_FIXED_RECORD_ERROR. Record framing is a format failure, not an
+    // internal error: the taxonomy family is CBKR, and the process boundary
+    // must report 4 like every other framing failure.
+    let copybook = NamedTempFile::new()?;
+    write_file(copybook.path(), "01 REC.\n   05 FIELD PIC X(4).\n")?;
+
+    // Six bytes for a 4-byte record: one whole record plus a 2-byte tail.
+    let input = NamedTempFile::new()?;
+    write_file(input.path(), [0x41u8, 0x42, 0x43, 0x44, 0x45, 0x46])?;
+
+    let output_dir = TempDir::new()?;
+    let output_path = output_dir.path().join("fixed-out.jsonl");
+
+    let args = vec![
+        OsString::from("decode"),
+        OsString::from("--format"),
+        OsString::from("fixed"),
+        OsString::from("--codepage"),
+        OsString::from("ascii"),
+        OsString::from("--output"),
+        output_path.into_os_string(),
+        copybook.path().as_os_str().to_owned(),
+        input.path().as_os_str().to_owned(),
+    ];
+
+    let (code, stderr) = run_and_status_with_stderr(&args)?;
+
+    assert!(
+        stderr.contains("CBKR101_FIXED_RECORD_ERROR"),
+        "expected a CBKR framing error, got stderr:\n{stderr}"
+    );
+    assert_eq!(code, 4, "CBKR errors should map to exit code 4, not 5");
+    Ok(())
+}
+
+#[test]
+#[serial]
 fn exit_code_cbkd_is_2() -> TestResult<()> {
     // Data error: invalid nibble for packed decimal → CBKD (2)
     let copybook = NamedTempFile::new()?;

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -573,7 +573,7 @@ copybook decode legacy-schema.cpy data.bin --format fixed --strict-comments --ou
 | 1 | CBK? | Unknown/unclassified failure (e.g. unknown `support --check` feature ID) |
 | 2 | CBKD | Data quality failure |
 | 3 | CBKE | Encode/validation failure (including structural parse/schema rejections) |
-| 4 | CBKF | Record format/RDW failure |
+| 4 | CBKF | Record format/RDW failure (also `CBKR*` fixed-record and RDW framing errors) |
 | 5 | CBKI | Internal orchestration error (including panics and otherwise unmapped errors) |
 
 Some subcommands document additional command-specific semantics: `verify` reports 3 for validation errors and 2 for fatal I/O/schema errors; `determinism` reports 0 for deterministic, 2 for drift detected, and 3 for codec/usage errors.


### PR DESCRIPTION
## Summary

`ExitCode::from_family_prefix` has no arm for `CBKR`, the record-framing family. Unmapped prefixes return `None`, `dominant_exit_code` returns `Unknown`, and `map_error_to_exit_code` rewrites `Unknown` to `Internal` — so decoding a truncated fixed-length file exits **5**:

```console
$ copybook decode rec.cpy truncated.bin -o - --format fixed
CBKR101_FIXED_RECORD_ERROR: Incomplete record at end of file: expected 12 bytes (record 2, File ends with partial record)
... code_tag=CBKI code=5 family=internal ...
$ echo $?
5
```

A file whose size is not a multiple of LRECL is a user-supplied input condition, not an internal orchestration failure. CI pipelines that key on exit 5 to page an operator get woken by a bad upload, and the four codes in the family (`CBKR101`, `CBKR201`, `CBKR202`, `CBKR211`) are all fixed-record or RDW framing failures.

`docs/CLI_REFERENCE.md` already documents exit 4 as "Record format/RDW failure". This makes that true for the record-format family itself, alongside `CBKF`.

**Scope.** Only `CBKR` is mapped here. `CBKC`, `CBKA`, and `CBKW` are also unmapped, but each needs its own decision rather than a blanket fix: `CBKC` mixes a data condition (`CBKC301_INVALID_EBCDIC_BYTE`) with an output-write failure (`CBKC201_JSON_WRITE_ERROR`), and `CBKA`/`CBKW` sit behind non-default features.

## Type of Change

- [x] Bugfix (fixes an issue)

## COBOL/Mainframe Context

- **COBOL features affected**: none
- **Data processing impact**: exit-code classification for fixed-length and RDW record framing; decode/encode behavior and output bytes are unchanged
- **Mainframe compatibility**: n/a

## Workspace Crates Affected

- [x] copybook-cli (CLI commands and options)

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [x] CHANGELOG.md updated (if user-facing change)
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace -- -D warnings -W clippy::pedantic` passes
- [x] `cargo test --workspace` passes
- [x] Follows conventional commit format

## Testing Instructions

```bash
cargo test -p copybook-cli --test exit_code_mapping
cargo run -p xtask -- docs freeze contracts
```

`exit_code_cbkr_is_4` decodes a 6-byte file against a 4-byte LRECL, asserts stderr carries `CBKR101_FIXED_RECORD_ERROR`, and asserts the process exits 4. It sits beside the existing `exit_code_cbk{d,e,f,i,p}_is_*` tests.

## Performance Impact

- [x] No performance impact expected

## Breaking Changes

- [x] No breaking changes

The stable-surface contract records `exit_code/tags` as `["CBKD", "CBKE", "CBKF", "CBKI"]` — the `ExitCode::tag()` values, which are unchanged. `cargo run -p xtask -- docs freeze contracts` passes. The observable change is that a class of failure previously reported as 5 is now reported as 4; consumers keying on 5 for framing errors were relying on the unmapped default, which contradicted the documented table.

## Related Issues

Relates to #552

---
_Generated by [Claude Code](https://claude.ai/code/session_014WgexC5kRkpPuRddZqiySu)_