### PR TITLE
fix(codec): stop discarding a trailing partial record at end of file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-
+- **codec**: `RecordIterator` no longer discards a trailing partial record.
+  `read_exact` reports `UnexpectedEof` both for a clean end of file and for a
+  reader that ran dry mid-record, so a file that is not a multiple of LRECL had
+  its trailing bytes dropped with no signal to the caller. `verify` therefore
+  reported `PASS` on truncated data that `decode` refused to process. Fixed
+  records now raise `CBKR101_FIXED_RECORD_ERROR` and truncated RDW headers raise
+  `CBKF221_RDW_UNDERFLOW`; a file ending on a record boundary is still a clean
+  end of file.
 - **cli**: `inspect` now renders a layout an operator can act on. The `Type`
   column reproduces the source PIC clause instead of restating the stored total
   digit count (`PIC S9(7)V99 COMP-3` printed as `S9(9)V9(2)`), binary fields

--- a/crates/copybook-codec/src/iterator.rs
+++ b/crates/copybook-codec/src/iterator.rs
@@ -212,10 +212,50 @@
 //! ```
 
 use crate::options::{DecodeOptions, RecordFormat};
-use copybook_core::{Error, ErrorCode, Result, Schema};
+use copybook_core::{Error, ErrorCode, ErrorContext, Result, Schema};
 use copybook_rdw::RdwHeader;
 use serde_json::Value;
 use std::io::{BufReader, Read};
+
+/// Outcome of reading a whole record-sized unit at a record boundary.
+enum BoundaryRead {
+    /// The buffer was filled.
+    Complete,
+    /// The reader was already exhausted; nothing was consumed.
+    CleanEof,
+    /// The reader ran out mid-unit after this many bytes.
+    Partial(usize),
+}
+
+/// Fill `buffer` from `reader`, distinguishing a clean end of file from a
+/// truncated final unit.
+///
+/// [`Read::read_exact`] reports [`std::io::ErrorKind::UnexpectedEof`] for both
+/// cases and consumes the bytes it did read, so it cannot tell "the file ended
+/// on a record boundary" from "the file ends with a partial record". Treating
+/// the two alike silently discards the trailing bytes.
+fn fill_at_record_boundary<R: Read>(
+    reader: &mut R,
+    buffer: &mut [u8],
+) -> std::io::Result<BoundaryRead> {
+    let mut filled = 0;
+    while filled < buffer.len() {
+        match reader.read(&mut buffer[filled..]) {
+            Ok(0) => break,
+            Ok(read) => filled += read,
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
+    }
+
+    if filled == buffer.len() {
+        Ok(BoundaryRead::Complete)
+    } else if filled == 0 {
+        Ok(BoundaryRead::CleanEof)
+    } else {
+        Ok(BoundaryRead::Partial(filled))
+    }
+}
 
 /// Iterator over records in a data file, yielding decoded JSON values
 ///
@@ -386,14 +426,30 @@ impl<R: Read> RecordIterator<R> {
                 let lrecl = crate::file::fixed::lrecl(&self.schema)? as usize;
                 self.buffer.resize(lrecl, 0);
 
-                match self.reader.read_exact(&mut self.buffer) {
-                    Ok(()) => {
+                match fill_at_record_boundary(&mut self.reader, &mut self.buffer) {
+                    Ok(BoundaryRead::Complete) => {
                         self.record_index += 1;
                         Some(self.buffer.clone())
                     }
-                    Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                    Ok(BoundaryRead::CleanEof) => {
                         self.eof_reached = true;
                         return Ok(None);
+                    }
+                    Ok(BoundaryRead::Partial(read)) => {
+                        self.eof_reached = true;
+                        return Err(Error::new(
+                            ErrorCode::CBKR101_FIXED_RECORD_ERROR,
+                            format!("Incomplete record at end of file: expected {lrecl} bytes"),
+                        )
+                        .with_context(ErrorContext {
+                            record_index: Some(self.record_index + 1),
+                            field_path: None,
+                            byte_offset: None,
+                            line_number: None,
+                            details: Some(format!(
+                                "File ends with partial record ({read} of {lrecl} bytes)"
+                            )),
+                        }));
                     }
                     Err(e) => {
                         return Err(Error::new(
@@ -406,11 +462,27 @@ impl<R: Read> RecordIterator<R> {
             RecordFormat::RDW => {
                 // Read RDW header
                 let mut rdw_header = [0u8; 4];
-                match self.reader.read_exact(&mut rdw_header) {
-                    Ok(()) => {}
-                    Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                match fill_at_record_boundary(&mut self.reader, &mut rdw_header) {
+                    Ok(BoundaryRead::Complete) => {}
+                    Ok(BoundaryRead::CleanEof) => {
                         self.eof_reached = true;
                         return Ok(None);
+                    }
+                    Ok(BoundaryRead::Partial(read)) => {
+                        self.eof_reached = true;
+                        return Err(Error::new(
+                            ErrorCode::CBKF221_RDW_UNDERFLOW,
+                            "Incomplete RDW header at end of file: expected 4 bytes".to_string(),
+                        )
+                        .with_context(ErrorContext {
+                            record_index: Some(self.record_index + 1),
+                            field_path: None,
+                            byte_offset: None,
+                            line_number: None,
+                            details: Some(format!(
+                                "File ends with partial RDW header ({read} of 4 bytes)"
+                            )),
+                        }));
                     }
                     Err(e) => {
                         return Err(Error::new(
@@ -796,7 +868,14 @@ mod tests {
 
         let mut iterator = RecordIterator::new(cursor, &schema, &options).unwrap();
 
-        // Should yield EOF (Ok(None)) when encountering truncated fixed-length data
+        // A truncated final record is reported, not silently dropped: returning
+        // EOF here would discard the four trailing bytes with no signal to the
+        // caller.
+        let error = iterator
+            .next()
+            .expect("truncated data yields an item")
+            .expect_err("truncated data is an error");
+        assert_eq!(error.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
         assert!(iterator.next().is_none());
     }
 
@@ -1127,5 +1206,130 @@ mod tests {
 
         let error = iterator.read_raw_record().unwrap_err();
         assert_eq!(error.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
+    }
+
+    /// Reader that hands out one byte per call, so `read_exact` cannot fill the
+    /// buffer in a single call and the boundary logic is exercised for real.
+    struct DribbleReader {
+        data: Vec<u8>,
+        position: usize,
+    }
+
+    impl Read for DribbleReader {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            if self.position >= self.data.len() || buf.is_empty() {
+                return Ok(0);
+            }
+            buf[0] = self.data[self.position];
+            self.position += 1;
+            Ok(1)
+        }
+    }
+
+    fn eight_byte_schema() -> Schema {
+        let mut schema = parse_copybook("01 RECORD.\n   05 NAME PIC X(8).").unwrap();
+        schema.lrecl_fixed = Some(8);
+        schema
+    }
+
+    #[test]
+    fn fixed_trailing_partial_record_is_reported_not_discarded() {
+        // Twelve bytes for an 8-byte LRECL: one whole record and a 4-byte tail.
+        let data = b"RECORD01HALF".to_vec();
+        let schema = eight_byte_schema();
+        let options = DecodeOptions::default().with_codepage(Codepage::ASCII);
+        let mut iterator = RecordIterator::new(Cursor::new(data), &schema, &options).unwrap();
+
+        assert_eq!(iterator.read_raw_record().unwrap().unwrap(), b"RECORD01");
+
+        let error = iterator.read_raw_record().unwrap_err();
+        assert_eq!(error.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
+        let context = error.context.expect("partial record reports context");
+        assert_eq!(context.record_index, Some(2));
+        assert!(
+            context.details.unwrap_or_default().contains("4 of 8 bytes"),
+            "details should name the short count"
+        );
+    }
+
+    #[test]
+    fn fixed_partial_record_terminates_iteration_after_one_error() {
+        let schema = eight_byte_schema();
+        let options = DecodeOptions::default().with_codepage(Codepage::ASCII);
+        let mut iterator =
+            RecordIterator::new(Cursor::new(b"RECORD01HALF".to_vec()), &schema, &options).unwrap();
+
+        assert!(iterator.next().unwrap().is_ok());
+        assert!(iterator.next().unwrap().is_err());
+        assert!(
+            iterator.next().is_none(),
+            "iteration must stop after the partial-record error"
+        );
+    }
+
+    #[test]
+    fn fixed_file_ending_on_a_record_boundary_is_still_clean_eof() {
+        let schema = eight_byte_schema();
+        let options = DecodeOptions::default().with_codepage(Codepage::ASCII);
+        let mut iterator =
+            RecordIterator::new(Cursor::new(b"RECORD01".to_vec()), &schema, &options).unwrap();
+
+        assert_eq!(iterator.read_raw_record().unwrap().unwrap(), b"RECORD01");
+        assert!(iterator.read_raw_record().unwrap().is_none());
+        assert!(iterator.is_eof());
+    }
+
+    #[test]
+    fn fixed_partial_record_detected_when_reads_return_one_byte_at_a_time() {
+        // A short `read` is not end of file. The boundary helper must keep
+        // reading until the buffer is full or the reader is genuinely dry.
+        let schema = eight_byte_schema();
+        let options = DecodeOptions::default().with_codepage(Codepage::ASCII);
+        let reader = DribbleReader {
+            data: b"RECORD01HALF".to_vec(),
+            position: 0,
+        };
+        let mut iterator = RecordIterator::new(reader, &schema, &options).unwrap();
+
+        assert_eq!(iterator.read_raw_record().unwrap().unwrap(), b"RECORD01");
+        assert_eq!(
+            iterator.read_raw_record().unwrap_err().code,
+            ErrorCode::CBKR101_FIXED_RECORD_ERROR
+        );
+    }
+
+    #[test]
+    fn rdw_trailing_partial_header_is_reported_not_discarded() {
+        // One 8-byte RDW record followed by a 2-byte stub of a second header.
+        let mut data = vec![0x00, 0x08, 0x00, 0x00];
+        data.extend_from_slice(b"RECORD01");
+        data.extend_from_slice(&[0x00, 0x08]);
+
+        let schema = eight_byte_schema();
+        let options = DecodeOptions::default()
+            .with_format(RecordFormat::RDW)
+            .with_codepage(Codepage::ASCII);
+        let mut iterator = RecordIterator::new(Cursor::new(data), &schema, &options).unwrap();
+
+        assert_eq!(iterator.read_raw_record().unwrap().unwrap(), b"RECORD01");
+
+        let error = iterator.read_raw_record().unwrap_err();
+        assert_eq!(error.code, ErrorCode::CBKF221_RDW_UNDERFLOW);
+    }
+
+    #[test]
+    fn rdw_file_ending_on_a_record_boundary_is_still_clean_eof() {
+        let mut data = vec![0x00, 0x08, 0x00, 0x00];
+        data.extend_from_slice(b"RECORD01");
+
+        let schema = eight_byte_schema();
+        let options = DecodeOptions::default()
+            .with_format(RecordFormat::RDW)
+            .with_codepage(Codepage::ASCII);
+        let mut iterator = RecordIterator::new(Cursor::new(data), &schema, &options).unwrap();
+
+        assert_eq!(iterator.read_raw_record().unwrap().unwrap(), b"RECORD01");
+        assert!(iterator.read_raw_record().unwrap().is_none());
+        assert!(iterator.is_eof());
     }
 }

--- a/crates/copybook-codec/tests/streaming_file_tests.rs
+++ b/crates/copybook-codec/tests/streaming_file_tests.rs
@@ -487,6 +487,14 @@ fn iter_records_partial_record_at_eof() {
     assert_eq!(second["TEST-FIELD"], "00002");
     assert_eq!(iter.current_record_index(), 2);
 
+    // The three trailing bytes are a truncated record, not a clean end of file.
+    // Reporting EOF here would discard them without telling the caller.
+    let error = iter
+        .next()
+        .expect("partial record yields an item")
+        .expect_err("partial record is an error");
+    assert_eq!(error.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
+
     assert!(iter.next().is_none());
     assert!(iter.is_eof());
     assert_eq!(iter.current_record_index(), 2);

--- a/tests/e2e/e2e_cli_integration.rs
+++ b/tests/e2e/e2e_cli_integration.rs
@@ -728,9 +728,10 @@ fn verify_valid_data_exits_zero() {
 }
 
 #[test]
-fn verify_truncated_data_reports_zero_records() {
+fn verify_truncated_data_is_a_validation_failure() {
     let dir = setup_simple();
-    // 5 bytes is not a complete record (13 needed); verify processes 0 records.
+    // 5 bytes where the record is 13. The file is truncated, not empty, and
+    // reporting PASS would say a partial upload is safe to decode.
     std::fs::write(dir.path().join("data.bin"), [0xF0; 5]).unwrap();
 
     let output = Command::cargo_bin("copybook")
@@ -743,11 +744,39 @@ fn verify_truncated_data_reports_zero_records() {
         .expect("run verify truncated");
 
     assert_no_panic(&stderr_str(&output));
-    // Truncated data yields 0 complete records; verify exits 0 with a warning.
+    assert_ne!(output.status.code(), Some(0));
     let so = stdout_str(&output);
     assert!(
-        so.contains("Records Total: 0") || so.contains("PASS"),
-        "verify of truncated data should process 0 records: {so}"
+        !so.contains("PASS"),
+        "truncated data must not be reported as PASS: {so}"
+    );
+    assert!(
+        so.contains("CBKR101_FIXED_RECORD_ERROR"),
+        "summary should name the framing error: {so}"
+    );
+}
+
+#[test]
+fn verify_empty_data_reports_zero_records() {
+    let dir = setup_simple();
+    // An empty file ends on a record boundary: zero records, nothing truncated.
+    std::fs::write(dir.path().join("data.bin"), []).unwrap();
+
+    let output = Command::cargo_bin("copybook")
+        .unwrap()
+        .args(["verify"])
+        .arg(temp_path(&dir, "schema.cpy"))
+        .arg(temp_path(&dir, "data.bin"))
+        .args(["--format", "fixed", "--codepage", "cp037"])
+        .output()
+        .expect("run verify empty");
+
+    assert_no_panic(&stderr_str(&output));
+    assert_eq!(output.status.code(), Some(0));
+    let so = stdout_str(&output);
+    assert!(
+        so.contains("Records Total: 0"),
+        "empty input should process 0 records: {so}"
     );
 }
 

--- a/tests/e2e/e2e_cli_subcommands.rs
+++ b/tests/e2e/e2e_cli_subcommands.rs
@@ -521,6 +521,40 @@ fn verify_with_report_produces_file() {
 }
 
 // =========================================================================
+// 13b. VERIFY: a truncated file is a validation failure, not a PASS
+// =========================================================================
+
+#[test]
+fn verify_reports_a_trailing_partial_record() {
+    // One whole 13-byte record plus a 5-byte tail. Reporting PASS here would
+    // tell an operator a truncated upload is safe to decode, and `decode`
+    // rejects the same file.
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("schema.cpy"), SIMPLE_CPY).unwrap();
+    let mut truncated = simple_record();
+    truncated.extend_from_slice(&simple_record()[..5]);
+    std::fs::write(dir.path().join("data.bin"), truncated).unwrap();
+
+    let assert = cmd()
+        .args(["verify"])
+        .arg(p(&dir, "schema.cpy"))
+        .arg(p(&dir, "data.bin"))
+        .args(["--format", "fixed", "--codepage", "cp037"])
+        .assert()
+        .failure();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+    assert!(
+        !stdout.contains("PASS"),
+        "truncated data must not be reported as PASS, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("CBKR101_FIXED_RECORD_ERROR"),
+        "summary should name the framing error, got:\n{stdout}"
+    );
+}
+
+// =========================================================================
 // 14. VERIFY: invalid data exits non-zero
 // =========================================================================
 

--- a/tests/e2e/e2e_cli_subcommands_comprehensive.rs
+++ b/tests/e2e/e2e_cli_subcommands_comprehensive.rs
@@ -638,22 +638,23 @@ fn verify_report_flag_writes_file() {
 }
 
 // =========================================================================
-// 24. VERIFY: truncated data (not multiple of LRECL) warns but passes with 0 records
+// 24. VERIFY: truncated data (not multiple of LRECL) is a validation failure
 // =========================================================================
 
 #[test]
-fn verify_truncated_data_exits_zero_with_zero_records() {
+fn verify_truncated_data_exits_nonzero() {
     let dir = setup(SIMPLE_CPY, &[0xF0; 5]); // 5 bytes, needs 13
-    // File size is not a multiple of LRECL; verify logs a warning
-    // but processes 0 records and exits 0 (PASS).
+    // The file is truncated, not empty. Passing it would tell an operator a
+    // partial upload is safe to decode, and `decode` rejects the same bytes.
     cmd()
         .args(["verify"])
         .arg(p(&dir, "schema.cpy"))
         .arg(p(&dir, "data.bin"))
         .args(["--format", "fixed", "--codepage", "cp037"])
         .assert()
-        .success()
-        .stdout(predicate::str::contains("PASS"));
+        .failure()
+        .stdout(predicate::str::contains("CBKR101_FIXED_RECORD_ERROR"))
+        .stdout(predicate::str::contains("PASS").not());
 }
 
 // =========================================================================

--- a/tests/e2e/e2e_streaming.rs
+++ b/tests/e2e/e2e_streaming.rs
@@ -22,7 +22,7 @@ use copybook_codec::{
     decode_file_to_jsonl, decode_record, decode_record_with_scratch, encode_jsonl_to_file,
     iter_records, memory::ScratchBuffers,
 };
-use copybook_core::parse_copybook;
+use copybook_core::{ErrorCode, parse_copybook};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -445,7 +445,7 @@ fn streaming_error_recovery_iterator() {
 }
 
 // ===========================================================================
-// 13. Iterator with partial trailing data does not panic
+// 13. Iterator with partial trailing data reports it and stops
 // ===========================================================================
 
 #[test]
@@ -460,9 +460,14 @@ fn streaming_iterator_partial_trailing_data() {
     let iter = iter_records(Cursor::new(&data), &schema, &dopts).expect("iter");
     let results: Vec<_> = iter.collect();
 
-    // Should get exactly 1 successful record; trailing data is too short
-    assert_eq!(results.len(), 1, "only 1 complete record");
+    // One complete record, then the truncated tail as an error. Yielding only
+    // the first item would drop the trailing bytes without telling the caller.
+    assert_eq!(results.len(), 2, "one record plus the truncation report");
     assert!(results[0].is_ok());
+    let error = results[1]
+        .as_ref()
+        .expect_err("trailing bytes are an error");
+    assert_eq!(error.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
 }
 
 // ===========================================================================

--- a/tests/e2e/e2e_verify_comprehensive.rs
+++ b/tests/e2e/e2e_verify_comprehensive.rs
@@ -375,14 +375,16 @@ fn verify_truncated_record_detected() {
     // Send 10 bytes when LRECL is 13
     let dir = setup(SIMPLE_CPY, &simple_record()[..10]);
 
-    // The CLI should warn about non-LRECL-aligned file but still exit
-    // The verify should detect the truncation
+    // The truncation is a validation error, so it lands in the error list and
+    // the command exits non-zero rather than reporting a clean run.
     cmd()
         .args(["verify", "--format", "fixed", "--codepage", "cp037"])
         .arg(cpy_path(&dir))
         .arg(data_path(&dir))
         .assert()
-        .stdout(predicate::str::contains("Records Total: 0"));
+        .failure()
+        .stdout(predicate::str::contains("CBKR101_FIXED_RECORD_ERROR"))
+        .stdout(predicate::str::contains("PASS").not());
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`verify` and `decode` disagreed about the same truncated file. On a 20-byte file with a 12-byte LRECL:

```console
$ copybook verify rec.cpy truncated.bin --format fixed
  Records Total: 1
  Status: PASS - No validation errors          # exit 0

$ copybook decode rec.cpy truncated.bin -o - --format fixed
CBKR101_FIXED_RECORD_ERROR: Incomplete record at end of file: expected 12 bytes
```

The command whose job is to catch truncation *before* decode was the one that missed it.

**Root cause.** `RecordIterator::read_raw_record` treats `UnexpectedEof` from `read_exact` as a clean end of file:

```rust
Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
    self.eof_reached = true;
    return Ok(None);
}
```

`read_exact` reports that same error for two different situations — the reader was already empty, and the reader ran dry mid-record — and it consumes whatever it did read. So a file that is not a multiple of LRECL had its trailing bytes silently dropped with no signal to the caller. `decode` goes through `copybook-fixed::FixedReader`, which probes a single byte first to tell the two cases apart; the iterator did not.

**Fix.** `fill_at_record_boundary` reads until the buffer is full or the reader is genuinely exhausted, then reports one of three outcomes. A partial unit becomes:

- fixed records → `CBKR101_FIXED_RECORD_ERROR`, with the short count in the error context (`"File ends with partial record (4 of 8 bytes)"`) and matching `FixedReader`'s message
- RDW headers → `CBKF221_RDW_UNDERFLOW`

A file ending exactly on a record boundary is still a clean EOF, and an empty file still decodes to zero records. `eof_reached` is set before the error is returned, so iteration terminates after one report rather than looping.

**With the fix, `verify` and `decode` agree:**

```console
$ copybook verify rec.cpy truncated.bin --format fixed
  Records Total: 2
  Errors: 1 (showing first 1)
    Record 1: CBKR101_FIXED_RECORD_ERROR - Incomplete record at end of file: expected 12 bytes
$ echo $?
3
```

## Type of Change

- [x] Bugfix (fixes an issue)

## COBOL/Mainframe Context

- **COBOL features affected**: none — record framing only
- **Data processing impact**: streaming iteration over fixed-length and RDW files. Well-formed files are unaffected; truncated files now raise an error instead of silently dropping their tail.
- **Mainframe compatibility**: a truncated transfer is the common way an FTP/NDM download goes wrong, and it is exactly the case that was being hidden

## Workspace Crates Affected

- [x] copybook-codec (encoding, decoding, character conversion)

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (CHANGELOG; error behavior already documented in `ERROR_CODES.md`)
- [x] CHANGELOG.md updated (if user-facing change)
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace --lib --bins --examples --all-features -- -D warnings -W clippy::pedantic` passes
- [x] `cargo test --workspace` passes
- [x] Follows conventional commit format

## Testing Instructions

```bash
cargo test -p copybook-codec
cargo test -p copybook-e2e
cargo test --workspace
```

New coverage:

- `fixed_trailing_partial_record_is_reported_not_discarded` — asserts the code, record index, and short count
- `fixed_partial_record_terminates_iteration_after_one_error` — the iterator stops rather than repeating
- `fixed_file_ending_on_a_record_boundary_is_still_clean_eof` / `rdw_file_ending_on_a_record_boundary_is_still_clean_eof` — no false positives
- `fixed_partial_record_detected_when_reads_return_one_byte_at_a_time` — a `Read` impl returning one byte per call, so a short read is not mistaken for EOF
- `rdw_trailing_partial_header_is_reported_not_discarded`
- `verify_reports_a_trailing_partial_record` and `verify_empty_data_reports_zero_records` (CLI level)

**Four existing tests asserted the old behavior and are updated** — they encoded the bug rather than the contract. One said so outright: *"File size is not a multiple of LRECL; verify logs a warning but processes 0 records and exits 0 (PASS)."* A separate test now covers the genuinely empty file, which still verifies clean with zero records — the distinction the old code could not express.

## Performance Impact

- [x] No performance impact expected

The read loop replaces `read_exact` with the same fill-until-full logic `read_exact` performs internally. Well-formed files take exactly one full-buffer path.

## Breaking Changes

- [x] No breaking changes

Behavior change for malformed input only: a truncated final record now surfaces as an error where it was previously discarded. Any consumer relying on the old behavior was losing data without knowing it. Well-formed files, empty files, and files ending on a record boundary are unchanged.

## Related Issues

Relates to #552, #572

---
_Generated by [Claude Code](https://claude.ai/code/session_014WgexC5kRkpPuRddZqiySu)_