### PR TITLE
fix(cli): make encode --fail-fast possible to turn off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `undisclosed_failure_count()` reports how many failures were not retained.
 
 ### Fixed
+- **cli**: `encode --fail-fast` can now be turned off. It was declared as a `bool`
+  with `default_value = "true"`, which clap gives `ArgAction::SetTrue` — so the
+  flag was permanently on and no invocation could disable it. Its own error text
+  advised `--fail-fast=false`, a form clap rejects outright, and the lenient
+  branch that reports skipped records was unreachable. Stopping at the first
+  failure remains the default; `--no-fail-fast` encodes the remaining records and
+  lists every failure at the end.
 - **cli**: A file the CLI cannot read now names the file and the argument it came
   from, and exits 4 instead of 5. `copybook inspect /nope.cpy` printed a bare
   `No such file or directory (os error 2)` — no path, no indication whether the

--- a/crates/copybook-cli/src/command_dispatch.rs
+++ b/crates/copybook-cli/src/command_dispatch.rs
@@ -153,6 +153,7 @@ fn run_encode_command(command: Commands) -> CommandOutcome {
         strict,
         max_errors,
         fail_fast,
+        no_fail_fast,
         threads,
         coerce_numbers,
         strict_comments,
@@ -178,7 +179,10 @@ fn run_encode_command(command: Commands) -> CommandOutcome {
                 bwz_encode,
                 strict,
                 max_errors,
-                fail_fast,
+                // Stopping on the first failure is the default, so only `--no-fail-fast`
+                // changes anything. clap rejects the two together, so this cannot be
+                // ambiguous.
+                fail_fast: fail_fast || !no_fail_fast,
                 threads,
                 coerce_numbers,
                 strict_comments,

--- a/crates/copybook-cli/src/main.rs
+++ b/crates/copybook-cli/src/main.rs
@@ -330,9 +330,21 @@ Field Projection:\n\
         /// Maximum errors before stopping
         #[arg(long)]
         max_errors: Option<u64>,
-        /// Stop on first error (default: true)
-        #[arg(long, default_value = "true")]
+        /// Stop on the first record that fails to encode. This is the default;
+        /// pass --no-fail-fast to encode the remaining records instead.
+        #[arg(
+            long,
+            action = clap::ArgAction::SetTrue,
+            conflicts_with = "no_fail_fast"
+        )]
         fail_fast: bool,
+        /// Continue past records that fail to encode, listing them when the run ends
+        #[arg(
+            long = "no-fail-fast",
+            action = clap::ArgAction::SetTrue,
+            conflicts_with = "fail_fast"
+        )]
+        no_fail_fast: bool,
         /// Number of threads for parallel processing
         #[arg(long, default_value = "1")]
         threads: usize,

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -222,7 +222,8 @@ copybook encode <COPYBOOK> <JSONL> [OPTIONS]
 - `--float-format <FORMAT>` - COMP-1/COMP-2 binary format: ieee-be, ibm-hex (default: ieee-be)
 
 **Error Handling:**
-- `--fail-fast` - Stop on first error (default: true)
+- `--fail-fast` - Stop on the first record that fails to encode (default)
+- `--no-fail-fast` - Encode the remaining records and list the failures at the end
 - `--strict` - Enable strict mode validation (default: false for lenient mode)
 - `--max-errors <N>` - Maximum errors before stopping
 

--- a/tests/e2e/e2e_cli_exit_codes.rs
+++ b/tests/e2e/e2e_cli_exit_codes.rs
@@ -695,3 +695,82 @@ fn missing_input_data_file_names_the_file_and_exits_4() {
         "a missing data file should be attributed to the input argument.\nstderr: {stderr}"
     );
 }
+
+// =========================================================================
+// `copybook encode --no-fail-fast` actually continues past failures
+// =========================================================================
+
+/// Three records that all fail to encode: PIC 9(3) cannot hold alphabetic text.
+fn three_bad_encode_records(dir: &std::path::Path) -> std::path::PathBuf {
+    let cpy = dir.join("num.cpy");
+    std::fs::write(&cpy, "       01 REC.\n          05 FLD PIC 9(3).\n").expect("write cpy");
+    let jsonl = dir.join("bad3.jsonl");
+    std::fs::write(
+        &jsonl,
+        "{\"FLD\":\"AAA\"}\n{\"FLD\":\"BBB\"}\n{\"FLD\":\"CCC\"}\n",
+    )
+    .expect("write jsonl");
+    cpy
+}
+
+fn run_encode(
+    dir: &std::path::Path,
+    cpy: &std::path::Path,
+    extra: &[&str],
+) -> std::process::Output {
+    let mut cmd = Command::cargo_bin("copybook").unwrap();
+    cmd.args(["encode"])
+        .arg(cpy)
+        .arg(dir.join("bad3.jsonl"))
+        .arg("--output")
+        .arg(dir.join("out.bin"))
+        .args(["--format", "fixed", "--codepage", "ascii"]);
+    for arg in extra {
+        cmd.arg(arg);
+    }
+    cmd.output().expect("failed to run copybook encode")
+}
+
+#[test]
+fn encode_fail_fast_stops_at_the_first_failure_by_default() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cpy = three_bad_encode_records(dir.path());
+
+    let out = run_encode(dir.path(), &cpy, &[]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_no_panic(&stderr);
+    assert_eq!(out.status.code(), Some(3), "stderr: {stderr}");
+    assert_eq!(
+        stderr.matches("  record ").count(),
+        1,
+        "the default stops at the first failure.\nstderr: {stderr}"
+    );
+}
+
+#[test]
+fn encode_no_fail_fast_reports_every_failure() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cpy = three_bad_encode_records(dir.path());
+
+    let out = run_encode(dir.path(), &cpy, &["--no-fail-fast"]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_no_panic(&stderr);
+    assert_eq!(
+        stderr.matches("  record ").count(),
+        3,
+        "--no-fail-fast must continue past the first failure.\nstderr: {stderr}"
+    );
+}
+
+#[test]
+fn encode_rejects_fail_fast_together_with_no_fail_fast() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cpy = three_bad_encode_records(dir.path());
+
+    let out = run_encode(dir.path(), &cpy, &["--fail-fast", "--no-fail-fast"]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("cannot be used with"),
+        "the two flags must conflict rather than silently picking one.\nstderr: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

`encode --fail-fast` could not be turned off by any invocation.

```rust
/// Stop on first error (default: true)
#[arg(long, default_value = "true")]
fail_fast: bool,
```

clap gives a bare `bool` `ArgAction::SetTrue`, so the value starts `true` and the flag can only set it `true` again. There was no path to `false`.

Two things followed from that, both user-visible:

**The advice it printed could not be followed.** `encode` told users to pass `--fail-fast=false`:

```console
$ copybook encode num.cpy bad.jsonl -o out.bin --format fixed --fail-fast=false
error: unexpected value 'false' for '--fail-fast' found; no more were expected
```

**The lenient reporting branch was dead code.** `commands/encode.rs` guards it on `!options.fail_fast`, which was never true, so "N records failed to encode but were skipped in lenient mode" could not print.

**Fix.** Add `--no-fail-fast`, following the `--strict-policy` / `--no-strict-policy` pair already in this CLI, with `conflicts_with` so passing both is rejected rather than silently resolved. Stopping at the first failure remains the default, so **no existing invocation changes behavior**.

```console
$ copybook encode num.cpy bad3.jsonl -o out.bin --format fixed --codepage ascii --no-fail-fast
  record 1: CBKE501_JSON_TYPE_MISMATCH: Invalid numeric component: 'AAA'
  record 2: CBKE501_JSON_TYPE_MISMATCH: Invalid numeric component: 'BBB'
  record 3: CBKE501_JSON_TYPE_MISMATCH: Invalid numeric component: 'CCC'

WARNING: 3 records failed to encode but were skipped in lenient mode.

$ copybook encode ... --fail-fast --no-fail-fast
error: the argument '--fail-fast' cannot be used with '--no-fail-fast'
```

That warning line is the previously-unreachable branch, now doing its job.

`decode` already had a working `--fail-fast` (`default_value = "false"`, which `SetTrue` handles correctly) and is untouched. The two commands now differ only in their default, which is documented on both.

## Type of Change

- [x] Bugfix (fixes an issue)

## COBOL/Mainframe Context

- **COBOL features affected**: none — CLI argument handling only
- **Data processing impact**: which records an encode run attempts after the first failure; no change to encoded bytes
- **Mainframe compatibility**: unaffected

## Workspace Crates Affected

- [x] copybook-cli (CLI commands and options)

## Checklist

- [x] Tests added/updated (or N/A for docs-only changes)
- [x] Documentation updated (`docs/CLI_REFERENCE.md`, flag help text)
- [x] CHANGELOG.md updated (if user-facing change)
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace -- -D warnings -W clippy::pedantic` passes
- [x] `cargo test --workspace` passes
- [x] Follows conventional commit format

## Testing Instructions

```bash
cargo test --workspace
cargo clippy --workspace -- -D warnings -W clippy::pedantic
cargo fmt --all --check
```

Three new e2e tests pin the behavior that was previously untestable: the default stops at the first failure (one reported record), `--no-fail-fast` continues and reports all three, and the two flags together are rejected. The first of these would have passed before this change; the other two could not have.

Reproducer:

```bash
printf '       01 REC.\n          05 FLD PIC 9(3).\n' > num.cpy
printf '{"FLD":"AAA"}\n{"FLD":"BBB"}\n{"FLD":"CCC"}\n' > bad3.jsonl
copybook encode num.cpy bad3.jsonl -o out.bin --format fixed --codepage ascii --no-fail-fast
```

## Performance Impact

- [x] No performance impact expected

Argument parsing only.

## Breaking Changes

- [x] No breaking changes

`--fail-fast` keeps its meaning and its default. The new `--no-fail-fast` is purely additive, and reaches a code path that previously could not execute.

## Related Issues

Relates to #535, #552

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qc2wCuoYw6A8d9dFhvZ8PX)_