### PR TITLE
fix(codec): reject unusable JSON values instead of encoding zeros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **codec**: `encode` no longer writes zeros over a numeric field whose JSON
+  value it cannot use. Zoned, packed, edited-numeric, and binary fields skipped
+  any present-but-unusable value and left the field at its default bytes, so
+  `{"CUST-ID": 12345}` without `--coerce-numbers` produced a record of zeros and
+  still reported success — silent corruption of the caller's data, including
+  under `--strict`. These fields now raise the already-documented
+  `CBKE501_JSON_TYPE_MISMATCH`, naming the field, the type found, and (for JSON
+  numbers) the `--coerce-numbers` remedy. `COMP-1`/`COMP-2` already behaved this
+  way; an absent field and an explicit `null` still keep their default bytes.
 - **codec**: `RecordIterator` no longer discards a trailing partial record.
   `read_exact` reports `UnexpectedEof` both for a clean end of file and for a
   reader that ran dry mid-record, so a file that is not a multiple of LRECL had

--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -1954,10 +1954,12 @@ fn encode_single_field(
             pic_string, scale, ..
         } => {
             // Phase E3.1: Encode edited PIC fields
-            if let Some(text) = json_obj
-                .get(&field.name)
-                .and_then(|v| coerce_to_str(v, options.coerce_numbers))
-            {
+            if let Some(text) = encodable_numeric_text(
+                json_obj,
+                field,
+                "an edited numeric string",
+                options.coerce_numbers,
+            )? {
                 // Tokenize the PIC pattern
                 let pattern = crate::edited_pic::tokenize_edited_pic(pic_string)?;
 
@@ -2318,6 +2320,55 @@ fn coerce_to_str(value: &Value, coerce: bool) -> Option<String> {
     }
 }
 
+/// Name the JSON type of `value` the way a user would recognize it in their input.
+fn json_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+/// Look up a numeric field's text value, rejecting a present-but-unusable JSON type.
+///
+/// Returns `Ok(None)` when the field is absent or `null`, which leaves the field at
+/// its default bytes. When the field *is* present but carries a type this encoder
+/// cannot use, this returns [`ErrorCode::CBKE501_JSON_TYPE_MISMATCH`] rather than
+/// silently writing zeros over the value the caller supplied.
+fn encodable_numeric_text(
+    json_obj: &serde_json::Map<String, Value>,
+    field: &copybook_core::Field,
+    expected: &str,
+    coerce_numbers: bool,
+) -> Result<Option<String>> {
+    let Some(value) = json_obj.get(&field.name) else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    if let Some(text) = coerce_to_str(value, coerce_numbers) {
+        return Ok(Some(text));
+    }
+
+    let hint = if value.is_number() {
+        " (pass --coerce-numbers to accept JSON numbers here)"
+    } else {
+        ""
+    };
+    Err(Error::new(
+        ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
+        format!(
+            "Field '{}' expects {expected}, found {}{hint}",
+            field.name,
+            json_type_name(value),
+        ),
+    ))
+}
+
 #[inline]
 #[allow(clippy::too_many_arguments)]
 fn encode_zoned_decimal_field(
@@ -2332,10 +2383,12 @@ fn encode_zoned_decimal_field(
 ) -> Result<usize> {
     let field_len = field.len as usize;
 
-    if let Some(text) = json_obj
-        .get(&field.name)
-        .and_then(|v| coerce_to_str(v, options.coerce_numbers))
-    {
+    if let Some(text) = encodable_numeric_text(
+        json_obj,
+        field,
+        "a zoned decimal string",
+        options.coerce_numbers,
+    )? {
         // Check BWZ policy: when field has BLANK WHEN ZERO and bwz_encode is enabled,
         // zero values are encoded as spaces instead of numeric zeros.
         if field.blank_when_zero && options.bwz_encode {
@@ -2402,10 +2455,12 @@ fn encode_packed_decimal_field(
 ) -> Result<usize> {
     let field_len = field.len as usize;
 
-    if let Some(text) = json_obj
-        .get(&field.name)
-        .and_then(|v| coerce_to_str(v, options.coerce_numbers))
-    {
+    if let Some(text) = encodable_numeric_text(
+        json_obj,
+        field,
+        "a packed decimal string",
+        options.coerce_numbers,
+    )? {
         let encoded =
             crate::numeric::encode_packed_decimal(&text, spec.digits, spec.scale, spec.signed)?;
         if current_offset + field_len <= buffer.len() && encoded.len() == field_len {
@@ -2434,16 +2489,37 @@ fn encode_binary_int_field(
 ) -> Result<usize> {
     let field_len = field.len as usize;
 
-    if let Some(num) = json_obj.get(&field.name).and_then(|v| {
-        if let Some(n) = v.as_i64() {
-            // Direct numeric path (always available for Value::Number with i64 range)
-            Some(n)
-        } else if let Some(s) = coerce_to_str(v, options.coerce_numbers) {
-            s.parse::<i64>().ok()
+    let value = match json_obj.get(&field.name) {
+        None => None,
+        Some(v) if v.is_null() => None,
+        Some(v) => Some(v),
+    };
+
+    if let Some(value) = value {
+        // Direct numeric path (always available for Value::Number in i64 range).
+        let num = if let Some(n) = value.as_i64() {
+            n
         } else {
-            None
-        }
-    }) {
+            let text = coerce_to_str(value, options.coerce_numbers).ok_or_else(|| {
+                Error::new(
+                    ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
+                    format!(
+                        "Field '{}' expects an integer, found {}",
+                        field.name,
+                        json_type_name(value),
+                    ),
+                )
+            })?;
+            text.parse::<i64>().map_err(|e| {
+                Error::new(
+                    ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
+                    format!(
+                        "Field '{}' expects an integer, found '{text}': {e}",
+                        field.name,
+                    ),
+                )
+            })?
+        };
         let encoded = crate::numeric::encode_binary_int(num, spec.bits, spec.signed)?;
         if current_offset + field_len <= buffer.len() && encoded.len() == field_len {
             buffer[current_offset..current_offset + field_len].copy_from_slice(&encoded);

--- a/crates/copybook-codec/tests/codec_integration.rs
+++ b/crates/copybook-codec/tests/codec_integration.rs
@@ -8,6 +8,7 @@ use copybook_codec::{
     decode_file_to_jsonl, decode_record, encode_jsonl_to_file, encode_record,
 };
 use copybook_core::parse_copybook;
+use copybook_error::ErrorCode;
 use std::io::Cursor;
 
 // ---------------------------------------------------------------------------
@@ -337,11 +338,46 @@ fn encode_without_coerce_numbers_rejects_number() {
     let json: serde_json::Value = serde_json::json!({"FLD": 42});
     let opts = ascii_encode_opts().with_coerce_numbers(false);
     let result = encode_record(&schema, &json, &opts);
-    // Without coerce_numbers, Value::Number is silently skipped (field stays zero-filled)
-    assert!(result.is_ok());
-    let encoded = result.unwrap();
-    // Field should be zero-filled since Value::Number was not coerced
-    assert_eq!(&encoded[..5], b"\x00\x00\x00\x00\x00");
+    // Without coerce_numbers a JSON number is a type mismatch. Reject it rather than
+    // writing zeros over the value the caller supplied.
+    let err = result.expect_err("JSON number must not be silently zero-filled");
+    assert_eq!(err.code(), ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+    let message = err.to_string();
+    assert!(
+        message.contains("FLD") && message.contains("--coerce-numbers"),
+        "error should name the field and the remedy: {message}"
+    );
+}
+
+#[test]
+fn encode_without_coerce_numbers_rejects_number_for_comp3() {
+    let schema = parse_copybook("01 FLD PIC S9(5) COMP-3.").unwrap();
+    let json: serde_json::Value = serde_json::json!({"FLD": 12345});
+    let opts = ascii_encode_opts().with_coerce_numbers(false);
+    let err = encode_record(&schema, &json, &opts)
+        .expect_err("JSON number must not be silently zero-filled for COMP-3");
+    assert_eq!(err.code(), ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+}
+
+#[test]
+fn encode_rejects_wrong_json_type_for_numeric_field() {
+    let schema = parse_copybook("01 FLD PIC 9(5).").unwrap();
+    let json: serde_json::Value = serde_json::json!({"FLD": true});
+    let opts = ascii_encode_opts().with_coerce_numbers(true);
+    let err = encode_record(&schema, &json, &opts)
+        .expect_err("a boolean is never an encodable numeric value");
+    assert_eq!(err.code(), ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+}
+
+#[test]
+fn encode_treats_null_numeric_field_as_absent() {
+    let schema = parse_copybook("01 FLD PIC 9(5).").unwrap();
+    let opts = ascii_encode_opts().with_coerce_numbers(false);
+    let explicit_null = encode_record(&schema, &serde_json::json!({"FLD": null}), &opts)
+        .expect("null should behave like an absent field");
+    let absent = encode_record(&schema, &serde_json::json!({}), &opts)
+        .expect("absent field should keep default bytes");
+    assert_eq!(explicit_null, absent);
 }
 
 #[test]

--- a/tests/e2e/e2e_cli_strict_comments.rs
+++ b/tests/e2e/e2e_cli_strict_comments.rs
@@ -117,7 +117,7 @@ fn encode_accepts_inline_comments_by_default() {
 
     // Create JSONL input
     let jsonl_path = dir.path().join("input.jsonl");
-    std::fs::write(&jsonl_path, r#"{"FIELD-A":"ABCDEFGHIJ","FIELD-B":12345}"#).unwrap();
+    std::fs::write(&jsonl_path, r#"{"FIELD-A":"ABCDEFGHIJ","FIELD-B":"12345"}"#).unwrap();
     let out = dir.path().join("out.bin");
 
     cmd()
@@ -145,7 +145,7 @@ fn encode_strict_comments_rejects_inline() {
     let (dir, cpy, _data) = setup(INLINE_COMMENT_CPY, &make_inline_data());
 
     let jsonl_path = dir.path().join("input.jsonl");
-    std::fs::write(&jsonl_path, r#"{"FIELD-A":"ABCDEFGHIJ","FIELD-B":12345}"#).unwrap();
+    std::fs::write(&jsonl_path, r#"{"FIELD-A":"ABCDEFGHIJ","FIELD-B":"12345"}"#).unwrap();
     let out = dir.path().join("out.bin");
 
     cmd()

--- a/tests/proptest-regressions/prop_determinism.txt
+++ b/tests/proptest-regressions/prop_determinism.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc f0de8aa3d979729840077123a510f9f8d3802559e81479880c095d440a938908 # shrinks to value = 0

--- a/tests/proptest/prop_determinism.rs
+++ b/tests/proptest/prop_determinism.rs
@@ -143,7 +143,9 @@ proptest! {
     #[test]
     fn prop_encode_deterministic_pic_9(value in 0u64..=99999) {
         let schema = parse_copybook("01 REC.\n   05 FLD PIC 9(5).").expect("parse");
-        let json: Value = serde_json::json!({ "FLD": value });
+        // PIC 9 takes its value as a string; a bare JSON number is a type mismatch
+        // unless the caller opts into coercion.
+        let json: Value = serde_json::json!({ "FLD": value.to_string() });
         let first = encode_record(&schema, &json, &encode_opts()).expect("encode 0");
         for i in 1..10 {
             let again = encode_record(&schema, &json, &encode_opts())


### PR DESCRIPTION
## Summary

`encode` silently wrote zeros over any numeric field whose JSON value it could not use, and reported success.

```console
$ cat rec.jsonl
{"CUST-ID":12345,"CUST-NAME":"ACME CORP","CUST-BAL":1234.56}

$ copybook encode cust.cpy rec.jsonl -o data.bin --format fixed
=== Encode Summary ===
Records processed: 1
$ echo $?
0
$ od -A d -t x1 data.bin
0000000 00 00 00 00 00 c1 c3 d4 c5 40 c3 d6 d9 d7 40 40
0000016 40 40 40 40 40 40 40 40 40 00 00 00 00 00
```

`CUST-ID` and `CUST-BAL` are zeros. Only the alphanumeric field survived. `--strict` did not change this, so a caller could ship a file of zeros believing the run succeeded.

**Cause.** The zoned, packed, edited-numeric, and binary paths in `lib_api.rs` look their value up with `coerce_to_str` and, when that returns `None`, fall through the `if let` and leave the field at its default bytes. A present-but-unusable value is therefore indistinguishable from an absent one. Without `--coerce-numbers`, `coerce_to_str` returns `None` for every `Value::Number`.

**Fix.** `CBKE501_JSON_TYPE_MISMATCH` is already documented for exactly this case in `docs/reference/ERROR_CODES.md` ("Expected: string (zoned decimal) / Found: number"), and `COMP-1`/`COMP-2` already raise it. The remaining numeric kinds now go through a shared helper that returns it, naming the field, the JSON type found, and the remedy:

```
CBKE501_JSON_TYPE_MISMATCH: Field 'CUST-ID' expects a zoned decimal string, found number (pass --coerce-numbers to accept JSON numbers here)
```

An absent key and an explicit `null` still keep their default bytes, so only the corrupting case changes. No docs update is needed — this makes the code match what `ERROR_CODES.md` already promises.

Found by hand-driving the CLI; not a reported issue. Two related CLI defects are out of scope here and will follow separately: this error's text is still swallowed by the encode summary (the codec drops error values in lenient mode and keeps only counts), and encode data errors exit 5 rather than 3.

## Type of Change

- [x] Bugfix (fixes an issue)

## COBOL/Mainframe Context

- **COBOL features affected**: zoned DISPLAY, COMP-3 packed decimal, edited PIC, COMP binary
- **Data processing impact**: encoding (JSON → binary)
- **Mainframe compatibility**: no dialect-specific behavior; affects all codepages equally

## Workspace Crates Affected

- [x] copybook-codec (encoding, decoding, character conversion)

## Checklist

- [x] Tests added/updated (or N/A for docs-only changes)
- [x] Documentation updated — N/A, code now matches documented `CBKE501` contract
- [x] CHANGELOG.md updated (if user-facing change)
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace -- -D warnings -W clippy::pedantic` passes
- [x] `cargo test --workspace` passes
- [x] Follows conventional commit format

## Testing Instructions

```bash
cargo test --workspace
cargo clippy --workspace -- -D warnings -W clippy::pedantic
cargo fmt --all --check
```

Manual check against the reproducer above — with the fix, the bad input is rejected, and the string form and `--coerce-numbers` both produce correct bytes:

```console
$ printf '{"CUST-ID":"12345","CUST-NAME":"ACME CORP","CUST-BAL":"1234.56"}\n' > ok.jsonl
$ copybook encode cust.cpy ok.jsonl -o ok.bin --format fixed && od -A d -t x1 ok.bin
0000000 f1 f2 f3 f4 f5 c1 c3 d4 c5 40 c3 d6 d9 d7 40 40
0000016 40 40 40 40 40 40 40 40 40 00 01 23 45 6c
```

### Test changes

- `encode_without_coerce_numbers_rejects_number` asserted the zero-fill its own name called a rejection; its body now matches the name.
- Added coverage for COMP-3 numbers, a non-numeric type (`true`), and `null`-behaves-as-absent.
- Two fixtures passed JSON numbers incidentally while testing inline comments (`e2e_cli_strict_comments`) and encode determinism (`prop_determinism`); they now pass strings so they keep testing their subject. The determinism property previously held by deterministically encoding zeros.

## Performance Impact

- [x] No performance impact expected

The added work is one `is_null` check on a value already fetched; the error path allocates only when the run is about to fail.

## Breaking Changes

- [x] Breaking changes with migration path (describe below)

### Migration Guide

Input that was silently corrupted is now rejected, so a caller relying on the zero-fill will see a new error. Both remedies were already supported:

```jsonc
// Before — encoded as zeros, exit 0
{"CUST-ID": 12345}

// After — either quote the value...
{"CUST-ID": "12345"}
```

```bash
# ...or opt into coercion explicitly
copybook encode cust.cpy rec.jsonl -o data.bin --format fixed --coerce-numbers
```

## Related Issues

Relates to #535

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qc2wCuoYw6A8d9dFhvZ8PX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Numeric fields now reject present JSON values with unsupported types instead of silently encoding zero-filled defaults.
  - Binary numeric values now report clear errors when invalid or unparsable.
  - Missing fields and explicit `null` values retain their existing behavior.
  - Numeric string inputs continue to support optional coercion.

- **Tests**
  - Added coverage for numeric type mismatches, boolean inputs, nulls, absent fields, and deterministic encoding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->