### PR TITLE
fix(cli): report which records failed, not just how many

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **codec**: `RunSummary` now carries `failures`, the first `MAX_CAPTURED_FAILURES`
+  (10) `RecordFailure` entries of a run, each naming the 1-based record index and
+  the `Error` that failed it. `records_with_errors` remains the full count, and
+  `undisclosed_failure_count()` reports how many failures were not retained.
+
 ### Fixed
+- **cli**: `decode` and `encode` now report which records failed and why. Both
+  commands counted failures and discarded the errors themselves, so a run ended
+  at `Records with errors: 3` with nothing to act on — the codec dropped each
+  `Error` in lenient mode and kept only a counter. Failed records are now listed
+  on stderr with their index and stable code. `encode` no longer advises
+  `--fail-fast=false`, a form the flag does not accept, nor suggests re-running
+  with `--fail-fast` for detail that is now printed either way.
 - **codec**: `encode` no longer writes zeros over a numeric field whose JSON
   value it cannot use. Zoned, packed, edited-numeric, and binary fields skipped
   any present-but-unusable value and left the field at its default bytes, so

--- a/crates/copybook-cli/src/commands/decode.rs
+++ b/crates/copybook-cli/src/commands/decode.rs
@@ -4,10 +4,13 @@
 use crate::exit_codes::ExitCode;
 use crate::subcode;
 use crate::utils::{
-    ParseOptionsConfig, SummaryIssueCountStyle, append_processing_summary, determine_exit_code,
-    effective_error_policy, log_strict_comments, parse_projected_schema, run_with_output,
+    ParseOptionsConfig, SummaryIssueCountStyle, append_processing_summary, append_record_failures,
+    determine_exit_code, effective_error_policy, log_strict_comments, parse_projected_schema,
+    run_with_output,
 };
-use crate::{ExitDiagnostics, Stage, emit_exit_diagnostics_stage, write_stdout_all};
+use crate::{
+    ExitDiagnostics, Stage, emit_exit_diagnostics_stage, write_stderr_all, write_stdout_all,
+};
 use copybook_codec::{
     Codepage, DecodeOptions, FloatFormat, JsonNumberMode, RawMode, RecordFormat, UnmappablePolicy,
 };
@@ -138,6 +141,13 @@ pub fn run(args: &DecodeArgs) -> anyhow::Result<ExitCode> {
         )?;
 
         write_stdout_all(summary_output.as_bytes())?;
+    }
+
+    // Failure detail goes to stderr so it survives `-o -` and shell redirection.
+    let mut failure_output = String::new();
+    append_record_failures(&mut failure_output, &summary)?;
+    if !failure_output.is_empty() {
+        write_stderr_all(failure_output.as_bytes())?;
     }
 
     info!("Decode completed successfully");

--- a/crates/copybook-cli/src/commands/encode.rs
+++ b/crates/copybook-cli/src/commands/encode.rs
@@ -3,8 +3,9 @@
 
 use crate::exit_codes::ExitCode;
 use crate::utils::{
-    ParseOptionsConfig, SummaryIssueCountStyle, append_processing_summary, determine_exit_code,
-    effective_error_policy, log_strict_comments, parse_projected_schema, run_with_output,
+    ParseOptionsConfig, SummaryIssueCountStyle, append_processing_summary, append_record_failures,
+    determine_exit_code, effective_error_policy, log_strict_comments, parse_projected_schema,
+    run_with_output,
 };
 use crate::{write_stderr_all, write_stdout_all};
 use anyhow::bail;
@@ -96,6 +97,13 @@ pub fn run(
         write_stdout_all(summary_output.as_bytes())?;
     }
 
+    // Report which records failed and why, not just how many.
+    let mut failure_output = String::new();
+    append_record_failures(&mut failure_output, &summary)?;
+    if !failure_output.is_empty() {
+        write_stderr_all(failure_output.as_bytes())?;
+    }
+
     // Provide detailed feedback about encode status
     if summary.records_processed == 0 && summary.records_with_errors > 0 {
         let mut err_output = String::new();
@@ -103,11 +111,6 @@ pub fn run(
         writeln!(
             &mut err_output,
             "ERROR: No records were successfully encoded."
-        )?;
-        writeln!(
-            &mut err_output,
-            "All {} records failed to encode. Use --fail-fast=false to see details of additional errors.",
-            summary.records_with_errors
         )?;
         writeln!(
             &mut err_output,
@@ -121,10 +124,6 @@ pub fn run(
             &mut err_output,
             "WARNING: {} records failed to encode but were skipped in lenient mode.",
             summary.records_with_errors
-        )?;
-        writeln!(
-            &mut err_output,
-            "Use --fail-fast to stop on first error for detailed error information."
         )?;
         write_stderr_all(err_output.as_bytes())?;
     }

--- a/crates/copybook-cli/src/utils.rs
+++ b/crates/copybook-cli/src/utils.rs
@@ -221,6 +221,30 @@ pub fn append_processing_summary(
     Ok(())
 }
 
+/// Append the record failures a run captured, so the operator can see which
+/// records failed and why instead of only how many.
+///
+/// Writes nothing when the run recorded no failures. The codec retains the
+/// first `MAX_CAPTURED_FAILURES`; any beyond that are reported as a remainder.
+pub fn append_record_failures(output: &mut String, summary: &RunSummary) -> std::fmt::Result {
+    if summary.failures.is_empty() {
+        return Ok(());
+    }
+
+    writeln!(output)?;
+    writeln!(output, "Failed records:")?;
+    for failure in &summary.failures {
+        writeln!(output, "  {failure}")?;
+    }
+
+    let remaining = summary.undisclosed_failure_count();
+    if remaining > 0 {
+        writeln!(output, "  ... and {remaining} more")?;
+    }
+
+    Ok(())
+}
+
 /// Atomically write data to a file using temporary file + rename
 ///
 /// This ensures that the output file is either completely written or not present at all,

--- a/crates/copybook-codec/src/lib.rs
+++ b/crates/copybook-codec/src/lib.rs
@@ -45,8 +45,8 @@ pub const JSON_SCHEMA_VERSION: &str = "copybook.v1";
 pub use iterator::{RecordIterator, iter_records, iter_records_from_file};
 
 pub use lib_api::{
-    RunSummary, decode_file_to_jsonl, decode_record, decode_record_with_scratch,
-    encode_jsonl_to_file, encode_record,
+    MAX_CAPTURED_FAILURES, RecordFailure, RunSummary, decode_file_to_jsonl, decode_record,
+    decode_record_with_scratch, encode_jsonl_to_file, encode_record,
 };
 
 pub use numeric::{SmallDecimal, ZonedEncodingInfo};

--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -25,7 +25,7 @@ mod telemetry;
 mod warnings;
 
 use envelope::build_json_envelope;
-pub use run_summary::RunSummary;
+pub use run_summary::{MAX_CAPTURED_FAILURES, RecordFailure, RunSummary};
 pub use warnings::increment_warning_counter;
 use warnings::{reset_warning_counter, warning_count};
 
@@ -2651,9 +2651,8 @@ fn process_fixed_records<R: Read, W: Write>(
                 summary.records_processed += 1;
             }
             Err(error) => {
-                summary.records_with_errors += 1;
-                let family = error.family_prefix();
-                telemetry::record_error(family);
+                summary.note_failure(record_index, &error);
+                telemetry::record_error(error.family_prefix());
                 if options.strict_mode {
                     return Err(error);
                 }
@@ -2673,6 +2672,8 @@ struct DecodeWork {
 struct DecodeOutcome {
     result: Result<Value>,
     warnings: u64,
+    /// Carried back from the work item so a failure can name its record.
+    record_index: u64,
 }
 
 fn effective_worker_count(requested: usize) -> usize {
@@ -2704,7 +2705,11 @@ fn decode_worker_pool(
                 scratch,
             );
             let warnings = warning_count().saturating_sub(warning_count_before);
-            DecodeOutcome { result, warnings }
+            DecodeOutcome {
+                result,
+                warnings,
+                record_index: work.record_index,
+            }
         },
     )
 }
@@ -2737,15 +2742,15 @@ fn process_decode_batch<W: Write>(
             continue;
         }
 
+        let record_index = outcome.record_index;
         match outcome.result {
             Ok(json_value) => {
                 write_json_record(output, &json_value)?;
                 summary.records_processed += 1;
             }
             Err(error) => {
-                summary.records_with_errors += 1;
-                let family = error.family_prefix();
-                telemetry::record_error(family);
+                summary.note_failure(record_index, &error);
+                telemetry::record_error(error.family_prefix());
                 if options.strict_mode {
                     first_error = Some(error);
                 }
@@ -2882,9 +2887,8 @@ fn process_rdw_records<R: Read, W: Write>(
         {
             let error = rdw_underflow_error(schema_lrecl, rdw_record.payload.len());
 
-            summary.records_with_errors += 1;
-            let family = error.family_prefix();
-            telemetry::record_error(family);
+            summary.note_failure(record_index, &error);
+            telemetry::record_error(error.family_prefix());
             if options.strict_mode {
                 return Err(error);
             }
@@ -2906,9 +2910,8 @@ fn process_rdw_records<R: Read, W: Write>(
                 summary.records_processed += 1;
             }
             Err(error) => {
-                summary.records_with_errors += 1;
-                let family = error.family_prefix();
-                telemetry::record_error(family);
+                summary.note_failure(record_index, &error);
+                telemetry::record_error(error.family_prefix());
                 if options.strict_mode {
                     return Err(error);
                 }
@@ -2985,9 +2988,8 @@ fn process_rdw_records_parallel<R: Read, W: Write>(
         {
             let error = rdw_underflow_error(schema_lrecl, rdw_record.payload.len());
 
-            summary.records_with_errors += 1;
-            let family = error.family_prefix();
-            telemetry::record_error(family);
+            summary.note_failure(record_index, &error);
+            telemetry::record_error(error.family_prefix());
             if options.strict_mode {
                 let pending_result = if batch_len > 0 {
                     process_decode_batch(&mut pool, batch_len, output, options, summary)
@@ -3118,7 +3120,8 @@ fn process_encode_batch<W: Write>(
                 summary.bytes_processed += binary_data.len() as u64;
             }
             Err(error) => {
-                summary.records_with_errors += 1;
+                // `position` is batch-relative; report the record's absolute index.
+                summary.note_failure(records_before_batch + position as u64 + 1, &error);
                 telemetry::record_error(error.family_prefix());
                 if options.strict_mode {
                     first_error = Some((position as u64 + 1, error));
@@ -3360,15 +3363,19 @@ pub fn encode_jsonl_to_file(
                 .map_err(|e| Error::new(ErrorCode::CBKE501_JSON_TYPE_MISMATCH, e.to_string()))?;
 
             // Encode to binary
-            if let Ok(binary_data) = encode_record(schema, &json_value, options) {
-                output
-                    .write_all(&binary_data)
-                    .map_err(|e| Error::new(ErrorCode::CBKC201_JSON_WRITE_ERROR, e.to_string()))?;
-                summary.bytes_processed += binary_data.len() as u64;
-            } else {
-                summary.records_with_errors += 1;
-                if options.strict_mode {
-                    break;
+            match encode_record(schema, &json_value, options) {
+                Ok(binary_data) => {
+                    output.write_all(&binary_data).map_err(|e| {
+                        Error::new(ErrorCode::CBKC201_JSON_WRITE_ERROR, e.to_string())
+                    })?;
+                    summary.bytes_processed += binary_data.len() as u64;
+                }
+                Err(error) => {
+                    summary.note_failure(record_count, &error);
+                    telemetry::record_error(error.family_prefix());
+                    if options.strict_mode {
+                        break;
+                    }
                 }
             }
         }

--- a/crates/copybook-codec/src/lib_api/run_summary.rs
+++ b/crates/copybook-codec/src/lib_api/run_summary.rs
@@ -1,7 +1,30 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! Processing run statistics and display formatting.
 
+use copybook_error::Error;
 use std::fmt;
+
+/// How many individual record failures a [`RunSummary`] retains.
+///
+/// A run over a badly mismatched file can fail on every record; keeping the
+/// first few is enough to diagnose it without holding the whole file in memory.
+/// `verify` already reports its errors under the same "first 10" convention.
+pub const MAX_CAPTURED_FAILURES: usize = 10;
+
+/// A single record that failed during a decode or encode run.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RecordFailure {
+    /// 1-based index of the record within the input.
+    pub record_index: u64,
+    /// The error that caused this record to fail, with its code and context.
+    pub error: Error,
+}
+
+impl fmt::Display for RecordFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "record {}: {}", self.record_index, self.error)
+    }
+}
 
 /// Summary of a processing run with comprehensive statistics.
 ///
@@ -30,6 +53,11 @@ pub struct RunSummary {
     pub peak_memory_bytes: Option<u64>,
     /// Number of worker threads used for parallel processing.
     pub threads_used: usize,
+    /// The first [`MAX_CAPTURED_FAILURES`] record failures seen during the run.
+    ///
+    /// `records_with_errors` remains the full count; this carries enough of the
+    /// detail to tell the caller *which* records failed and *why*.
+    pub failures: Vec<RecordFailure>,
 }
 
 impl RunSummary {
@@ -62,6 +90,29 @@ impl RunSummary {
     #[must_use]
     pub const fn has_errors(&self) -> bool {
         self.records_with_errors > 0
+    }
+
+    /// Count a failed record and retain its detail, up to [`MAX_CAPTURED_FAILURES`].
+    ///
+    /// Callers previously incremented `records_with_errors` and dropped the
+    /// `Error`, which left the caller with a count and no way to find out what
+    /// went wrong. Recording both keeps the count authoritative while making the
+    /// first failures reportable.
+    pub fn note_failure(&mut self, record_index: u64, error: &Error) {
+        self.records_with_errors += 1;
+        if self.failures.len() < MAX_CAPTURED_FAILURES {
+            self.failures.push(RecordFailure {
+                record_index,
+                error: error.clone(),
+            });
+        }
+    }
+
+    /// Number of failures that occurred beyond the retained [`Self::failures`].
+    #[must_use]
+    pub fn undisclosed_failure_count(&self) -> u64 {
+        self.records_with_errors
+            .saturating_sub(self.failures.len() as u64)
     }
 
     /// Check if processing had any warnings

--- a/crates/copybook-codec/tests/codec_integration.rs
+++ b/crates/copybook-codec/tests/codec_integration.rs
@@ -557,3 +557,67 @@ fn pipeline_preserves_spaces_in_alpha() {
     // Alpha fields should preserve leading/trailing spaces through round-trip
     assert_eq!(encoded.len(), 8);
 }
+
+#[test]
+fn decode_summary_reports_which_records_failed() {
+    let schema = parse_copybook("01 REC.\n   05 FLD PIC 9(3).").unwrap();
+    // Three records: valid, invalid, valid.
+    let data = b"123XYZ456";
+    let mut output = Vec::new();
+    let opts = DecodeOptions::new()
+        .with_codepage(Codepage::ASCII)
+        .with_format(RecordFormat::Fixed);
+    let summary =
+        decode_file_to_jsonl(&schema, Cursor::new(&data[..]), &mut output, &opts).unwrap();
+
+    assert_eq!(summary.records_with_errors, 1);
+    assert_eq!(
+        summary.failures.len(),
+        1,
+        "the failed record must be reported, not just counted"
+    );
+    assert_eq!(
+        summary.failures[0].record_index, 2,
+        "record index should be 1-based and name the record that actually failed"
+    );
+    assert_eq!(summary.undisclosed_failure_count(), 0);
+}
+
+#[test]
+fn encode_summary_reports_which_records_failed() {
+    let schema = parse_copybook("01 REC.\n   05 FLD PIC 9(3).").unwrap();
+    let jsonl = "{\"FLD\":\"123\"}\n{\"FLD\":456}\n";
+    let mut output = Vec::new();
+    let opts = ascii_encode_opts();
+    let summary =
+        encode_jsonl_to_file(&schema, Cursor::new(jsonl.as_bytes()), &mut output, &opts).unwrap();
+
+    assert_eq!(summary.records_with_errors, 1);
+    assert_eq!(summary.failures.len(), 1);
+    assert_eq!(summary.failures[0].record_index, 2);
+    assert_eq!(
+        summary.failures[0].error.code(),
+        ErrorCode::CBKE501_JSON_TYPE_MISMATCH
+    );
+}
+
+#[test]
+fn summary_caps_retained_failures_and_reports_the_remainder() {
+    let schema = parse_copybook("01 REC.\n   05 FLD PIC 9(3).").unwrap();
+    // 15 records, all invalid, exceeding MAX_CAPTURED_FAILURES.
+    let data = "XYZ".repeat(15);
+    let mut output = Vec::new();
+    let opts = DecodeOptions::new()
+        .with_codepage(Codepage::ASCII)
+        .with_format(RecordFormat::Fixed);
+    let summary =
+        decode_file_to_jsonl(&schema, Cursor::new(data.as_bytes()), &mut output, &opts).unwrap();
+
+    assert_eq!(summary.records_with_errors, 15);
+    assert_eq!(
+        summary.failures.len(),
+        copybook_codec::MAX_CAPTURED_FAILURES,
+        "retained detail must stay bounded"
+    );
+    assert_eq!(summary.undisclosed_failure_count(), 5);
+}

--- a/docs/reference/LIBRARY_API.md
+++ b/docs/reference/LIBRARY_API.md
@@ -934,6 +934,28 @@ pub struct RunSummary {
     pub throughput_mbps: f64,
     pub peak_memory_bytes: Option<u64>,
     pub threads_used: usize,
+    /// The first `MAX_CAPTURED_FAILURES` record failures seen during the run.
+    pub failures: Vec<RecordFailure>,
+}
+
+pub struct RecordFailure {
+    /// 1-based index of the record within the input.
+    pub record_index: u64,
+    /// The error that caused this record to fail, with its code and context.
+    pub error: Error,
+}
+```
+
+`records_with_errors` is the full count of failed records. `failures` carries the
+detail for the first `MAX_CAPTURED_FAILURES` (10) of them, so a caller can report
+*which* records failed and *why* without holding an unbounded list for a file that
+fails on every record. `undisclosed_failure_count()` returns how many failures
+occurred beyond the retained ones.
+
+```rust
+let summary = decode_file_to_jsonl(&schema, input, &mut output, &options)?;
+for failure in &summary.failures {
+    eprintln!("record {}: {}", failure.record_index, failure.error);
 }
 ```
 


### PR DESCRIPTION
## Summary

A lenient `decode` or `encode` run ended with a count and nothing to act on:

```console
$ copybook decode cust.cpy data.bin -o out.jsonl --format fixed
=== Decode Summary ===
Records processed: 0
Records with errors: 3
```

Which records? Failing how? The output did not say, and no flag would make it say — the information was gone before the CLI saw it.

**Cause.** Seven sites in `lib_api.rs` shared one shape: increment the counter, record telemetry, drop the `Error` unless strict mode returned it.

```rust
Err(error) => {
    summary.records_with_errors += 1;
    let family = error.family_prefix();
    telemetry::record_error(family);
    if options.strict_mode {
        return Err(error);
    }
}
```

`RunSummary` carried only counts, so nothing downstream could report more. `encode` papered over this with advice that does not work: it suggested `--fail-fast=false` (a form clap rejects — `fail_fast` is a `bool` with `ArgAction::SetTrue`) and, in the lenient branch, re-running under `--fail-fast` for detail.

**Fix.** `RunSummary` retains the first `MAX_CAPTURED_FAILURES` (10) failures as `RecordFailure { record_index, error }` through a shared `note_failure`. The bound keeps a file that fails on every record from being accumulated in memory; `undisclosed_failure_count()` reports the remainder. `verify` already reports errors under the same "first 10" convention.

After:

```console
=== Decode Summary ===
Records processed: 0
Records with errors: 3

Failed records:
  record 1: CBKD411_ZONED_BAD_SIGN: Invalid EBCDIC zone 0xD at position 0, expected 0xF
  record 2: CBKD411_ZONED_BAD_SIGN: Invalid EBCDIC zone 0x6 at position 0, expected 0xF
  record 3: CBKD411_ZONED_BAD_SIGN: Invalid digit nibble 0xB at position 0
```

This also makes #702's new message reachable — that error text existed but was being swallowed by the same gap:

```
Failed records:
  record 1: CBKE501_JSON_TYPE_MISMATCH: Field 'CUST-ID' expects a zoned decimal string, found number (pass --coerce-numbers to accept JSON numbers here)
```

Failure detail goes to stderr so it survives `-o -` and shell redirection.

### Two record indices were not previously recoverable

- `DecodeOutcome` discarded its work item's `record_index`, so the parallel decode path could not name the record. It now carries it back.
- The parallel encode batch reported `position + 1`, which is batch-relative; it now reports `records_before_batch + position + 1`.

The serial encode path also gained the `telemetry::record_error` call its six siblings already had.

**Explicitly out of scope:** record counting is untouched. `encode` still counts a failed record as processed (`Records processed: 1` alongside `Records with errors: 1` for a one-record file), because `records_processed` is assigned from the line counter. That is a separate defect and a separate PR.

## Type of Change

- [x] Bugfix (fixes an issue)

## COBOL/Mainframe Context

- **COBOL features affected**: none specifically — applies to every field type that can fail
- **Data processing impact**: decode and encode error reporting
- **Mainframe compatibility**: unaffected

## Workspace Crates Affected

- [x] copybook-codec (encoding, decoding, character conversion)
- [x] copybook-cli (CLI commands and options)

## Checklist

- [x] Tests added/updated (or N/A for docs-only changes)
- [x] Documentation updated (`docs/reference/LIBRARY_API.md` — `RunSummary` gained a public field)
- [x] CHANGELOG.md updated (if user-facing change)
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace -- -D warnings -W clippy::pedantic` passes
- [x] `cargo test --workspace` passes
- [x] Follows conventional commit format

## Testing Instructions

```bash
cargo test --workspace
cargo clippy --workspace -- -D warnings -W clippy::pedantic
cargo fmt --all --check
```

Manual check — three records where the middle one is invalid:

```bash
printf '123XYZ456' > data.bin
copybook decode rec.cpy data.bin -o out.jsonl --format fixed   # names record 2
```

New tests cover the three behaviors that matter: the reported index is 1-based and identifies the record that actually failed (not the first or last), the retained list stays bounded at `MAX_CAPTURED_FAILURES` with the remainder counted, and an encode failure carries its stable `CBKE501` code through to the summary.

## Performance Impact

- [x] No performance impact expected

`note_failure` does the counter increment that was already happening, plus a length check and — for at most the first 10 failures of a run — one `Error` clone. The success path is untouched.

## Breaking Changes

- [x] Breaking changes with migration path (describe below)

### Migration Guide

`RunSummary` gains a public field. Code constructing it with a struct literal and no `..Default::default()` will need updating:

```rust
// Before
let summary = RunSummary { records_processed: 3, /* ...every field... */ };

// After — or add `failures: Vec::new()`
let summary = RunSummary { records_processed: 3, ..RunSummary::default() };
```

Both in-tree literal constructions already used `..RunSummary::default()` and needed no change. Reading `records_with_errors` is unaffected.

## Related Issues

Relates to #535, #552

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qc2wCuoYw6A8d9dFhvZ8PX)_