### PR TITLE
docs: state the current release in status lines, and gate it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **docs**: State the current release in the status lines that declare it.
+  `CLAUDE.md`, `CONTRIBUTING.md`, `docs/USER_GUIDE.md`, and the readiness
+  assessment in `docs/REPORT.md` still said `v0.4.3` after the 0.5.0 release —
+  `docs/REPORT.md` contradicted its own header — and `SECURITY.md` promised
+  security updates for the `0.4.x` series rather than `0.5.x`.
+  `xtask docs verify-all` gained a `status-versioning` check so these lines
+  cannot drift from the workspace version again.
 - **cli**: `inspect` now renders a layout an operator can act on. The `Type`
   column reproduces the source PIC clause instead of restating the stored total
   digit count (`PIC S9(7)V99 COMP-3` printed as `S9(9)V9(2)`), binary fields

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Maintainer and operator guidance for Claude Code working in this repository.
 
 - Rust workspace, Edition 2024, MSRV 1.95
 - COBOL copybook parsing and data conversion (EBCDIC/ASCII to JSON and back)
-- Engineering Preview v0.4.3
+- Engineering Preview v0.5.0
 - 38 publishable crates under `crates/` (36 core + 2 facade), 4 dev-only under `tools/`, 3 test suites under `tests/`
 
 ## Canonical Sources

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,7 +192,7 @@ receipt at `scripts/bench/perf.json`; benchmark methodology remains in
 
 ## Project Status & Resources
 
-**Status**: Engineering Preview (v0.4.3)
+**Status**: Engineering Preview (v0.5.0)
 
 **Key Documentation**:
 - [ROADMAP.md](docs/ROADMAP.md) - Project status and adoption guidance

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,11 +7,11 @@ copybook-rs maintains security updates for the following versions:
 
 | Version | Supported          | Status |
 | ------- | ------------------ | ------ |
-| 0.4.x   | :white_check_mark: | Current stable release (Engineering Preview) |
-| 0.3.x   | :x:                | No longer supported |
-| < 0.3.0 | :x:                | No longer supported |
+| 0.5.x   | :white_check_mark: | Current stable release (Engineering Preview) |
+| 0.4.x   | :x:                | No longer supported |
+| < 0.4.0 | :x:                | No longer supported |
 
-**Note**: copybook-rs is currently in Engineering Preview (v0.4.x). While the CLI and library APIs are production-ready, feature completeness is still in preview. Security patches are applied to the current 0.4.x release series. See [ROADMAP.md](docs/ROADMAP.md) for version stability timeline and v1.0.0 plans.
+**Note**: copybook-rs is currently in Engineering Preview (v0.5.x). While the CLI and library APIs are production-ready, feature completeness is still in preview. Security patches are applied to the current 0.5.x release series. See [ROADMAP.md](docs/ROADMAP.md) for version stability timeline and v1.0.0 plans.
 
 ## Reporting a Vulnerability
 

--- a/docs/REPORT.md
+++ b/docs/REPORT.md
@@ -267,7 +267,7 @@ environment-specific; validate on your target hardware before production use.
 
 ## Readiness Assessment
 
-### Status: ⚠️ Engineering Preview (v0.4.3) - Cautious Adoption Recommended
+### Status: ⚠️ Engineering Preview (v0.5.0) - Cautious Adoption Recommended
 
 **Official Status**: See [ROADMAP.md](ROADMAP.md) for canonical project status
 and development timeline.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -333,7 +333,7 @@ For production deployments:
 4. Use verification mode for data quality auditing
 5. Validate representative copybooks against supported features before deployment
 
-**Status**: copybook-rs is in Engineering Preview (v0.4.3). Suitable for teams that validate copybooks against supported features. Production deployment requires pilot validation on representative workloads. See [ROADMAP.md](ROADMAP.md) for adoption guidance.
+**Status**: copybook-rs is in Engineering Preview (v0.5.0). Suitable for teams that validate copybooks against supported features. Production deployment requires pilot validation on representative workloads. See [ROADMAP.md](ROADMAP.md) for adoption guidance.
 ## License
 
 Licensed under **AGPL-3.0-or-later**. See [LICENSE](LICENSE).

--- a/tools/xtask/src/docs_verify.rs
+++ b/tools/xtask/src/docs_verify.rs
@@ -19,7 +19,7 @@ use xtask::perf;
 type Verifier = (&'static str, fn() -> Result<()>);
 
 pub(crate) fn run() -> Result<()> {
-    let checks: [Verifier; 14] = [
+    let checks: [Verifier; 15] = [
         (
             "workspace-version-and-msrv",
             verify_workspace_version_and_msrv,
@@ -52,6 +52,7 @@ pub(crate) fn run() -> Result<()> {
             verify_surface_deprecation_audit,
         ),
         ("quick-start-versioning", verify_quick_start_versioning),
+        ("status-versioning", verify_status_versioning),
     ];
     run_checks(&checks)
 }
@@ -1635,6 +1636,102 @@ fn verify_quick_start_versioning() -> Result<()> {
     Ok(())
 }
 
+/// Documents that declare the project's current release status.
+///
+/// Each of these carries a line naming the Engineering Preview version. They
+/// drifted to `v0.4.3` while the workspace was on `0.5.0`, and `docs/REPORT.md`
+/// contradicted itself in two places within one file.
+const STATUS_VERSION_TARGETS: [&str; 7] = [
+    "CLAUDE.md",
+    "CONTRIBUTING.md",
+    "README.md",
+    "SECURITY.md",
+    "docs/REPORT.md",
+    "docs/ROADMAP.md",
+    "docs/USER_GUIDE.md",
+];
+
+/// Extract version-like tokens (`0.5.0`, `v0.5.0`, `0.5.x`) from one line.
+fn version_tokens(line: &str) -> Vec<String> {
+    let bytes: Vec<char> = line.chars().collect();
+    let mut tokens = Vec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        if !bytes[index].is_ascii_digit() {
+            index += 1;
+            continue;
+        }
+        let start = index;
+        while index < bytes.len() && (bytes[index].is_ascii_digit() || bytes[index] == '.') {
+            index += 1;
+        }
+        // Allow a trailing wildcard component such as `0.5.x`.
+        if index < bytes.len() && bytes[index] == 'x' && bytes[start..index].contains(&'.') {
+            index += 1;
+        }
+        let token: String = bytes[start..index].iter().collect();
+        if token.matches('.').count() >= 1 {
+            tokens.push(token);
+        }
+    }
+    tokens
+}
+
+/// Fail when a current-status line names a version other than the workspace one.
+///
+/// Only lines mentioning "Engineering Preview" are considered, so historical
+/// statements ("promoted to stable in v0.4.3") stay untouched.
+fn verify_status_versioning() -> Result<()> {
+    // Resolve from the workspace root rather than the current directory so the
+    // check behaves the same under `xtask docs verify-all` and `cargo test`.
+    let manifest_path = workspace_root().join("Cargo.toml");
+    let manifest = fs::read_to_string(&manifest_path)
+        .with_context(|| format!("loading {}", manifest_path.display()))?;
+    let workspace: toml::Value = toml::from_str(&manifest)?;
+    let version = workspace_version(&workspace)?;
+    let mut parts = version.split('.');
+    let major = parts
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("invalid workspace version: {version}"))?;
+    let minor = parts
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("invalid workspace version: {version}"))?;
+    let expected_prefix = format!("{major}.{minor}");
+
+    for target in STATUS_VERSION_TARGETS {
+        // Resolved from the workspace root, not the current directory: several
+        // packages ship their own README.md, which would otherwise shadow the
+        // repository one.
+        let path = workspace_root().join(target);
+        let source =
+            fs::read_to_string(&path).with_context(|| format!("loading {}", path.display()))?;
+        for (offset, line) in source.lines().enumerate() {
+            if !line.contains("Engineering Preview") {
+                continue;
+            }
+            let tokens = version_tokens(line);
+            if tokens.is_empty() {
+                continue;
+            }
+            // At least one token must be the current release. Status lines
+            // legitimately also mention the v1.0.0 target, so requiring *every*
+            // token to match would reject correct prose.
+            if !tokens
+                .iter()
+                .any(|token| token.starts_with(&expected_prefix))
+            {
+                bail!(
+                    "status version drift in {target}:{}: found `{}`, expected one naming `{expected_prefix}`",
+                    offset + 1,
+                    tokens.join("`, `")
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
 fn load_deprecation_audit_report() -> Result<DeprecatedAuditReport> {
     let path = resolve_workspace_file(DEPRECATION_AUDIT_PATH)
         .ok_or_else(|| anyhow::anyhow!("loading docs/reports/deprecation-audit.json"))?;
@@ -2055,6 +2152,39 @@ mod tests {
     )]
     fn ok() -> Result<()> {
         Ok(())
+    }
+
+    #[test]
+    fn version_tokens_finds_release_shapes() {
+        assert_eq!(version_tokens("Engineering Preview v0.5.0"), vec!["0.5.0"]);
+        assert_eq!(version_tokens("| 0.5.x | supported |"), vec!["0.5.x"]);
+        assert_eq!(
+            version_tokens("Preview (v0.5.0) and (v0.4.3)"),
+            vec!["0.5.0", "0.4.3"]
+        );
+        assert!(version_tokens("Engineering Preview, no version here").is_empty());
+        // A bare integer is not a version.
+        assert!(version_tokens("supports 63 error codes").is_empty());
+    }
+
+    #[test]
+    fn status_versioning_matches_the_workspace_version() {
+        // The repository's own status lines must already agree.
+        verify_status_versioning().expect("status lines name the workspace version");
+    }
+
+    #[test]
+    fn status_version_targets_all_exist_and_declare_status() {
+        for target in STATUS_VERSION_TARGETS {
+            let path = workspace_root().join(target);
+            let source = fs::read_to_string(&path)
+                .unwrap_or_else(|err| panic!("status target {target} is unreadable: {err}"));
+            assert!(
+                source.contains("Engineering Preview"),
+                "{target} no longer declares a release status; drop it from \
+                 STATUS_VERSION_TARGETS or restore the claim"
+            );
+        }
     }
 
     fn failing() -> Result<()> {

--- a/tools/xtask/src/docs_verify.rs
+++ b/tools/xtask/src/docs_verify.rs
@@ -2175,16 +2175,20 @@ mod tests {
 
     #[test]
     fn status_version_targets_all_exist_and_declare_status() {
+        let mut problems = Vec::new();
         for target in STATUS_VERSION_TARGETS {
             let path = workspace_root().join(target);
-            let source = fs::read_to_string(&path)
-                .unwrap_or_else(|err| panic!("status target {target} is unreadable: {err}"));
-            assert!(
-                source.contains("Engineering Preview"),
-                "{target} no longer declares a release status; drop it from \
-                 STATUS_VERSION_TARGETS or restore the claim"
-            );
+            match fs::read_to_string(&path) {
+                Ok(source) if source.contains("Engineering Preview") => {}
+                Ok(_) => problems.push(format!("{target} no longer declares a release status")),
+                Err(err) => problems.push(format!("{target} is unreadable: {err}")),
+            }
         }
+        assert!(
+            problems.is_empty(),
+            "drop these from STATUS_VERSION_TARGETS or restore the claim: {}",
+            problems.join("; ")
+        );
     }
 
     fn failing() -> Result<()> {


### PR DESCRIPTION
## Summary

Four documents still declared `v0.4.3` after the 0.5.0 release, and `docs/REPORT.md` contradicted itself — its header says v0.5.0 while the readiness assessment 260 lines later says v0.4.3:

| File | Before | After |
|---|---|---|
| `CLAUDE.md:10` | `Engineering Preview v0.4.3` | `Engineering Preview v0.5.0` |
| `CONTRIBUTING.md:195` | `Engineering Preview (v0.4.3)` | `Engineering Preview (v0.5.0)` |
| `docs/REPORT.md:270` | `Engineering Preview (v0.4.3)` | `Engineering Preview (v0.5.0)` |
| `docs/USER_GUIDE.md:336` | `Engineering Preview (v0.4.3)` | `Engineering Preview (v0.5.0)` |
| `SECURITY.md:9-11` | supported series `0.4.x` | supported series `0.5.x` |

`SECURITY.md` is the consequential one. It listed 0.4.x as the current stable release and stated that "security patches are applied to the current 0.4.x release series", so a reader running 0.5.0 could not tell whether their version was covered.

## The gate

`xtask docs verify-all` gains a `status-versioning` check, sitting beside the existing `quick-start-versioning` check that guards dependency versions. It reads lines mentioning **"Engineering Preview"** in the seven documents that declare project status, and requires at least one version token on the line to name the workspace major.minor.

Two deliberate scoping choices:

- **Only lines with that phrase.** Historical statements like *"promoted to stable in v0.4.3"* and *"post-v0.4.3"* are accurate and are left alone.
- **At least one token, not every token.** `SECURITY.md:14` legitimately names both the current preview and the v1.0.0 target on one line; requiring every token to match would reject correct prose.

Status documents resolve from the workspace root rather than the current directory — several packages ship their own `README.md`, which shadowed the repository one when the check ran under `cargo test`.

## Type of Change

- [x] Documentation (README, docs/, code comments)
- [x] CI/CD (workflow or tooling changes)

## COBOL/Mainframe Context

- **COBOL features affected**: none
- **Data processing impact**: none
- **Mainframe compatibility**: n/a

## Workspace Crates Affected

None. `tools/xtask` (dev-only) gains one check.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [x] CHANGELOG.md updated (if user-facing change)
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace -- -D warnings -W clippy::pedantic` passes
- [x] `cargo test -p xtask` passes
- [x] Follows conventional commit format

## Testing Instructions

```bash
cargo test -p xtask
cargo run -p xtask -- docs verify-all
```

Three tests: `version_tokens_finds_release_shapes` covers `v0.5.0` / `0.5.x` / multiple tokens per line and confirms a bare integer is not treated as a version; `status_versioning_matches_the_workspace_version` runs the check against the repository; `status_version_targets_all_exist_and_declare_status` fails if a listed document stops declaring a status, so the target list cannot silently go stale.

The gate was verified against the regression it exists for — reverting `CLAUDE.md` to `v0.4.3` produces:

```
status version drift in CLAUDE.md:10: found `0.4.3`, expected one naming `0.5`
```

## Infrastructure/Tooling Changes

**Areas modified:**
- [x] xtask automation or docs verification tools

### Validation Evidence

```bash
cargo run -p xtask -- docs freeze contracts   # ✅ Pass
cargo test -p xtask                           # ✅ Pass (36 tests)
```

**Adversarial Testing:**
- [x] Tested with malformed input (a line with no version token is skipped; a bare integer such as "63 error codes" is not read as a version)
- [x] Verified boundary cases (`0.5.x` wildcard, a line naming both the preview and the v1.0.0 target)
- [x] Drift detection validated (see the reverted-CLAUDE.md run above)

## Performance Impact

- [x] No performance impact expected

## Breaking Changes

- [x] No breaking changes

## Related Issues

Relates to #535

---
_Generated by [Claude Code](https://claude.ai/code/session_014WgexC5kRkpPuRddZqiySu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project documentation to reflect Engineering Preview v0.5.0.
  * Clarified that v0.5.x is the current supported release, while v0.4.x and earlier are no longer supported.
  * Added an unreleased changelog entry and normalized historical formatting.

* **Quality Improvements**
  * Added automated checks to keep documented release versions consistent across project materials.
  * Expanded verification coverage for version references and documentation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->