### PR TITLE
fix(cli): make support list the IDs it tells you to use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **cli**: `support` now prints the feature IDs its own footer tells you to
+  pass to `--check`; previously the identifiers were only reachable through
+  `--format json`. Columns size to their contents instead of truncating at a
+  fixed 25 characters, statuses are spelled the way `--status` and the JSON
+  `status` field spell them rather than as Rust `Debug` output, an unknown
+  `--check` value lists the known IDs, and output goes through the CLI's
+  pipe-safe writer so `copybook support | head` no longer prints a panic
+  backtrace.
 - **cli**: `inspect` now renders a layout an operator can act on. The `Type`
   column reproduces the source PIC clause instead of restating the stored total
   digit count (`PIC S9(7)V99 COMP-3` printed as `S9(9)V9(2)`), binary fields

--- a/crates/copybook-cli/src/commands/support.rs
+++ b/crates/copybook-cli/src/commands/support.rs
@@ -8,6 +8,7 @@
 use crate::exit_codes::ExitCode;
 use copybook_governance as governance;
 use governance::FeatureFlags;
+use std::fmt::Write as _;
 
 #[derive(clap::Args)]
 pub struct SupportArgs {
@@ -74,7 +75,8 @@ fn run_check(
     feature_flags: &FeatureFlags,
 ) -> ExitCode {
     let Some(support) = governance::support_matrix::find_feature(feature_id) else {
-        eprintln!("Error: Unknown feature ID: {feature_id}");
+        eprintln!("Error: unknown feature ID: {feature_id}");
+        eprintln!("Known feature IDs: {}", known_feature_ids().join(", "));
         return ExitCode::Unknown;
     };
 
@@ -87,57 +89,75 @@ fn run_check(
     };
 
     // Simple rule: only `supported` is success; everything else is non-zero exit.
+    let mut out = String::new();
     match state.support_status {
         governance::SupportStatus::Supported => {
-            println!("Feature: {}", state.support_name);
-            println!("Status: {:?}", state.support_status);
-            println!("Description: {}", state.support_description);
+            writeln!(out, "Feature: {}", state.support_name).ok();
+            writeln!(out, "ID: {}", feature_id_str(state.support_id)).ok();
+            writeln!(out, "Status: {}", status_str(state.support_status)).ok();
+            writeln!(out, "Description: {}", state.support_description).ok();
             if let Some(doc_ref) = state.doc_ref {
-                println!("Documentation: {doc_ref}");
+                writeln!(out, "Documentation: {doc_ref}").ok();
             }
 
             if with_governance {
-                println!("Runtime-Available: {}", state.runtime_enabled);
-                println!(
+                writeln!(out, "Runtime-Available: {}", state.runtime_enabled).ok();
+                writeln!(
+                    out,
                     "Required Feature Flags: {}",
                     format_flags(state.required_feature_flags)
-                );
-                println!(
+                )
+                .ok();
+                writeln!(
+                    out,
                     "Missing Feature Flags: {}",
                     format_flags(&state.missing_feature_flags)
-                );
-                println!("Rationale: {}", state.rationale);
+                )
+                .ok();
+                writeln!(out, "Rationale: {}", state.rationale).ok();
 
                 if let Some(state) =
                     governance::governance_state_for_support_id(state.support_id, feature_flags)
                 {
                     if state.missing_feature_flags.is_empty() {
-                        println!("Runtime gating status: enabled by feature flags");
+                        writeln!(out, "Runtime gating status: enabled by feature flags").ok();
                     } else {
-                        println!("Runtime gating status: disabled by feature flags");
+                        writeln!(out, "Runtime gating status: disabled by feature flags").ok();
                     }
                 }
             }
 
+            write_stdout(&out);
             ExitCode::Ok
         }
         _status => {
             eprintln!(
-                "Feature '{}' not fully supported (status: {:?}). See {}",
+                "Feature '{}' is not fully supported (status: {}). See {}",
                 feature_id,
-                state.support_status,
+                status_str(state.support_status),
                 state.doc_ref.unwrap_or("project documentation"),
             );
             if with_governance {
-                println!("Runtime-Available: {}", state.runtime_enabled);
-                println!(
+                writeln!(out, "Runtime-Available: {}", state.runtime_enabled).ok();
+                writeln!(
+                    out,
                     "Missing Feature Flags: {}",
                     format_flags(&state.missing_feature_flags)
-                );
+                )
+                .ok();
+                write_stdout(&out);
             }
             ExitCode::Encode // Non-zero exit for policy/validation failure.
         }
     }
+}
+
+/// Write to stdout through the CLI's pipe-safe writer.
+///
+/// `println!` panics when the consumer closes the pipe, so `copybook support |
+/// head` printed a panic backtrace before the process exited.
+fn write_stdout(text: &str) {
+    let _ = crate::write_stdout_all(text.as_bytes());
 }
 
 fn run_matrix_view(
@@ -155,53 +175,68 @@ fn run_matrix_view(
         None => features.to_vec(),
     };
 
+    let mut out = String::new();
     match format {
         OutputFormat::Table => {
-            if with_governance {
-                println!("COBOL Feature Support + Governance");
-                println!();
-                println!(
-                    "{:<25} {:<15} {:<20} {:<16} Description",
-                    "Feature", "Status", "Feature Flags", "Runtime",
-                );
-                println!("{}", "-".repeat(100));
-                for feature in &filtered {
-                    let status_str = format!("{:?}", feature.support_status);
-                    println!(
-                        "{:<25} {:<15} {:<20} {:<16} {}",
-                        feature.support_name,
-                        status_str,
-                        format_flags(feature.required_feature_flags),
+            // The `ID` column is what `--check` consumes; without it the footer
+            // points at identifiers the table never shows.
+            let mut rows: Vec<Vec<String>> = Vec::with_capacity(filtered.len());
+            let headers: Vec<&str> = if with_governance {
+                writeln!(out, "COBOL Feature Support + Governance").ok();
+                vec![
+                    "ID",
+                    "Feature",
+                    "Status",
+                    "Feature Flags",
+                    "Runtime",
+                    "Description",
+                ]
+            } else {
+                writeln!(out, "COBOL Feature Support Matrix").ok();
+                vec!["ID", "Feature", "Status", "Description"]
+            };
+            out.push('\n');
+
+            for feature in &filtered {
+                let mut row = vec![
+                    feature_id_str(feature.support_id),
+                    feature.support_name.to_string(),
+                    status_str(feature.support_status).to_string(),
+                ];
+                if with_governance {
+                    row.push(format_flags(feature.required_feature_flags));
+                    row.push(
                         if feature.runtime_enabled {
                             "enabled"
                         } else {
                             "disabled-by-flags"
-                        },
-                        feature.support_description,
+                        }
+                        .to_string(),
                     );
                 }
-            } else {
-                println!("COBOL Feature Support Matrix");
-                println!();
-                println!("{:<25} {:<15} Description", "Feature", "Status");
-                println!("{}", "-".repeat(80));
-                for feature in &filtered {
-                    println!(
-                        "{:<25} {:<15} {}",
-                        feature.support_name,
-                        format!("{:?}", feature.support_status),
-                        feature.support_description,
-                    );
-                }
+                row.push(feature.support_description.to_string());
+                rows.push(row);
             }
 
-            println!();
-            println!("Use 'copybook support --check <feature-id>' to check a specific feature.");
-            println!("Use 'copybook support --format json' for machine-readable output.");
-            if with_governance {
-                println!(
+            render_table(&mut out, &headers, &rows);
+
+            out.push('\n');
+            writeln!(
+                out,
+                "Use 'copybook support --check <ID>' to check a specific feature."
+            )
+            .ok();
+            writeln!(
+                out,
+                "Use 'copybook support --format json' for machine-readable output."
+            )
+            .ok();
+            if !with_governance {
+                writeln!(
+                    out,
                     "Use 'copybook support --with-governance' to include runtime flag linkage."
-                );
+                )
+                .ok();
             }
         }
         OutputFormat::Json => {
@@ -216,11 +251,78 @@ fn run_matrix_view(
                     .collect();
                 serde_json::to_string_pretty(&basic)?
             };
-            println!("{json}");
+            writeln!(out, "{json}").ok();
         }
     }
 
+    write_stdout(&out);
     Ok(ExitCode::Ok)
+}
+
+/// Canonical kebab-case identifier for a feature, matching `--check` and the
+/// `id` field emitted by `--format json`.
+fn feature_id_str(id: governance::FeatureId) -> String {
+    serde_plain::to_string(&id).unwrap_or_else(|_| format!("{id:?}"))
+}
+
+/// Canonical status spelling, matching `--status` values and `--format json`.
+fn status_str(status: governance::SupportStatus) -> &'static str {
+    match status {
+        governance::SupportStatus::Supported => "supported",
+        governance::SupportStatus::Partial => "partial",
+        governance::SupportStatus::Planned => "planned",
+        governance::SupportStatus::NotPlanned => "not-planned",
+        // `SupportStatus` is non-exhaustive upstream.
+        _ => "unknown",
+    }
+}
+
+/// Every identifier `--check` accepts, in matrix order.
+fn known_feature_ids() -> Vec<String> {
+    governance::support_matrix::all_features()
+        .iter()
+        .map(|feature| feature_id_str(feature.id))
+        .collect()
+}
+
+/// Render a table whose columns fit their contents.
+///
+/// The final column is not padded, so a long description never drags trailing
+/// whitespace across the line.
+fn render_table(out: &mut String, headers: &[&str], rows: &[Vec<String>]) {
+    let widths: Vec<usize> = headers
+        .iter()
+        .enumerate()
+        .map(|(column, header)| {
+            rows.iter()
+                .filter_map(|row| row.get(column))
+                .map(String::len)
+                .chain(std::iter::once(header.len()))
+                .max()
+                .unwrap_or(0)
+        })
+        .collect();
+
+    let render = |cells: &[&str]| -> String {
+        let last = cells.len().saturating_sub(1);
+        let mut line = String::new();
+        for (column, cell) in cells.iter().enumerate() {
+            if column == last {
+                line.push_str(cell);
+            } else {
+                write!(line, "{cell:<width$} ", width = widths[column]).ok();
+            }
+        }
+        line
+    };
+
+    let header_line = render(headers);
+    writeln!(out, "{header_line}").ok();
+    writeln!(out, "{}", "-".repeat(header_line.len())).ok();
+    for row in rows {
+        let cells: Vec<&str> = row.iter().map(String::as_str).collect();
+        writeln!(out, "{}", render(&cells)).ok();
+    }
 }
 
 fn format_flags(flags: &[governance::Feature]) -> String {

--- a/crates/copybook-cli/tests/support_cli.rs
+++ b/crates/copybook-cli/tests/support_cli.rs
@@ -24,7 +24,8 @@ fn support_table_prints_known_features() {
     assert!(stdout.contains("Status"));
     assert!(stdout.contains("Description"));
     assert!(stdout.contains("LEVEL 88"));
-    assert!(stdout.contains("Supported")); // At least one feature should be supported
+    // Status is spelled the way `--status` and the JSON `status` field spell it.
+    assert!(stdout.contains("supported")); // At least one feature should be supported
 }
 
 #[test]
@@ -82,7 +83,7 @@ fn support_check_unknown_feature_exits_nonzero() {
 
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("Unknown feature ID"));
+    assert!(stderr.contains("unknown feature ID"));
 }
 
 #[test]
@@ -170,5 +171,5 @@ fn support_check_partial_feature_exits_nonzero_nested_odo() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("not fully supported"));
-    assert!(stderr.contains("Partial"));
+    assert!(stderr.contains("partial"));
 }

--- a/tests/e2e/e2e_cli_support.rs
+++ b/tests/e2e/e2e_cli_support.rs
@@ -73,7 +73,10 @@ fn support_filter_supported() {
         .args(["support", "--status", "supported"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Supported"));
+        // The table spells the status the way `--status` and the JSON `status`
+        // field do, so the three surfaces agree.
+        .stdout(predicate::str::contains("supported"))
+        .stdout(predicate::str::contains("partial").not());
 }
 
 // =========================================================================
@@ -86,7 +89,7 @@ fn support_filter_partial() {
         .args(["support", "--status", "partial"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Partial"));
+        .stdout(predicate::str::contains("partial"));
 }
 
 // =========================================================================
@@ -126,4 +129,97 @@ fn support_json_with_governance() {
     let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
     let _parsed: serde_json::Value = serde_json::from_str(&stdout)
         .unwrap_or_else(|e| panic!("JSON with governance should be valid: {e}"));
+}
+
+// =========================================================================
+// 9. The table lists the IDs its own footer tells you to use
+// =========================================================================
+
+#[test]
+fn support_table_lists_checkable_ids() {
+    let assert = cmd().args(["support"]).assert().success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+
+    assert!(
+        stdout.contains("ID"),
+        "table needs an ID column, got:\n{stdout}"
+    );
+    for id in ["level-88", "occurs-depending", "edited-pic", "nested-odo"] {
+        assert!(
+            stdout.contains(id),
+            "table should list the {id} identifier, got:\n{stdout}"
+        );
+    }
+}
+
+#[test]
+fn support_table_ids_are_accepted_by_check() {
+    // Every identifier the table prints must be one `--check` resolves,
+    // otherwise the footer sends users to a command that rejects them.
+    let assert = cmd()
+        .args(["support", "--format", "json"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let features: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    for feature in features.as_array().expect("json array") {
+        let id = feature["id"].as_str().expect("string id");
+        let output = cmd()
+            .args(["support", "--check", id])
+            .assert()
+            .get_output()
+            .clone();
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            !combined.contains("unknown feature ID"),
+            "--check rejected the advertised id {id}"
+        );
+    }
+}
+
+// =========================================================================
+// 10. An unknown identifier names the ones that work
+// =========================================================================
+
+#[test]
+fn support_check_unknown_id_lists_known_ids() {
+    cmd()
+        .args(["support", "--check", "no-such-feature"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unknown feature ID"))
+        .stderr(predicate::str::contains("Known feature IDs:"))
+        .stderr(predicate::str::contains("level-88"));
+}
+
+// =========================================================================
+// 11. A closed pipe is not a panic
+// =========================================================================
+
+#[test]
+fn support_survives_a_closed_stdout() {
+    // `copybook support | head` closes stdout early. `println!` panics there;
+    // the command must use the pipe-safe writer instead.
+    use std::process::{Command as StdCommand, Stdio};
+
+    let mut child = StdCommand::new(assert_cmd::cargo::cargo_bin("copybook"))
+        .args(["support"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn copybook support");
+
+    drop(child.stdout.take());
+    let output = child.wait_with_output().expect("wait for copybook support");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !stderr.contains("panicked at"),
+        "closed stdout must not panic, stderr:\n{stderr}"
+    );
 }


### PR DESCRIPTION
## Summary

`copybook support` ends every run with:

```
Use 'copybook support --check <feature-id>' to check a specific feature.
```

…but the table it printed had no ID column, so the identifiers that command accepts were reachable only by running `--format json` and reading the `id` field. Three further problems in the same output:

**Before**

```
Feature                   Status          Description
--------------------------------------------------------------------------------
LEVEL 88 condition names  Supported       Condition-name VALUE clauses (space- and comma-separated).
COMP-1/COMP-2 floating-point Supported       Single/double precision IEEE 754 floating-point types; enabled by default.
SIGN LEADING/TRAILING SEPARATE Supported       Separate sign byte directives; enabled by default.
```

**After**

```
ID               Feature                        Status    Description
---------------------------------------------------------------------
level-88         LEVEL 88 condition names       supported Condition-name VALUE clauses (space- and comma-separated).
comp-1-comp-2    COMP-1/COMP-2 floating-point   supported Single/double precision IEEE 754 floating-point types; enabled by default.
sign-separate    SIGN LEADING/TRAILING SEPARATE supported Separate sign byte directives; enabled by default.
```

- **Alignment.** `{:<25}` pushed the Status column right for the three feature names longer than 25 characters. Columns now size to their contents.
- **Status spelling.** `{:?}` rendered `Supported` / `NotPlanned`, while `--status` accepts `supported` / `not-planned` and the JSON `status` field emits the same lowercase form. All three surfaces now agree.
- **Unknown `--check` value.** `Error: Unknown feature ID: bogus` gave no way forward. It now lists the identifiers that work.

**Broken pipe.** Separately, `support` wrote through `println!` instead of the CLI's pipe-safe `write_stdout_all`, so `copybook support | head` printed a full panic backtrace:

```
thread 'main' panicked at library/std/src/io/stdio.rs:1166:9:
failed printing to stdout: Broken pipe (os error 32)
```

`main` already catches this and exits 0, so the process status was fine — the user just saw a backtrace for piping into `head`. Output is now buffered and written once through the same helper the rest of the CLI uses.

## Type of Change

- [x] Bugfix (fixes an issue)

## COBOL/Mainframe Context

- **COBOL features affected**: none — this is the support-matrix view, not a parsing path
- **Data processing impact**: none
- **Mainframe compatibility**: n/a

## Workspace Crates Affected

- [x] copybook-cli (CLI commands and options)

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (the command's own output is the documentation here)
- [x] CHANGELOG.md updated (if user-facing change)
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace -- -D warnings -W clippy::pedantic` passes
- [x] `cargo test --workspace` passes
- [x] Follows conventional commit format

## Testing Instructions

```bash
cargo test -p copybook-cli --test support_cli
cargo test -p copybook-e2e --test e2e_cli_support
cargo run --bin copybook -- support
cargo run --bin copybook -- support | head -4      # no backtrace
cargo run --bin copybook -- support --check bogus
```

New tests:

- `support_table_lists_checkable_ids` — the ID column exists and carries real identifiers
- `support_table_ids_are_accepted_by_check` — every advertised ID actually resolves through `--check`, so the footer can't drift from the table
- `support_check_unknown_id_lists_known_ids`
- `support_survives_a_closed_stdout` — spawns the command with stdout dropped and asserts stderr carries no panic

Three existing assertions on `Supported` / `Partial` / `Unknown feature ID` are updated to the lowercase spellings, with a comment recording why the table now matches the flag and the JSON field.

## Performance Impact

- [x] No performance impact expected

## Breaking Changes

- [x] No breaking changes

The table is human-readable output; `--format json` is the machine surface and is byte-for-byte unchanged (it now routes through the buffered writer, but the JSON text is identical). Scripts grepping the table for a capitalized `Supported` would need the lowercase form — that spelling was Rust `Debug` output, never a documented contract, and it contradicted both the flag and the JSON field.

## Related Issues

Relates to #552

---
_Generated by [Claude Code](https://claude.ai/code/session_014WgexC5kRkpPuRddZqiySu)_