### PR TITLE
fix(cli): stop reporting bad input as an internal error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **error**: `CBKF001_FILE_READ_ERROR` for a file named on the command line that
+  cannot be opened or read. Severity Fatal; maps to exit code 4 like the rest of
+  the `CBKF` family.
+- **codec**: `RunSummary` now carries `failures`, the first `MAX_CAPTURED_FAILURES`
+  (10) `RecordFailure` entries of a run, each naming the 1-based record index and
+  the `Error` that failed it. `records_with_errors` remains the full count, and
+  `undisclosed_failure_count()` reports how many failures were not retained.
+
 ### Fixed
+- **cli**: A file the CLI cannot read now names the file and the argument it came
+  from, and exits 4 instead of 5. `copybook inspect /nope.cpy` printed a bare
+  `No such file or directory (os error 2)` — no path, no indication whether the
+  copybook or the data file was missing — and, carrying no `CBK*` family, mapped
+  to `ExitCode::Internal`, reporting a mistyped path as an internal copybook-rs
+  error. Applies to `inspect`, `parse`, `decode`, `encode`, and `verify`, for both
+  the copybook and input arguments.
 - **cli**: `encode` now exits 3 (`CBKE`) when input data fails to encode, instead
   of 5 (`CBKI`, "internal orchestration error"). The fail-fast bail read
   `"Encoding failed with N error(s) in fail-fast mode"`, and `parse_prefix_from_str`
@@ -17,14 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   default, reporting the user's bad input as a bug in copybook-rs. The message now
   leads with the failing record's stable code, which is what the top-level `--help`
   already documents ("3 encode/schema errors (CBKE)").
-
-### Added
-- **codec**: `RunSummary` now carries `failures`, the first `MAX_CAPTURED_FAILURES`
-  (10) `RecordFailure` entries of a run, each naming the 1-based record index and
-  the `Error` that failed it. `records_with_errors` remains the full count, and
-  `undisclosed_failure_count()` reports how many failures were not retained.
-
-### Fixed
 - **cli**: `decode` and `encode` now report which records failed and why. Both
   commands counted failures and discarded the errors themselves, so a run ended
   at `Records with errors: 3` with nothing to act on — the codec dropped each

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **cli**: `encode` now exits 3 (`CBKE`) when input data fails to encode, instead
+  of 5 (`CBKI`, "internal orchestration error"). The fail-fast bail read
+  `"Encoding failed with N error(s) in fail-fast mode"`, and `parse_prefix_from_str`
+  recovers a family only from the message's *first* whitespace-delimited token — so
+  a message opening with prose carried no family and fell through to the internal
+  default, reporting the user's bad input as a bug in copybook-rs. The message now
+  leads with the failing record's stable code, which is what the top-level `--help`
+  already documents ("3 encode/schema errors (CBKE)").
+
 ### Added
 - **codec**: `RunSummary` now carries `failures`, the first `MAX_CAPTURED_FAILURES`
   (10) `RecordFailure` entries of a run, each naming the 1-based record index and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ cargo test --workspace golden
 
 ## Error Taxonomy
 
-10 families, 63 stable codes. See `docs/reference/ERROR_CODES.md` for the full list.
+10 families, 65 stable codes. See `docs/reference/ERROR_CODES.md` for the full list.
 
 | Prefix | Domain |
 |--------|--------|

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ See [COBOL_SUPPORT_MATRIX.md](docs/reference/COBOL_SUPPORT_MATRIX.md) for the fu
 |----:|:----:|--------------------|------|
 | 2 | CBKD | Data quality failure | exit_code_mapping::exit_code_cbkd_is_2 |
 | 3 | CBKE | Encode/validation failure | exit_code_mapping::exit_code_cbke_is_3 |
-| 4 | CBKF | Record format/RDW failure | exit_code_mapping::exit_code_cbkf_is_4 |
+| 4 | CBKF | File read or record format/RDW failure | exit_code_mapping::exit_code_cbkf_is_4 |
 | 5 | CBKI | Internal orchestration error | exit_code_mapping::exit_code_cbki_is_5 |
 
 ## Development

--- a/crates/copybook-cli/src/commands/encode.rs
+++ b/crates/copybook-cli/src/commands/encode.rs
@@ -128,13 +128,22 @@ pub fn run(
         write_stderr_all(err_output.as_bytes())?;
     }
 
-    // Check for fatal errors when fail-fast is enabled
+    // Check for fatal errors when fail-fast is enabled.
+    //
+    // `map_error_to_exit_code` derives the process exit code from the CBK* prefix it
+    // finds in the error chain, and `parse_prefix_from_str` only inspects the message's
+    // *first* whitespace-delimited token. A message that opens with prose therefore
+    // carries no recoverable family and falls through to `ExitCode::Internal`, telling
+    // the user their bad input was a bug in copybook-rs. Lead with the stable code.
     if options.fail_fast && summary.has_errors() {
-        let error_msg = format!(
-            "Encoding failed with {} error(s) in fail-fast mode",
+        if let Some(first) = summary.failures.first() {
+            bail!("{} (record {})", first.error, first.record_index);
+        }
+        bail!(
+            "{}: encoding failed with {} error(s)",
+            ExitCode::Encode.tag(),
             summary.records_with_errors
         );
-        bail!("{error_msg}");
     }
 
     info!("Encode completed successfully");

--- a/crates/copybook-cli/src/commands/inspect.rs
+++ b/crates/copybook-cli/src/commands/inspect.rs
@@ -2,7 +2,7 @@
 //! Inspect command implementation
 
 use crate::exit_codes::ExitCode;
-use crate::utils::read_file_or_stdin;
+use crate::utils::{InputRole, read_input_or_stdin};
 use crate::write_stdout_all;
 use copybook_codec::Codepage;
 use copybook_core::{Field, FieldKind, Occurs, ParseOptions, parse_copybook_with_options};
@@ -33,7 +33,7 @@ pub fn run(
     }
 
     // Read copybook file or stdin
-    let copybook_text = read_file_or_stdin(copybook)?;
+    let copybook_text = read_input_or_stdin(InputRole::Copybook, copybook)?;
 
     // Parse copybook with options
     let options = ParseOptions {

--- a/crates/copybook-cli/src/commands/parse.rs
+++ b/crates/copybook-cli/src/commands/parse.rs
@@ -2,7 +2,7 @@
 //! Parse command implementation
 
 use crate::exit_codes::ExitCode;
-use crate::utils::{atomic_write, read_file_or_stdin};
+use crate::utils::{InputRole, atomic_write, read_input_or_stdin};
 use crate::write_stdout_all;
 use copybook_core::{ParseOptions, parse_copybook_with_options};
 use std::path::PathBuf;
@@ -22,7 +22,7 @@ pub fn run(
     }
 
     // Read copybook file or stdin
-    let copybook_text = read_file_or_stdin(copybook)?;
+    let copybook_text = read_input_or_stdin(InputRole::Copybook, copybook)?;
 
     // Parse copybook with options
     let options = ParseOptions {

--- a/crates/copybook-cli/src/commands/verify.rs
+++ b/crates/copybook-cli/src/commands/verify.rs
@@ -6,8 +6,8 @@
 use super::verify_report::{VerifyCliEcho, VerifyError, VerifyReport, VerifySample};
 use crate::exit_codes::ExitCode;
 use crate::utils::{
-    ParseOptionsConfig, apply_field_projection, atomic_write, build_parse_options,
-    read_file_or_stdin,
+    InputRole, ParseOptionsConfig, apply_field_projection, atomic_write, build_parse_options,
+    read_input_or_stdin,
 };
 use crate::write_stdout_all;
 use anyhow::bail;
@@ -19,7 +19,7 @@ use copybook_core::parse_copybook_with_options;
 use std::fmt::Write as _;
 use std::fs::{File, metadata};
 use std::io::{BufReader, Read, Seek, SeekFrom};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tracing::{error, info, warn};
 
 // Hex display constants for consistent output formatting
@@ -63,8 +63,8 @@ pub struct VerifyOptions<'a> {
 
 #[allow(clippy::too_many_lines)]
 pub fn run(
-    copybook_path: &PathBuf,
-    input: &PathBuf,
+    copybook_path: &Path,
+    input: &Path,
     report: Option<PathBuf>,
     opts: &VerifyOptions,
 ) -> anyhow::Result<ExitCode> {
@@ -75,7 +75,7 @@ pub fn run(
     }
 
     // Read copybook file or stdin
-    let copybook_text = read_file_or_stdin(copybook_path)?;
+    let copybook_text = read_input_or_stdin(InputRole::Copybook, copybook_path)?;
 
     // Parse copybook with options
     let parse_options = build_parse_options(&ParseOptionsConfig {

--- a/crates/copybook-cli/src/exit_codes.rs
+++ b/crates/copybook-cli/src/exit_codes.rs
@@ -26,7 +26,7 @@ pub enum ExitCode {
     Data = 2,
     /// Encode/validation failure (`CBKE*`) or verification mismatch.
     Encode = 3,
-    /// Record format / iterator fatal (`CBKF*`).
+    /// Unreadable input file, record format, or iterator fatal (`CBKF*`).
     Format = 4,
     /// Internal orchestration error (`CBKI*`).
     Internal = 5,
@@ -81,7 +81,7 @@ impl ExitCode {
             ExitCode::Unknown => "Unhandled failure",
             ExitCode::Data => "Data quality failure",
             ExitCode::Encode => "Encode/validation failure",
-            ExitCode::Format => "Record format/RDW failure",
+            ExitCode::Format => "File read or record format/RDW failure",
             ExitCode::Internal => "Internal orchestration error",
         }
     }

--- a/crates/copybook-cli/src/main.rs
+++ b/crates/copybook-cli/src/main.rs
@@ -104,7 +104,7 @@ Two settings are never guessed and are worth getting right first:
               mismatch decodes without error but yields mojibake text.
 
 Exit codes: 0 success, 2 data errors (CBKD), 3 encode/schema errors (CBKE),
-4 record-format errors (CBKF), 5 internal errors (CBKI), 1 otherwise.
+4 file/record-format errors (CBKF), 5 internal errors (CBKI), 1 otherwise.
 
 Error codes: docs/reference/ERROR_CODES.md
 Full CLI reference: docs/CLI_REFERENCE.md";

--- a/crates/copybook-cli/src/utils.rs
+++ b/crates/copybook-cli/src/utils.rs
@@ -3,7 +3,9 @@
 
 use crate::exit_codes::ExitCode;
 use copybook_codec::RunSummary;
-use copybook_core::{ParseOptions, Schema, parse_copybook_with_options};
+use copybook_core::{
+    Error as CoreError, ErrorCode, ParseOptions, Schema, parse_copybook_with_options,
+};
 use std::fmt::Write as FmtWrite;
 use std::fs;
 use std::io::{self, Read, Write};
@@ -52,7 +54,7 @@ pub fn parse_projected_schema(
     config: &ParseOptionsConfig,
     select_args: &[String],
 ) -> anyhow::Result<Schema> {
-    let copybook_text = read_file_or_stdin(copybook)?;
+    let copybook_text = read_input_or_stdin(InputRole::Copybook, copybook)?;
     let parse_options = build_parse_options(config);
     let schema = parse_copybook_with_options(&copybook_text, &parse_options)?;
     apply_field_projection(schema, select_args)
@@ -152,14 +154,16 @@ where
     let write_to_stdout = output == Path::new("-");
 
     if write_to_stdout {
-        let input_file = fs::File::open(input)?;
+        let input_file =
+            fs::File::open(input).map_err(|e| file_read_error(InputRole::Input, input, &e))?;
         let mut stdout = std::io::stdout().lock();
         return Ok((process(input_file, &mut stdout)?, true));
     }
 
     let mut summary = None;
     atomic_write(output, |output_writer| {
-        let input_file = fs::File::open(input).map_err(std::io::Error::other)?;
+        let input_file = fs::File::open(input)
+            .map_err(|e| std::io::Error::other(file_read_error(InputRole::Input, input, &e)))?;
         let run_summary = process(input_file, output_writer).map_err(std::io::Error::other)?;
         summary = Some(run_summary);
         Ok(())
@@ -326,6 +330,51 @@ pub fn determine_exit_code(
 /// # Errors
 ///
 /// Returns an error if the file cannot be read or if stdin reading fails.
+/// Describe a file the user named on the command line, so a failure to open it can
+/// say *which* file and *which* argument it came from.
+#[derive(Clone, Copy)]
+pub enum InputRole {
+    /// The `<COPYBOOK>` positional argument.
+    Copybook,
+    /// The `<INPUT>` positional argument (data or JSONL).
+    Input,
+}
+
+impl InputRole {
+    const fn label(self) -> &'static str {
+        match self {
+            InputRole::Copybook => "copybook",
+            InputRole::Input => "input file",
+        }
+    }
+}
+
+/// Turn a file-open/read failure into a `CBKF001_FILE_READ_ERROR` naming the path.
+///
+/// A bare `io::Error` reaching the top level prints as an unattributed
+/// "No such file or directory (os error 2)" and, carrying no CBK* family, maps to
+/// `ExitCode::Internal` — reporting a mistyped path as a bug in copybook-rs.
+pub fn file_read_error(role: InputRole, path: &Path, error: &io::Error) -> CoreError {
+    CoreError::new(
+        ErrorCode::CBKF001_FILE_READ_ERROR,
+        format!(
+            "failed to read {} '{}': {error}",
+            role.label(),
+            path.display()
+        ),
+    )
+}
+
+/// Read a user-named file (or stdin for `-`), attributing any failure to the path.
+///
+/// # Errors
+///
+/// Returns [`ErrorCode::CBKF001_FILE_READ_ERROR`] naming the path and the argument
+/// it came from when the file cannot be read.
+pub fn read_input_or_stdin(role: InputRole, path: &Path) -> Result<String, CoreError> {
+    read_file_or_stdin(path).map_err(|error| file_read_error(role, path, &error))
+}
+
 pub fn read_file_or_stdin<P: AsRef<Path>>(path: P) -> io::Result<String> {
     let path = path.as_ref();
 

--- a/crates/copybook-cli/tests/cli_golden_fixtures.rs
+++ b/crates/copybook-cli/tests/cli_golden_fixtures.rs
@@ -386,10 +386,12 @@ fn test_cli_encode_fail_fast() -> TestResult<()> {
         .arg("cp037")
         .arg("--fail-fast");
 
-    // Should fail with detailed error message
-    cmd.assert().failure().stderr(predicate::str::contains(
-        "Encoding failed with 1 error(s) in fail-fast mode",
-    ));
+    // Should fail naming the record and its stable code, and exit 3 (CBKE) rather
+    // than 5 — a bad input record is not an internal error.
+    cmd.assert()
+        .code(3)
+        .stderr(predicate::str::contains("CBKE"))
+        .stderr(predicate::str::contains("record 1"));
 
     Ok(())
 }

--- a/crates/copybook-cli/tests/panic_elimination_tests.rs
+++ b/crates/copybook-cli/tests/panic_elimination_tests.rs
@@ -37,8 +37,10 @@ fn panic_elimination_cli_smoke() -> TestResult<()> {
     let assert = cmd.assert().failure();
     let output = assert.get_output();
     let stderr = String::from_utf8_lossy(&output.stderr);
+    // Match panic markers, not the bare substring "panic": the error now names the
+    // file it could not read, and this test's own temp path contains "panic".
     assert!(
-        !stderr.contains("panic"),
+        !stderr.contains("panicked at") && !stderr.contains("thread 'main' panicked"),
         "panic elimination smoke test observed panic output: {stderr}"
     );
     Ok(())

--- a/crates/copybook-error-reporter/src/lib.rs
+++ b/crates/copybook-error-reporter/src/lib.rs
@@ -362,6 +362,8 @@ impl ErrorReporter {
             | ErrorCode::CBKR101_FIXED_RECORD_ERROR
             | ErrorCode::CBKR201_RDW_READ_ERROR
             | ErrorCode::CBKR202_RDW_WRITE_ERROR
+            // A file the user named cannot be read: nothing downstream can proceed
+            | ErrorCode::CBKF001_FILE_READ_ERROR
             // Iterator/internal state errors are fatal
             | ErrorCode::CBKI001_INVALID_STATE => ErrorSeverity::Fatal,
 

--- a/crates/copybook-error/src/lib.rs
+++ b/crates/copybook-error/src/lib.rs
@@ -247,6 +247,8 @@ pub enum ErrorCode {
     // =============================================================================
     // File/Format Errors (CBKF*) - File structure and format validation
     // =============================================================================
+    /// CBKF001: An input file could not be opened or read
+    CBKF001_FILE_READ_ERROR,
     /// CBKF102: RDW length field references incomplete or oversized payload
     CBKF102_RECORD_LENGTH_INVALID,
     /// CBKF104: RDW appears to be corrupted by ASCII conversion
@@ -336,6 +338,7 @@ impl fmt::Display for ErrorCode {
             ErrorCode::CBKE521_ARRAY_LEN_OOB => "CBKE521_ARRAY_LEN_OOB",
             ErrorCode::CBKE530_SIGN_SEPARATE_ENCODE_ERROR => "CBKE530_SIGN_SEPARATE_ENCODE_ERROR",
             ErrorCode::CBKE531_FLOAT_ENCODE_OVERFLOW => "CBKE531_FLOAT_ENCODE_OVERFLOW",
+            ErrorCode::CBKF001_FILE_READ_ERROR => "CBKF001_FILE_READ_ERROR",
             ErrorCode::CBKF102_RECORD_LENGTH_INVALID => "CBKF102_RECORD_LENGTH_INVALID",
             ErrorCode::CBKF104_RDW_SUSPECT_ASCII => "CBKF104_RDW_SUSPECT_ASCII",
             ErrorCode::CBKF221_RDW_UNDERFLOW => "CBKF221_RDW_UNDERFLOW",
@@ -410,7 +413,8 @@ impl ErrorCode {
             | Self::CBKE521_ARRAY_LEN_OOB
             | Self::CBKE530_SIGN_SEPARATE_ENCODE_ERROR
             | Self::CBKE531_FLOAT_ENCODE_OVERFLOW => "CBKE",
-            Self::CBKF102_RECORD_LENGTH_INVALID
+            Self::CBKF001_FILE_READ_ERROR
+            | Self::CBKF102_RECORD_LENGTH_INVALID
             | Self::CBKF104_RDW_SUSPECT_ASCII
             | Self::CBKF221_RDW_UNDERFLOW => "CBKF",
             Self::CBKA001_BASELINE_ERROR => "CBKA",

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -594,7 +594,7 @@ copybook decode legacy-schema.cpy data.bin --format fixed --strict-comments --ou
 | 1 | CBK? | Unknown/unclassified failure (e.g. unknown `support --check` feature ID) |
 | 2 | CBKD | Data quality failure |
 | 3 | CBKE | Encode/validation failure (including structural parse/schema rejections) |
-| 4 | CBKF | Record format/RDW failure (also `CBKR*` fixed-record and RDW framing errors) |
+| 4 | CBKF | Unreadable input file (`CBKF001`), or record format/RDW failure (also `CBKR*` fixed-record and RDW framing errors) |
 | 5 | CBKI | Internal orchestration error (including panics and otherwise unmapped errors) |
 
 Some subcommands document additional command-specific semantics: `verify` reports 3 for validation errors and 2 for fatal I/O/schema errors; `determinism` reports 0 for deterministic, 2 for drift detected, and 3 for codec/usage errors.

--- a/docs/reference/ERROR_CODES.md
+++ b/docs/reference/ERROR_CODES.md
@@ -898,7 +898,7 @@ Errors in Apache Arrow and Parquet conversion (copybook-arrow integration).
 
 ## Error Code Index
 
-All 64 stable error codes across 10 families:
+All 65 stable error codes across 10 families:
 
 | Code | Category | Severity | Description |
 |------|----------|----------|-------------|

--- a/docs/reference/ERROR_CODES.md
+++ b/docs/reference/ERROR_CODES.md
@@ -645,6 +645,17 @@ Fixed format iterator requires LRECL; set schema.lrecl_fixed or use RecordFormat
 
 Errors in file operations and transfer corruption detection.
 
+#### CBKF001_FILE_READ_ERROR
+**Description**: A file named on the command line could not be opened or read
+**Severity**: Fatal
+**Context**: The path, and which argument it came from (copybook or input file)
+**Resolution**: Check the path, spelling, and read permissions
+
+```
+Error: CBKF001_FILE_READ_ERROR
+failed to read copybook '/nope.cpy': No such file or directory (os error 2)
+```
+
 #### CBKF102_RECORD_LENGTH_INVALID
 **Description**: RDW header length references an incomplete or oversized payload
 **Severity**: Fatal
@@ -946,6 +957,7 @@ All 64 stable error codes across 10 families:
 | CBKE521 | Encode | Fatal | Array length OOB |
 | CBKE530 | Encode | Error | SIGN SEPARATE encode error |
 | CBKE531 | Encode | Error | Float encode overflow (f64 to f32) |
+| CBKF001 | File | Fatal | Input file could not be read |
 | CBKF102 | File | Fatal | RDW length invalid |
 | CBKF104 | File | Warning | RDW suspect ASCII |
 | CBKF221 | File | Fatal | RDW underflow |

--- a/tests/e2e/e2e_cli_exit_codes.rs
+++ b/tests/e2e/e2e_cli_exit_codes.rs
@@ -635,3 +635,63 @@ fn encode_bad_input_data_exits_3_not_internal() {
         "stderr should carry the stable code so the exit mapping is derivable.\nstderr: {stderr}"
     );
 }
+
+// =========================================================================
+// A missing file names the path and exits 4 (CBKF), not 5 (internal)
+// =========================================================================
+
+#[test]
+fn missing_copybook_names_the_file_and_exits_4() {
+    for subcommand in ["inspect", "parse"] {
+        let out = Command::cargo_bin("copybook")
+            .unwrap()
+            .args([subcommand, "/definitely/not/here.cpy"])
+            .output()
+            .expect("failed to run copybook");
+
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert_no_panic(&stderr);
+        assert_eq!(
+            out.status.code(),
+            Some(4),
+            "`{subcommand}` on a missing copybook is a file error (4), not internal (5).\nstderr: {stderr}"
+        );
+        assert!(
+            stderr.contains("CBKF001_FILE_READ_ERROR"),
+            "stderr should carry the stable code.\nstderr: {stderr}"
+        );
+        assert!(
+            stderr.contains("/definitely/not/here.cpy"),
+            "stderr should name the file the user typed.\nstderr: {stderr}"
+        );
+        assert!(
+            stderr.contains("copybook"),
+            "stderr should say which argument the path came from.\nstderr: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn missing_input_data_file_names_the_file_and_exits_4() {
+    let dir = write_temp_file("schema.cpy", VALID_COPYBOOK.as_bytes());
+    let cpy_path = dir.path().join("schema.cpy");
+
+    let out = Command::cargo_bin("copybook")
+        .unwrap()
+        .args(["decode"])
+        .arg(&cpy_path)
+        .arg("/definitely/not/here.bin")
+        .arg("--output")
+        .arg(dir.path().join("out.jsonl"))
+        .args(["--format", "fixed"])
+        .output()
+        .expect("failed to run copybook decode");
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_no_panic(&stderr);
+    assert_eq!(out.status.code(), Some(4), "stderr: {stderr}");
+    assert!(
+        stderr.contains("CBKF001_FILE_READ_ERROR") && stderr.contains("input file"),
+        "a missing data file should be attributed to the input argument.\nstderr: {stderr}"
+    );
+}

--- a/tests/e2e/e2e_cli_exit_codes.rs
+++ b/tests/e2e/e2e_cli_exit_codes.rs
@@ -596,3 +596,42 @@ fn error_paths_do_not_produce_backtraces() {
         "stderr should not contain stack backtrace on normal errors:\n{stderr}"
     );
 }
+
+// =========================================================================
+// `copybook encode` bad input data → exit 3 (CBKE), not 5 (internal)
+// =========================================================================
+
+#[test]
+fn encode_bad_input_data_exits_3_not_internal() {
+    let dir = write_temp_file("schema.cpy", VALID_COPYBOOK.as_bytes());
+    let cpy_path = dir.path().join("schema.cpy");
+
+    // ID-FIELD is PIC 9(6); a bare JSON number is a type mismatch (CBKE501).
+    let jsonl_path = dir.path().join("bad.jsonl");
+    std::fs::write(&jsonl_path, "{\"ID-FIELD\":1,\"NAME-FIELD\":\"HELLO\"}\n")
+        .expect("write jsonl");
+
+    let out = Command::cargo_bin("copybook")
+        .unwrap()
+        .args(["encode"])
+        .arg(&cpy_path)
+        .arg(&jsonl_path)
+        .arg("--output")
+        .arg(dir.path().join("out.bin"))
+        .args(["--format", "fixed", "--codepage", "cp037"])
+        .output()
+        .expect("failed to run copybook encode");
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_no_panic(&stderr);
+    assert_eq!(
+        out.status.code(),
+        Some(3),
+        "a bad input record is an encode error (exit 3), not an internal error (exit 5).\n\
+         stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("CBKE501_JSON_TYPE_MISMATCH"),
+        "stderr should carry the stable code so the exit mapping is derivable.\nstderr: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

Two of the most ordinary things a user can do wrong — mistype a filename, feed a record that will not encode — both exited **5**, which `exit_codes.rs` defines as "Internal orchestration error". The CLI was telling people their own input was a bug in copybook-rs.

```console
$ copybook inspect /nope.cpy
No such file or directory (os error 2)
$ echo $?
5

$ copybook encode cust.cpy rec.jsonl -o out.bin --format fixed
Encoding failed with 1 error(s) in fail-fast mode
$ echo $?
5
```

**One shared cause.** `map_error_to_exit_code` derives the exit code from the `CBK*` family it can find in the error chain, and `parse_prefix_from_str` only inspects the message's **first whitespace-delimited token**:

```rust
fn parse_prefix_from_str(message: &str) -> Option<String> {
    let token = message.split_whitespace().next()?.trim_end_matches(':');
    if token.len() < 4 || !token.starts_with("CBK") { return None; }
    Some(token[..4].to_string())
}
```

A message opening with prose (`"Encoding failed…"`, `"No such file…"`) yields no family, and `map_error_to_exit_code` maps the resulting `Unknown` to `Internal`. Two commits, one per case.

### 1. Encode data errors exit 3

The fail-fast bail now leads with the failing record's stable code, which #704 made available on the summary:

```console
$ copybook encode cust.cpy rec.jsonl -o out.bin --format fixed
CBKE501_JSON_TYPE_MISMATCH: Field 'CUST-ID' expects a zoned decimal string, found number (pass --coerce-numbers to accept JSON numbers here) (record 1)
$ echo $?
3
```

The top-level `--help` already documents "3 encode/schema errors (CBKE)", so this makes behavior match the documented contract rather than changing it.

### 2. Unreadable files name the path and exit 4

New `CBKF001_FILE_READ_ERROR`, with the CLI's file reads routed through a helper that attributes the failure to the argument it came from:

```console
$ copybook inspect /nope.cpy
CBKF001_FILE_READ_ERROR: failed to read copybook '/nope.cpy': No such file or directory (os error 2)
$ echo $?
4

$ copybook decode cust.cpy /nope.bin -o out.jsonl --format fixed
CBKF001_FILE_READ_ERROR: failed to read input file '/nope.bin': No such file or directory (os error 2)
```

Covers `inspect`, `parse`, `decode`, `encode`, and `verify`, for both the copybook and input arguments. `CBKF` is already the file/format family and already maps to exit 4, so no new mapping was needed — but the family's documented meaning widens from record-format to "file read or record format", updated in `--help`, the exit-code table, `CLI_REFERENCE.md`, `ERROR_CODES.md`, and `README.md`.

**Deliberately not changed:** `verify.rs` has a similar prose-leading bail ("Fixed format requires LRECL from schema…") that also lands on exit 5. CLAUDE.md documents fixed-format-without-LRECL as `CBKI001`, so exit 5 is the intended mapping there and I left it alone.

## Type of Change

- [x] Bugfix (fixes an issue)

## COBOL/Mainframe Context

- **COBOL features affected**: none — CLI error reporting only
- **Data processing impact**: exit codes and error messages; no parsing, encode, or decode behavior changes
- **Mainframe compatibility**: unaffected

## Workspace Crates Affected

- [x] copybook-cli (CLI commands and options)
- [x] copybook-error (new `CBKF001_FILE_READ_ERROR`) and copybook-error-reporter (its severity)

## Checklist

- [x] Tests added/updated (or N/A for docs-only changes)
- [x] Documentation updated (`--help`, `CLI_REFERENCE.md`, `ERROR_CODES.md`, `README.md`, `CLAUDE.md`)
- [x] CHANGELOG.md updated (if user-facing change)
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace -- -D warnings -W clippy::pedantic` passes
- [x] `cargo test --workspace` passes
- [x] Follows conventional commit format

## Testing Instructions

```bash
cargo test --workspace
cargo clippy --workspace -- -D warnings -W clippy::pedantic
cargo fmt --all --check
```

New tests assert exit codes and stable codes rather than message text: a bad encode record exits 3 carrying `CBKE501`, and a missing copybook or data file exits 4 carrying `CBKF001`, the path the user typed, and which argument it came from.

### Two existing guards this tripped

Both are reported rather than worked around:

- `readme_exit_code_table_matches_source_of_truth` caught that exit 4's description had widened without `README.md` being updated. The guard did exactly its job; README is updated.
- `panic_elimination_cli_smoke` asserts stderr never contains the substring `"panic"` — and its own temp file is `panic_elimination_smoke_missing.cpy`. Naming the file in the error made the test trip over its own fixture name. It now matches real panic markers (`"panicked at"`, `"thread 'main' panicked"`), as `tests/e2e/e2e_cli_exit_codes.rs` already does. **About fifteen sibling assertions in that file use the same substring check**; they pass today because their paths happen not to contain the word, but they are latently fragile and worth a follow-up.

### One drift correction

`CLAUDE.md` claimed "63 stable codes" while the enum already held **64** before this change. Counted from source and set to 65.

## Performance Impact

- [x] No performance impact expected

Error paths only; no allocation added to any success path.

## Breaking Changes

- [x] Breaking changes with migration path (describe below)

### Migration Guide

Exit codes change for two previously-misreported cases. Any script branching on exit 5 for these needs updating:

```bash
# Before: both exited 5 (internal error)
# After:
copybook inspect missing.cpy   # exit 4  (CBKF001_FILE_READ_ERROR)
copybook encode bad.jsonl ...  # exit 3  (CBKE*)
```

Exit 5 keeps its documented meaning — genuine internal errors — and is now more trustworthy for it. Adding `CBKF001` is additive to the taxonomy; existing codes are unchanged.

## Related Issues

Relates to #535, #552

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qc2wCuoYw6A8d9dFhvZ8PX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics for unreadable copybook and input files, including the affected path and input type.
  * File-read failures now return a consistent error classification and exit code.
  * Encode failures now identify the first failed record and provide clearer error details.
  * Decode and encode operations now report failed records more accurately.

* **Documentation**
  * Updated CLI help, exit-code references, error-code documentation, and changelog entries.
  * Added documentation for the new file-read error and expanded error-code coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->