### PR TITLE
refactor(codec): own runtime memory support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,7 +866,6 @@ dependencies = [
  "base64",
  "blake3",
  "copybook-charset",
- "copybook-codec-memory",
  "copybook-core",
  "copybook-corruption",
  "copybook-determinism",
@@ -875,7 +874,9 @@ dependencies = [
  "copybook-options",
  "copybook-overpunch",
  "copybook-rdw",
+ "copybook-sequence-ring",
  "copybook-zoned-format",
+ "crossbeam-channel",
  "hex",
  "indexmap",
  "metrics",
@@ -884,6 +885,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "smallvec",
  "tempfile",
  "thiserror",
  "tracing",
@@ -894,10 +896,8 @@ name = "copybook-codec-memory"
 version = "0.5.0"
 dependencies = [
  "anyhow",
+ "copybook-codec",
  "copybook-sequence-ring",
- "crossbeam-channel",
- "smallvec",
- "tracing",
 ]
 
 [[package]]
@@ -1123,7 +1123,6 @@ dependencies = [
  "anyhow",
  "copybook-charset",
  "copybook-codec",
- "copybook-codec-memory",
  "copybook-contracts",
  "copybook-core",
  "copybook-corruption",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Rust toolkit for COBOL copybook parsing and fixed-record data conversion. Determ
 Engineering Preview (v0.5.0). Stable CLI and library APIs; feature completeness is preview-level. See [ROADMAP.md](docs/ROADMAP.md) for adoption guidance and known limitations.
 
 <!-- TEST_STATUS:BEGIN -->
-**conformance:** 9915/9915  • **roundtrip:** N/A  • **negative:** N/A  • **skipped:** 0  • **leaks:** 0<br>
+**conformance:** 9916/9916  • **roundtrip:** N/A  • **negative:** N/A  • **skipped:** 0  • **leaks:** 0<br>
 _Source: CI receipts (nextest/junit). This block is updated automatically._
 <!-- TEST_STATUS:END -->
 

--- a/crates/copybook-codec-memory/Cargo.toml
+++ b/crates/copybook-codec-memory/Cargo.toml
@@ -20,10 +20,8 @@ all-features = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-crossbeam-channel.workspace = true
+copybook-codec.workspace = true
 copybook-sequence-ring.workspace = true
-smallvec.workspace = true
-tracing.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/crates/copybook-codec-memory/README.md
+++ b/crates/copybook-codec-memory/README.md
@@ -1,10 +1,11 @@
 # copybook-codec-memory
 
-Core memory management utilities for `copybook-codec`, extracted as a dedicated crate.
+Backward-compatible facade for the runtime utilities owned by `copybook-codec`.
 
 ## Overview
 
-Provides performance-critical memory patterns for high-throughput COBOL data processing:
+The canonical `copybook_codec::runtime` module provides performance-critical memory patterns
+for high-throughput COBOL data processing:
 reusable scratch buffers to eliminate hot-path allocations, a deterministic worker pool for
 parallel record processing, and a streaming processor that enforces bounded memory usage
 (<256 MiB) for multi-GB files.
@@ -12,7 +13,10 @@ parallel record processing, and a streaming processor that enforces bounded memo
 ## Usage
 
 ```rust
-use copybook_codec_memory::ScratchBuffers;
+use copybook_codec::runtime::ScratchBuffers;
+
+// The 0.5 path remains valid through this compatibility facade:
+// use copybook_codec_memory::ScratchBuffers;
 
 // Reuse buffers across records to avoid allocation
 let mut scratch = ScratchBuffers::new();

--- a/crates/copybook-codec-memory/src/lib.rs
+++ b/crates/copybook-codec-memory/src/lib.rs
@@ -1,112 +1,13 @@
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // SPDX-License-Identifier: AGPL-3.0-or-later
-//! Memory management utilities for streaming record processing
+//! Backward-compatible facade for codec-owned runtime support.
 //!
-//! This module provides bounded memory usage patterns, reusable scratch buffers,
-//! and ordered parallel processing with sequence tracking.
-//!
-//! # Overview
-//!
-//! The memory module implements performance-critical memory management patterns
-//! for high-throughput COBOL data processing. It provides three key capabilities:
-//!
-//! 1. **Scratch buffer reuse** ([`ScratchBuffers`]) - Eliminate allocations in hot paths
-//! 2. **Deterministic parallel processing** ([`WorkerPool`], [`SequenceRing`]) - Maintain record order
-//! 3. **Bounded memory usage** ([`StreamingProcessor`]) - Process multi-GB files with <256 MiB RAM
-//!
-//! # Performance Impact
-//!
-//! These utilities enable copybook-rs to achieve:
-//! - **205 MiB/s** throughput on DISPLAY-heavy workloads (baseline: 2025-09-30)
-//! - **58 MiB/s** throughput on COMP-3-heavy workloads
-//! - **<256 MiB** steady-state memory for multi-GB file processing
-//! - **Deterministic output** with parallel processing (1-8+ worker threads)
-//!
-//! # Examples
-//!
-//! ## Basic Scratch Buffer Usage
-//!
-//! ```rust
-//! use copybook_codec_memory::ScratchBuffers;
-//!
-//! let mut scratch = ScratchBuffers::new();
-//!
-//! // Use buffers for processing
-//! scratch.digit_buffer.push(5);
-//! scratch.byte_buffer.extend_from_slice(b"data");
-//! scratch.string_buffer.push_str("text");
-//!
-//! // Clear for reuse (no deallocation)
-//! scratch.clear();
-//! ```
-//!
-//! ## Parallel Processing with Deterministic Output
-//!
-//! ```rust
-//! use copybook_codec_memory::{WorkerPool, ScratchBuffers};
-//!
-//! // Create worker pool with 4 threads
-//! let mut pool = WorkerPool::new(
-//!     4,   // num_workers
-//!     100, // channel_capacity
-//!     50,  // max_window_size
-//!     |input: Vec<u8>, _scratch: &mut ScratchBuffers| -> String {
-//!         // Process input (runs in parallel)
-//!         String::from_utf8_lossy(&input).to_string()
-//!     },
-//! );
-//!
-//! // Collect chunks so we know the count
-//! let chunks: Vec<Vec<u8>> = get_data_chunks();
-//! let num_chunks = chunks.len();
-//!
-//! // Submit work
-//! for chunk in chunks {
-//!     pool.submit(chunk).unwrap();
-//! }
-//!
-//! // Receive exactly num_chunks results in order (non-blocking pattern)
-//! for _ in 0..num_chunks {
-//!     let result = pool.recv_ordered().unwrap().unwrap();
-//!     println!("{}", result);
-//! }
-//!
-//! pool.shutdown().unwrap();
-//! # fn get_data_chunks() -> Vec<Vec<u8>> { vec![vec![1, 2, 3]] }
-//! ```
-//!
-//! ## Memory-Bounded Streaming
-//!
-//! ```rust
-//! use copybook_codec_memory::StreamingProcessor;
-//! # let records: Vec<Vec<u8>> = vec![vec![1, 2, 3]];
-//!
-//! let mut processor = StreamingProcessor::with_default_limit(); // 256 MiB
-//!
-//! for record in records {
-//!     // Check memory pressure before processing
-//!     if processor.is_memory_pressure() {
-//!         // Flush buffers or throttle input
-//!     }
-//!
-//!     // Track memory usage
-//!     processor.update_memory_usage(record.len() as isize);
-//!     processor.record_processed(record.len());
-//! }
-//!
-//! // Get statistics
-//! let stats = processor.stats();
-//! println!("Processed {} records", stats.records_processed);
-//! ```
+//! The canonical implementation now lives in [`copybook_codec::runtime`].
+//! This package remains available for consumers migrating from the 0.5 package
+//! layout and continues to forward the stable memory/worker API.
 
-mod scratch;
-mod streaming;
-mod worker_pool;
-
-#[cfg(test)]
-mod tests;
-
+pub use copybook_codec::runtime::{
+    DigitBuffer, ScratchBuffers, StreamingProcessor, StreamingProcessorStats, WorkerPool,
+    WorkerPoolStats,
+};
 pub use copybook_sequence_ring::{SequenceRing, SequenceRingStats, SequencedRecord};
-pub use scratch::{DigitBuffer, ScratchBuffers};
-pub use streaming::{StreamingProcessor, StreamingProcessorStats};
-pub use worker_pool::{WorkerPool, WorkerPoolStats};

--- a/crates/copybook-codec/Cargo.toml
+++ b/crates/copybook-codec/Cargo.toml
@@ -37,7 +37,9 @@ tracing.workspace = true
 base64.workspace = true
 sha2.workspace = true
 blake3.workspace = true
-copybook-codec-memory.workspace = true
+copybook-sequence-ring.workspace = true
+crossbeam-channel.workspace = true
+smallvec.workspace = true
 indexmap.workspace = true
 metrics = { workspace = true, optional = true }
 

--- a/crates/copybook-codec/README.md
+++ b/crates/copybook-codec/README.md
@@ -44,7 +44,10 @@ println!("{json}");
 ```rust
 use copybook_core::parse_copybook;
 use copybook_codec::{decode_record_with_scratch, DecodeOptions, Codepage, JsonNumberMode};
-use copybook_codec::memory::ScratchBuffers;
+use copybook_codec::runtime::ScratchBuffers;
+
+// The pre-0.6 path remains available as a compatibility alias:
+// use copybook_codec::memory::ScratchBuffers;
 
 let schema = parse_copybook("01 A.\n   05 AMOUNT PIC S9(7)V99 COMP-3.\n")?;
 let options = DecodeOptions::new()

--- a/crates/copybook-codec/examples/scratch_buffers.rs
+++ b/crates/copybook-codec/examples/scratch_buffers.rs
@@ -9,7 +9,7 @@
 // ScratchBuffers usage example
 // Demonstrates zero-allocation decoding with reusable scratch buffers
 
-use copybook_codec::memory::ScratchBuffers;
+use copybook_codec::runtime::ScratchBuffers;
 use copybook_codec::{Codepage, DecodeOptions, RecordFormat, decode_record_with_scratch};
 use copybook_core::parse_copybook;
 

--- a/crates/copybook-codec/examples/sequence_ring.rs
+++ b/crates/copybook-codec/examples/sequence_ring.rs
@@ -9,7 +9,7 @@
 // SequenceRing usage example
 // Demonstrates ordered emission for parallel processing
 
-use copybook_codec::memory::{SequenceRing, SequencedRecord};
+use copybook_codec::runtime::{SequenceRing, SequencedRecord};
 use std::thread;
 use std::time::Duration;
 

--- a/crates/copybook-codec/examples/worker_pool.rs
+++ b/crates/copybook-codec/examples/worker_pool.rs
@@ -9,7 +9,7 @@
 // WorkerPool usage example
 // Demonstrates parallel record processing with deterministic output ordering
 
-use copybook_codec::memory::{ScratchBuffers, WorkerPool};
+use copybook_codec::runtime::{ScratchBuffers, WorkerPool};
 use copybook_codec::{Codepage, DecodeOptions, RecordFormat, decode_record_with_scratch};
 use copybook_core::parse_copybook;
 use std::sync::Arc;

--- a/crates/copybook-codec/src/lib.rs
+++ b/crates/copybook-codec/src/lib.rs
@@ -26,8 +26,10 @@ pub mod file;
 pub mod iterator;
 /// Core library API: record decode/encode and file-level processing.
 pub mod lib_api;
-/// Re-export of [`copybook_codec_memory`] for scratch buffers and streaming.
-pub use copybook_codec_memory as memory;
+/// Codec-owned runtime support for scratch buffers, streaming, and workers.
+pub mod runtime;
+/// Compatibility alias for the pre-0.6 memory module path.
+pub use runtime as memory;
 /// Numeric field decoding and encoding (zoned decimal, packed decimal, binary).
 pub mod numeric;
 /// Configuration types: codepage, record format, JSON modes, raw capture.

--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -63,7 +63,7 @@ pub fn decode_record(schema: &Schema, data: &[u8], options: &DecodeOptions) -> R
 /// ```
 /// use copybook_core::parse_copybook;
 /// use copybook_codec::{decode_record_with_scratch, DecodeOptions};
-/// use copybook_codec::memory::ScratchBuffers;
+/// use copybook_codec::runtime::ScratchBuffers;
 /// use copybook_codec::options::{Codepage, RecordFormat};
 ///
 /// let schema = parse_copybook("01 FLD PIC X(5).").unwrap();

--- a/crates/copybook-codec/src/numeric.rs
+++ b/crates/copybook-codec/src/numeric.rs
@@ -2339,7 +2339,7 @@ fn zoned_ensure_unsigned(
 ///
 /// ```no_run
 /// use copybook_codec::numeric::{decode_zoned_decimal_with_scratch};
-/// use copybook_codec::memory::ScratchBuffers;
+/// use copybook_codec::runtime::ScratchBuffers;
 /// use copybook_codec::options::Codepage;
 ///
 /// let mut scratch = ScratchBuffers::new();
@@ -2353,7 +2353,7 @@ fn zoned_ensure_unsigned(
 ///
 /// ```no_run
 /// use copybook_codec::numeric::{decode_zoned_decimal_with_scratch};
-/// use copybook_codec::memory::ScratchBuffers;
+/// use copybook_codec::runtime::ScratchBuffers;
 /// use copybook_codec::options::Codepage;
 ///
 /// let mut scratch = ScratchBuffers::new();
@@ -2365,7 +2365,7 @@ fn zoned_ensure_unsigned(
 ///
 /// # See Also
 /// * [`decode_zoned_decimal`] - For basic zoned decimal decoding
-/// * [`ScratchBuffers`] - For scratch buffer management
+/// * [`crate::runtime::ScratchBuffers`] - For scratch buffer management
 #[inline]
 #[must_use = "Handle the Result or propagate the error"]
 pub fn decode_zoned_decimal_with_scratch(

--- a/crates/copybook-codec/src/runtime/mod.rs
+++ b/crates/copybook-codec/src/runtime/mod.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Codec-owned runtime support for bounded, reusable record processing.
+//!
+//! The runtime family owns scratch buffers, streaming accounting, and worker
+//! coordination. Sequence ordering remains a separate compatibility dependency
+//! until issue #654 Slice C moves that implementation into this module family.
+
+mod scratch;
+mod streaming;
+mod worker_pool;
+
+#[cfg(test)]
+mod tests;
+
+pub use scratch::{DigitBuffer, ScratchBuffers};
+pub use streaming::{StreamingProcessor, StreamingProcessorStats};
+pub use worker_pool::{WorkerPool, WorkerPoolStats};
+// Sequence ordering remains externally implemented until issue #654 Slice C.
+pub use copybook_sequence_ring::{SequenceRing, SequenceRingStats, SequencedRecord};

--- a/crates/copybook-codec/src/runtime/scratch.rs
+++ b/crates/copybook-codec/src/runtime/scratch.rs
@@ -40,7 +40,7 @@ pub type DigitBuffer = SmallVec<[u8; 32]>;
 /// ## Basic Usage
 ///
 /// ```rust
-/// use copybook_codec_memory::ScratchBuffers;
+/// use copybook_codec::runtime::ScratchBuffers;
 ///
 /// let mut scratch = ScratchBuffers::new();
 ///
@@ -59,7 +59,7 @@ pub type DigitBuffer = SmallVec<[u8; 32]>;
 /// ## Integration with Codec Functions
 ///
 /// ```ignore
-/// use copybook_codec_memory::ScratchBuffers;
+/// use copybook_codec::runtime::ScratchBuffers;
 /// use copybook_codec::{decode_record_with_scratch, DecodeOptions};
 /// use copybook_core::parse_copybook;
 ///
@@ -80,7 +80,7 @@ pub type DigitBuffer = SmallVec<[u8; 32]>;
 /// ## Capacity Management
 ///
 /// ```rust
-/// use copybook_codec_memory::ScratchBuffers;
+/// use copybook_codec::runtime::ScratchBuffers;
 ///
 /// let mut scratch = ScratchBuffers::new();
 ///
@@ -125,7 +125,7 @@ impl ScratchBuffers {
     /// # Examples
     ///
     /// ```rust
-    /// use copybook_codec_memory::ScratchBuffers;
+    /// use copybook_codec::runtime::ScratchBuffers;
     ///
     /// let scratch = ScratchBuffers::new();
     /// assert_eq!(scratch.digit_buffer.len(), 0);
@@ -153,7 +153,7 @@ impl ScratchBuffers {
     /// # Examples
     ///
     /// ```rust
-    /// use copybook_codec_memory::ScratchBuffers;
+    /// use copybook_codec::runtime::ScratchBuffers;
     ///
     /// let mut scratch = ScratchBuffers::new();
     ///
@@ -193,7 +193,7 @@ impl ScratchBuffers {
     /// # Examples
     ///
     /// ```rust
-    /// use copybook_codec_memory::ScratchBuffers;
+    /// use copybook_codec::runtime::ScratchBuffers;
     ///
     /// let mut scratch = ScratchBuffers::new();
     ///
@@ -228,7 +228,7 @@ impl ScratchBuffers {
     /// # Examples
     ///
     /// ```rust
-    /// use copybook_codec_memory::ScratchBuffers;
+    /// use copybook_codec::runtime::ScratchBuffers;
     ///
     /// let mut scratch = ScratchBuffers::new();
     ///

--- a/crates/copybook-codec/src/runtime/streaming.rs
+++ b/crates/copybook-codec/src/runtime/streaming.rs
@@ -35,7 +35,7 @@
 /// ## Basic Streaming with Memory Bounds
 ///
 /// ```rust
-/// use copybook_codec_memory::StreamingProcessor;
+/// use copybook_codec::runtime::StreamingProcessor;
 ///
 /// let mut processor = StreamingProcessor::with_default_limit(); // 256 MiB
 ///
@@ -71,7 +71,7 @@
 /// ## File Processing with Adaptive Batching
 ///
 /// ```rust
-/// use copybook_codec_memory::StreamingProcessor;
+/// use copybook_codec::runtime::StreamingProcessor;
 ///
 /// let mut processor = StreamingProcessor::new(512); // 512 MiB limit
 /// let mut batch = Vec::new();
@@ -130,7 +130,7 @@ impl StreamingProcessor {
     /// # Examples
     ///
     /// ```rust
-    /// use copybook_codec_memory::StreamingProcessor;
+    /// use copybook_codec::runtime::StreamingProcessor;
     ///
     /// let processor = StreamingProcessor::new(512); // 512 MiB limit
     /// assert!(!processor.is_memory_pressure());
@@ -154,7 +154,7 @@ impl StreamingProcessor {
     /// # Examples
     ///
     /// ```rust
-    /// use copybook_codec_memory::StreamingProcessor;
+    /// use copybook_codec::runtime::StreamingProcessor;
     ///
     /// let processor = StreamingProcessor::with_default_limit();
     /// let stats = processor.stats();
@@ -175,7 +175,7 @@ impl StreamingProcessor {
     /// # Examples
     ///
     /// ```rust
-    /// use copybook_codec_memory::StreamingProcessor;
+    /// use copybook_codec::runtime::StreamingProcessor;
     ///
     /// let mut processor = StreamingProcessor::new(1); // 1 MiB limit
     ///
@@ -206,7 +206,7 @@ impl StreamingProcessor {
     /// # Examples
     ///
     /// ```rust
-    /// use copybook_codec_memory::StreamingProcessor;
+    /// use copybook_codec::runtime::StreamingProcessor;
     ///
     /// let mut processor = StreamingProcessor::new(256);
     ///
@@ -244,7 +244,7 @@ impl StreamingProcessor {
     /// # Examples
     ///
     /// ```rust
-    /// use copybook_codec_memory::StreamingProcessor;
+    /// use copybook_codec::runtime::StreamingProcessor;
     ///
     /// let mut processor = StreamingProcessor::with_default_limit();
     ///
@@ -269,7 +269,7 @@ impl StreamingProcessor {
     /// # Examples
     ///
     /// ```rust
-    /// use copybook_codec_memory::StreamingProcessor;
+    /// use copybook_codec::runtime::StreamingProcessor;
     ///
     /// let mut processor = StreamingProcessor::new(100); // 100 MiB
     /// processor.update_memory_usage(50 * 1024 * 1024); // 50 MiB

--- a/crates/copybook-codec/src/runtime/tests.rs
+++ b/crates/copybook-codec/src/runtime/tests.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 use super::*;
 use anyhow::{Context, Result, anyhow};
+use copybook_sequence_ring::{SequenceRing, SequencedRecord};
 use std::fmt::Write;
 use std::time::Duration;
 

--- a/crates/copybook-codec/src/runtime/worker_pool.rs
+++ b/crates/copybook-codec/src/runtime/worker_pool.rs
@@ -40,7 +40,7 @@ use super::ScratchBuffers;
 /// ## Basic Usage
 ///
 /// ```rust
-/// use copybook_codec_memory::{WorkerPool, ScratchBuffers};
+/// use copybook_codec::runtime::{WorkerPool, ScratchBuffers};
 ///
 /// let mut pool = WorkerPool::new(
 ///     4,   // 4 worker threads
@@ -68,7 +68,7 @@ use super::ScratchBuffers;
 /// ## COBOL Record Processing
 ///
 /// ```ignore
-/// use copybook_codec_memory::{WorkerPool, ScratchBuffers};
+/// use copybook_codec::runtime::{WorkerPool, ScratchBuffers};
 /// use copybook_codec::{decode_record_with_scratch, DecodeOptions};
 /// use copybook_core::{parse_copybook, Schema};
 /// use std::sync::Arc;

--- a/crates/copybook-codec/tests/codec_roundtrip_exhaustive.rs
+++ b/crates/copybook-codec/tests/codec_roundtrip_exhaustive.rs
@@ -453,7 +453,7 @@ fn roundtrip_scratch_buffer_equivalence() {
 
     let without_scratch = copybook_codec::decode_record(&schema, &data, &opts).unwrap();
 
-    let mut scratch = copybook_codec::memory::ScratchBuffers::new();
+    let mut scratch = copybook_codec::runtime::ScratchBuffers::new();
     let with_scratch =
         copybook_codec::decode_record_with_scratch(&schema, &data, &opts, &mut scratch).unwrap();
 

--- a/crates/copybook-codec/tests/runtime_compatibility.rs
+++ b/crates/copybook-codec/tests/runtime_compatibility.rs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Compatibility coverage for the pre-0.6 `copybook_codec::memory` path.
+
+use copybook_codec::memory::{ScratchBuffers, SequenceRing, SequencedRecord, WorkerPool};
+
+#[test]
+fn memory_alias_forwards_runtime_types() {
+    let mut scratch = ScratchBuffers::new();
+    scratch.byte_buffer.extend_from_slice(b"runtime");
+    assert_eq!(scratch.byte_buffer, b"runtime");
+
+    let mut ring = SequenceRing::new(2, 1);
+    ring.sender()
+        .send(SequencedRecord::new(1, 7))
+        .expect("compatibility ring send");
+    assert_eq!(
+        ring.recv_ordered().expect("compatibility ring receive"),
+        Some(7)
+    );
+
+    let mut pool = WorkerPool::new(1, 2, 1, |value: u8, _| value + 1);
+    pool.submit(41).expect("compatibility worker submit");
+    assert_eq!(
+        pool.recv_ordered().expect("compatibility worker receive"),
+        Some(42)
+    );
+    pool.shutdown().expect("compatibility worker shutdown");
+}

--- a/crates/copybook-codec/tests/scratch_decode_integration.rs
+++ b/crates/copybook-codec/tests/scratch_decode_integration.rs
@@ -5,7 +5,7 @@
 //! identical output to `decode_record` and that scratch buffers are properly
 //! reused across calls.
 
-use copybook_codec::memory::ScratchBuffers;
+use copybook_codec::runtime::ScratchBuffers;
 use copybook_codec::{
     Codepage, DecodeOptions, JsonNumberMode, RawMode, RecordFormat, UnmappablePolicy,
     ZonedEncodingFormat, decode_record, decode_record_with_scratch,

--- a/crates/copybook-codec/tests/streaming_large_file.rs
+++ b/crates/copybook-codec/tests/streaming_large_file.rs
@@ -7,7 +7,7 @@
 //! content correctness, scratch buffer integration, and streaming
 //! processor patterns with the codec APIs.
 
-use copybook_codec::memory::{ScratchBuffers, StreamingProcessor};
+use copybook_codec::runtime::{ScratchBuffers, StreamingProcessor};
 use copybook_codec::{
     Codepage, DecodeOptions, EncodeOptions, JsonNumberMode, RecordFormat, decode_file_to_jsonl,
     decode_record, decode_record_with_scratch, encode_jsonl_to_file, iter_records,

--- a/docs/REPORT.md
+++ b/docs/REPORT.md
@@ -55,7 +55,7 @@ responsibilities:
 ### Test Coverage
 
 <!-- TEST_STATUS:BEGIN -->
-**conformance:** 9915/9915  • **roundtrip:** N/A  • **negative:** N/A  • **skipped:** 0  • **leaks:** 0<br>
+**conformance:** 9916/9916  • **roundtrip:** N/A  • **negative:** N/A  • **skipped:** 0  • **leaks:** 0<br>
 _Source: CI receipts (nextest/junit). This block is updated automatically._
 <!-- TEST_STATUS:END -->
 

--- a/docs/architecture/package-boundary-debt.json
+++ b/docs/architecture/package-boundary-debt.json
@@ -34,16 +34,16 @@
       "owner_issue": 655
     },
     {
-      "id": "primary-dep:copybook-codec->copybook-codec-memory",
-      "owner_issue": 654
-    },
-    {
       "id": "primary-dep:copybook-codec->copybook-corruption",
       "owner_issue": 655
     },
     {
       "id": "primary-dep:copybook-codec->copybook-overpunch",
       "owner_issue": 653
+    },
+    {
+      "id": "primary-dep:copybook-codec->copybook-sequence-ring",
+      "owner_issue": 654
     },
     {
       "id": "primary-dep:copybook-codec->copybook-zoned-format",

--- a/docs/reference/LIBRARY_API.md
+++ b/docs/reference/LIBRARY_API.md
@@ -505,7 +505,7 @@ safe_ops::safe_write_str(&mut json_buffer, ",\n")?;
 copybook-rs provides enterprise-grade encoding/decoding with comprehensive panic-safe operations:
 
 ```rust
-use copybook_codec::{decode_record_with_scratch, memory::ScratchBuffers};
+use copybook_codec::{decode_record_with_scratch, runtime::ScratchBuffers};
 
 // High-performance decoding with scratch buffer optimization
 let mut scratch = ScratchBuffers::new();
@@ -1077,7 +1077,7 @@ let handles: Vec<_> = (0..num_threads).map(|i| {
     
     thread::spawn(move || {
         // Use decode_record_with_scratch for per-thread decode with reused buffers
-        let mut scratch = copybook_codec::memory::ScratchBuffers::new();
+        let mut scratch = copybook_codec::runtime::ScratchBuffers::new();
         // Process chunk of data: decode_record_with_scratch(&schema, data, &opts, &mut scratch)
         let _ = (schema, opts, scratch);
         Ok(())
@@ -1168,7 +1168,7 @@ fn streaming_decode(
 
 ```rust
 // Reuse scratch buffers for better performance across many records
-use copybook_codec::{decode_record_with_scratch, memory::ScratchBuffers};
+use copybook_codec::{decode_record_with_scratch, runtime::ScratchBuffers};
 
 let mut scratch = ScratchBuffers::new();
 

--- a/examples/kafka_pipeline/Cargo.lock
+++ b/examples/kafka_pipeline/Cargo.lock
@@ -111,29 +111,21 @@ dependencies = [
  "base64",
  "blake3",
  "copybook-charset",
- "copybook-codec-memory",
  "copybook-core",
  "copybook-corruption",
  "copybook-error",
  "copybook-fixed",
  "copybook-overpunch",
  "copybook-rdw",
+ "copybook-sequence-ring",
  "copybook-zoned-format",
+ "crossbeam-channel",
  "indexmap",
  "serde",
  "serde_json",
  "sha2",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "copybook-codec-memory"
-version = "0.5.0"
-dependencies = [
- "copybook-sequence-ring",
- "crossbeam-channel",
  "smallvec",
+ "thiserror",
  "tracing",
 ]
 

--- a/examples/kafka_streaming/Cargo.lock
+++ b/examples/kafka_streaming/Cargo.lock
@@ -111,29 +111,21 @@ dependencies = [
  "base64",
  "blake3",
  "copybook-charset",
- "copybook-codec-memory",
  "copybook-core",
  "copybook-corruption",
  "copybook-error",
  "copybook-fixed",
  "copybook-overpunch",
  "copybook-rdw",
+ "copybook-sequence-ring",
  "copybook-zoned-format",
+ "crossbeam-channel",
  "indexmap",
  "serde",
  "serde_json",
  "sha2",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "copybook-codec-memory"
-version = "0.5.0"
-dependencies = [
- "copybook-sequence-ring",
- "crossbeam-channel",
  "smallvec",
+ "thiserror",
  "tracing",
 ]
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -98,29 +98,21 @@ dependencies = [
  "base64",
  "blake3",
  "copybook-charset",
- "copybook-codec-memory",
  "copybook-core",
  "copybook-corruption",
  "copybook-error",
  "copybook-fixed",
  "copybook-overpunch",
  "copybook-rdw",
+ "copybook-sequence-ring",
  "copybook-zoned-format",
+ "crossbeam-channel",
  "indexmap",
  "serde",
  "serde_json",
  "sha2",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "copybook-codec-memory"
-version = "0.5.0"
-dependencies = [
- "copybook-sequence-ring",
- "crossbeam-channel",
  "smallvec",
+ "thiserror",
  "tracing",
 ]
 

--- a/tests/proptest/Cargo.toml
+++ b/tests/proptest/Cargo.toml
@@ -40,7 +40,6 @@ copybook-support-matrix.workspace = true
 copybook-overflow.workspace = true
 copybook-overpunch.workspace = true
 copybook-charset.workspace = true
-copybook-codec-memory.workspace = true
 copybook-fixed.workspace = true
 copybook-rdw.workspace = true
 copybook-record-io.workspace = true


### PR DESCRIPTION
## Summary

Issue #654 Slice B: move codec runtime memory/worker support into the codec-owned `copybook_codec::runtime` module family while preserving the 0.5 compatibility surface.

Review map = reading order, not file inventory:

1. `crates/copybook-codec/src/runtime/` — canonical ownership for scratch buffers, streaming accounting, worker coordination, and their tests.
2. `crates/copybook-codec/src/lib.rs` and `crates/copybook-codec/tests/runtime_compatibility.rs` — public runtime surface plus the `copybook_codec::memory` compatibility alias.
3. `crates/copybook-codec-memory/` — published-package compatibility facade forwarding to the canonical implementation.
4. lockfiles, architecture debt, docs, examples, and consumers — dependency/source-truth convergence.

The existing allocation reuse, bounded streaming accounting, worker ordering, and shutdown behavior are preserved. Sequence-ring implementation remains external and is intentionally out of scope for Slice C.

## Verification

| Proof | Result |
| --- | --- |
| `cargo check --offline -p copybook-codec -p copybook-codec-memory` | pass |
| `cargo test --offline -p copybook-codec-memory` | 79 passed |
| `cargo test --offline -p copybook-codec --test runtime_compatibility` | 1 passed |
| `cargo test --offline -p copybook-codec --lib runtime` | 26 passed |
| `cargo test --offline -p copybook-proptest determinism --quiet` | 24 + 24 passed |
| CI-profile workspace nextest, serialized build | 9,916 passed, 6 skipped |
| fmt, clippy, docs, architecture, docs verification, locked metadata | pass |
| standalone example/fuzz locked metadata | pass |

## Scope boundary

This PR delivers only issue #654 Slice B. Slice C will own sequence ordering in `copybook_codec::runtime::sequence_ring` after this dependency boundary is reviewed.
