### PR TITLE
test(e2e): prove CLI RDW accounting

### DIFF
--- a/tests/e2e/e2e_cli_decode_flags.rs
+++ b/tests/e2e/e2e_cli_decode_flags.rs
@@ -178,7 +178,7 @@ fn decode_rdw_record_raw_cli_preserves_physical_frames() {
     let (dir, cpy, data) = setup(RDW_CPY, &rdw_data);
     let out = dir.path().join("out.jsonl");
 
-    cmd()
+    let cli_output = cmd()
         .args([
             "decode",
             "--format",
@@ -195,8 +195,17 @@ fn decode_rdw_record_raw_cli_preserves_physical_frames() {
         .arg(&out)
         .arg(&cpy)
         .arg(&data)
-        .assert()
-        .success();
+        .output()
+        .unwrap();
+    assert!(
+        cli_output.status.success(),
+        "decode failed: {}",
+        String::from_utf8_lossy(&cli_output.stderr)
+    );
+    let summary = String::from_utf8_lossy(&cli_output.stdout);
+    assert!(summary.contains("Records processed: 2"));
+    assert!(summary.contains("Warnings: 1"));
+    assert!(summary.contains("Bytes processed: 18"));
 
     use base64::Engine;
     let lines: Vec<Value> = std::fs::read_to_string(&out)


### PR DESCRIPTION
## Summary

Strengthen the existing #652/#572 CLI RDW evidence by asserting the user-facing aggregate accounting summary, not only the emitted raw frames.

Review map = reading order, not file inventory:

1. `tests/e2e/e2e_cli_decode_flags.rs` extends the existing RDW CLI scenario with summary assertions.

## Behavior

- Runs `copybook decode --format rdw --emit-raw record+rdw --emit-meta --threads 4` on two nine-byte physical RDW frames.
- Asserts `Records processed: 2`, `Warnings: 1`, and `Bytes processed: 18` in the CLI summary.
- Retains the existing assertions for both RDW headers, canonical `raw_b64`, compatibility `__raw_b64`, payload metadata, and record ordering.
- Test-only change; production behavior is unchanged.

## Verification

| Scope | Proof |
| --- | --- |
| Focused regression | `CARGO_BIN_EXE_copybook=$PWD/target/debug/copybook cargo test --offline -p copybook-e2e --test e2e_cli_decode_flags decode_rdw_record_raw_cli_preserves_physical_frames -- --exact` |
| Full target | Same command without the test filter: 8 passed, 0 failed |
| Static checks | Scoped Clippy with `-D warnings`, workspace rustfmt check, and `git diff --check` |

The CLI contract exposes aggregate physical bytes in the summary. File offsets remain a separate library/evidence question and are not invented here.

Refs #652, #572


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end coverage for raw-record decoding.
  * Added checks for successful command execution and expected processing, warning, and byte-count summaries.
  * Retained validation of generated output files and raw data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->