### PR TITLE
test(e2e): prove CLI RDW raw frames

### DIFF
--- a/tests/e2e/e2e_cli_decode_flags.rs
+++ b/tests/e2e/e2e_cli_decode_flags.rs
@@ -22,6 +22,8 @@ const SIMPLE_CPY: &str = "\
            05  AMOUNT   PIC 9(5).
 ";
 
+const RDW_CPY: &str = "01 FIELD PIC X(5).\n";
+
 /// Build ASCII record: 10 bytes name + 5 bytes amount = 15 bytes.
 fn make_ascii_record(name: &str, amount: &str) -> Vec<u8> {
     let mut rec = vec![b' '; 15];
@@ -164,6 +166,66 @@ fn decode_emit_raw_record_includes_base64() {
         decoded, record,
         "Decoded raw bytes should match input record"
     );
+}
+
+#[test]
+fn decode_rdw_record_raw_cli_preserves_physical_frames() {
+    let rdw_data = [
+        [0x00, 0x05, 0x00, 0x00, b'A', b'B', b'C', b'D', b'E'],
+        [0x00, 0x05, 0x12, 0x34, b'F', b'G', b'H', b'I', b'J'],
+    ]
+    .concat();
+    let (dir, cpy, data) = setup(RDW_CPY, &rdw_data);
+    let out = dir.path().join("out.jsonl");
+
+    cmd()
+        .args([
+            "decode",
+            "--format",
+            "rdw",
+            "--codepage",
+            "ascii",
+            "--emit-meta",
+            "--emit-raw",
+            "record+rdw",
+            "--threads",
+            "4",
+            "--output",
+        ])
+        .arg(&out)
+        .arg(&cpy)
+        .arg(&data)
+        .assert()
+        .success();
+
+    use base64::Engine;
+    let lines: Vec<Value> = std::fs::read_to_string(&out)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(lines.len(), 2);
+
+    let expected_raw = [
+        vec![0x00, 0x05, 0x00, 0x00, b'A', b'B', b'C', b'D', b'E'],
+        vec![0x00, 0x05, 0x12, 0x34, b'F', b'G', b'H', b'I', b'J'],
+    ];
+    for (index, line) in lines.iter().enumerate() {
+        assert!(line.get("raw_b64").is_some());
+        assert!(line.get("__raw_b64").is_some());
+        assert_eq!(line["length"], 5);
+        assert_eq!(line["__length"], 5);
+        assert_eq!(line["record_index"], index + 1);
+        assert_eq!(line["__record_index"], index + 1);
+        let raw = base64::engine::general_purpose::STANDARD
+            .decode(line["raw_b64"].as_str().unwrap())
+            .unwrap();
+        assert_eq!(raw, expected_raw[index]);
+        let compatibility_raw = base64::engine::general_purpose::STANDARD
+            .decode(line["__raw_b64"].as_str().unwrap())
+            .unwrap();
+        assert_eq!(compatibility_raw, raw);
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Add a focused CLI regression test for the remaining #652/#572 command-path evidence: RDW decoding with threaded execution, `record+rdw` raw capture, metadata, and compatibility keys.

Review map = reading order, not file inventory:

1. `tests/e2e/e2e_cli_decode_flags.rs` adds the CLI scenario and asserts the observable JSON contract.

## Behavior

- Runs `copybook decode --format rdw --emit-raw record+rdw --emit-meta --threads 4`.
- Preserves both RDW headers, including non-zero reserved bytes, in canonical `raw_b64` and compatibility `__raw_b64`.
- Verifies payload metadata and one-based record ordering for both records.
- Test-only change; production behavior is unchanged.

## Verification

| Scope | Proof |
| --- | --- |
| Focused regression | `CARGO_BIN_EXE_copybook=$PWD/target/debug/copybook cargo test --offline -p copybook-e2e --test e2e_cli_decode_flags decode_rdw_record_raw_cli_preserves_physical_frames -- --exact` |
| Full target | Same command without the test filter: 8 passed, 0 failed |
| Static checks | Scoped Clippy with `-D warnings`, workspace rustfmt check, and `git diff --check` |

Residual physical-accounting scope remains in the library summary/evidence lane: the CLI JSON contract exposes per-record payload length, not file offsets or the aggregate physical-byte summary.

Refs #652, #572
