### PR TITLE
fix(codec): emit streaming source offsets

### DIFF
--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -24,7 +24,7 @@ mod run_summary;
 mod telemetry;
 mod warnings;
 
-use envelope::build_json_envelope;
+use envelope::{RecordMetadata, build_json_envelope};
 pub use run_summary::{MAX_CAPTURED_FAILURES, RecordFailure, RunSummary};
 pub use warnings::increment_warning_counter;
 use warnings::{reset_warning_counter, warning_count};
@@ -89,7 +89,7 @@ pub fn decode_record_with_scratch(
     options: &DecodeOptions,
     scratch: &mut crate::memory::ScratchBuffers,
 ) -> Result<Value> {
-    decode_record_with_scratch_and_raw(schema, data, options, None, 0, scratch)
+    decode_record_with_scratch_and_raw(schema, data, options, None, 0, None, scratch)
 }
 
 /// Decode a record with optional raw data and scratch buffers for maximum performance
@@ -99,6 +99,7 @@ fn decode_record_with_scratch_and_raw(
     options: &DecodeOptions,
     raw_data: Option<Vec<u8>>,
     record_index: u64,
+    record_offset: Option<u64>,
     scratch: &mut crate::memory::ScratchBuffers,
 ) -> Result<Value> {
     use serde_json::Map;
@@ -131,7 +132,10 @@ fn decode_record_with_scratch_and_raw(
         schema,
         options,
         record_index,
-        data.len(),
+        RecordMetadata {
+            length: data.len(),
+            offset: record_offset,
+        },
         record_raw,
         encoding_acc,
     ))
@@ -149,6 +153,24 @@ pub fn decode_record_with_raw_data(
     options: &DecodeOptions,
     raw_data_with_header: Option<&[u8]>,
     record_index: u64,
+) -> Result<Value> {
+    decode_record_with_raw_data_at_offset(
+        schema,
+        data,
+        options,
+        raw_data_with_header,
+        record_index,
+        None,
+    )
+}
+
+fn decode_record_with_raw_data_at_offset(
+    schema: &Schema,
+    data: &[u8],
+    options: &DecodeOptions,
+    raw_data_with_header: Option<&[u8]>,
+    record_index: u64,
+    record_offset: Option<u64>,
 ) -> Result<Value> {
     use crate::options::RawMode;
     use serde_json::Map;
@@ -190,7 +212,10 @@ pub fn decode_record_with_raw_data(
         schema,
         options,
         record_index,
-        data.len(),
+        RecordMetadata {
+            length: data.len(),
+            offset: record_offset,
+        },
         record_raw,
         encoding_acc,
     ))
@@ -2621,9 +2646,12 @@ fn process_fixed_records<R: Read, W: Write>(
     let mut reader = crate::file::fixed::reader(reader, schema)?;
     let mut scratch = crate::memory::ScratchBuffers::new();
     let mut record_index = 0u64;
+    let mut record_offset = 0u64;
 
     while let Some(record_data) = reader.read_record()? {
         record_index += 1;
+        let current_offset = record_offset;
+        record_offset = record_offset.saturating_add(record_data.len() as u64);
         crate::file::fixed::validate_record_length(
             schema,
             reader.lrecl(),
@@ -2644,6 +2672,7 @@ fn process_fixed_records<R: Read, W: Write>(
             options,
             raw_data_for_decode,
             record_index,
+            Some(current_offset),
             &mut scratch,
         ) {
             Ok(json_value) => {
@@ -2667,6 +2696,7 @@ struct DecodeWork {
     payload: Vec<u8>,
     raw_data: Option<Vec<u8>>,
     record_index: u64,
+    record_offset: u64,
 }
 
 struct DecodeOutcome {
@@ -2702,6 +2732,7 @@ fn decode_worker_pool(
                 &options,
                 work.raw_data,
                 work.record_index,
+                Some(work.record_offset),
                 scratch,
             );
             let warnings = warning_count().saturating_sub(warning_count_before);
@@ -2773,6 +2804,7 @@ fn process_fixed_records_parallel<R: Read, W: Write>(
     let batch_capacity = workers.saturating_mul(4).max(1);
     let mut pool = decode_worker_pool(schema, options);
     let mut record_index = 0_u64;
+    let mut record_offset = 0_u64;
     let mut batch_len = 0_usize;
 
     loop {
@@ -2792,6 +2824,8 @@ fn process_fixed_records_parallel<R: Read, W: Write>(
         let Some(record_data) = record else { break };
 
         record_index += 1;
+        let current_offset = record_offset;
+        record_offset = record_offset.saturating_add(record_data.len() as u64);
         crate::file::fixed::validate_record_length(
             schema,
             reader.lrecl(),
@@ -2809,6 +2843,7 @@ fn process_fixed_records_parallel<R: Read, W: Write>(
             payload: record_data,
             raw_data,
             record_index,
+            record_offset: current_offset,
         }) {
             let pending_result = if batch_len > 0 {
                 process_decode_batch(&mut pool, batch_len, output, options, summary)
@@ -2864,10 +2899,13 @@ fn process_rdw_records<R: Read, W: Write>(
     let mut reader = crate::record::RDWRecordReader::new(reader, options.strict_mode);
     let mut scratch = crate::memory::ScratchBuffers::new();
     let mut record_index = 0u64;
+    let mut record_offset = 0u64;
 
     while let Some(rdw_record) = reader.read_record()? {
         record_index += 1;
         let record_bytes = rdw_record.header.len() + rdw_record.payload.len();
+        let current_offset = record_offset;
+        record_offset = record_offset.saturating_add(record_bytes as u64);
         summary.bytes_processed += record_bytes as u64;
         telemetry::record_read(record_bytes, options);
         if rdw_record.reserved() != 0 {
@@ -2903,6 +2941,7 @@ fn process_rdw_records<R: Read, W: Write>(
             options,
             full_raw_data,
             record_index,
+            Some(current_offset),
             &mut scratch,
         ) {
             Ok(json_value) => {
@@ -2957,6 +2996,7 @@ fn process_rdw_records_parallel<R: Read, W: Write>(
     let batch_capacity = workers.saturating_mul(4).max(1);
     let mut pool = decode_worker_pool(schema, options);
     let mut record_index = 0_u64;
+    let mut record_offset = 0_u64;
     let mut batch_len = 0_usize;
 
     loop {
@@ -2977,6 +3017,8 @@ fn process_rdw_records_parallel<R: Read, W: Write>(
 
         record_index += 1;
         let record_bytes = rdw_record.header.len() + rdw_record.payload.len();
+        let current_offset = record_offset;
+        record_offset = record_offset.saturating_add(record_bytes as u64);
         summary.bytes_processed += record_bytes as u64;
         telemetry::record_read(record_bytes, options);
         if rdw_record.reserved() != 0 {
@@ -3010,6 +3052,7 @@ fn process_rdw_records_parallel<R: Read, W: Write>(
             payload: rdw_record.payload,
             raw_data: full_raw_data,
             record_index,
+            record_offset: current_offset,
         }) {
             let pending_result = if batch_len > 0 {
                 process_decode_batch(&mut pool, batch_len, output, options, summary)

--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -132,7 +132,7 @@ fn decode_record_with_scratch_and_raw(
         schema,
         options,
         record_index,
-        RecordMetadata {
+        &RecordMetadata {
             length: data.len(),
             offset: record_offset,
         },
@@ -212,7 +212,7 @@ fn decode_record_with_raw_data_at_offset(
         schema,
         options,
         record_index,
-        RecordMetadata {
+        &RecordMetadata {
             length: data.len(),
             offset: record_offset,
         },

--- a/crates/copybook-codec/src/lib_api/envelope.rs
+++ b/crates/copybook-codec/src/lib_api/envelope.rs
@@ -6,6 +6,11 @@ use crate::options::{DecodeOptions, ZonedEncodingFormat};
 use copybook_core::Schema;
 use serde_json::Value;
 
+pub(super) struct RecordMetadata {
+    pub(super) length: usize,
+    pub(super) offset: Option<u64>,
+}
+
 /// Recursively flatten hierarchical fields into a target map so that leaf
 /// field names are accessible at the root level for backward compatibility.
 fn flatten_fields_into(
@@ -31,7 +36,7 @@ pub(super) fn build_json_envelope(
     schema: &Schema,
     options: &DecodeOptions,
     record_index: u64,
-    record_length: usize,
+    record_metadata: RecordMetadata,
     raw_b64: Option<String>,
     encoding_metadata: Vec<(String, ZonedEncodingFormat)>,
 ) -> Value {
@@ -65,7 +70,7 @@ pub(super) fn build_json_envelope(
         }
         root.insert(
             String::from("length"),
-            Value::Number(serde_json::Number::from(record_length)),
+            Value::Number(serde_json::Number::from(record_metadata.length)),
         );
         root.insert(
             String::from("__record_index"),
@@ -73,8 +78,14 @@ pub(super) fn build_json_envelope(
         );
         root.insert(
             String::from("__length"),
-            Value::Number(serde_json::Number::from(record_length)),
+            Value::Number(serde_json::Number::from(record_metadata.length)),
         );
+        if let Some(offset) = record_metadata.offset {
+            root.insert(
+                String::from("offset"),
+                Value::Number(serde_json::Number::from(offset)),
+            );
+        }
     }
 
     if let Some(raw) = raw_b64 {

--- a/crates/copybook-codec/src/lib_api/envelope.rs
+++ b/crates/copybook-codec/src/lib_api/envelope.rs
@@ -36,7 +36,7 @@ pub(super) fn build_json_envelope(
     schema: &Schema,
     options: &DecodeOptions,
     record_index: u64,
-    record_metadata: RecordMetadata,
+    record_metadata: &RecordMetadata,
     raw_b64: Option<String>,
     encoding_metadata: Vec<(String, ZonedEncodingFormat)>,
 ) -> Value {

--- a/crates/copybook-codec/tests/streaming_file_tests.rs
+++ b/crates/copybook-codec/tests/streaming_file_tests.rs
@@ -1058,6 +1058,51 @@ fn decode_file_to_jsonl_raw_mode_rdw_is_stable_across_workers() {
 }
 
 #[test]
+fn decode_file_to_jsonl_emit_meta_reports_physical_offsets_across_formats() {
+    let fixed_schema = parse_copybook("01 FIELD PIC X(5).").unwrap();
+    let fixed_opts = ascii_decode_opts().with_emit_meta(true).with_threads(4);
+    let mut fixed_output = Vec::new();
+    decode_file_to_jsonl(
+        &fixed_schema,
+        Cursor::new(b"ABCDE12345"),
+        &mut fixed_output,
+        &fixed_opts,
+    )
+    .unwrap();
+    let fixed_lines: Vec<_> = String::from_utf8(fixed_output)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+        .collect();
+    assert_eq!(fixed_lines.len(), 2);
+    assert_eq!(fixed_lines[0]["offset"], 0);
+    assert_eq!(fixed_lines[1]["offset"], 5);
+
+    let rdw_schema = parse_copybook(RDW_SCHEMA).unwrap();
+    let rdw_data = build_rdw_records(&["ABCDE", "FGHIJ"]);
+    let rdw_opts = ascii_decode_opts()
+        .with_format(RecordFormat::RDW)
+        .with_emit_meta(true)
+        .with_threads(4);
+    let mut rdw_output = Vec::new();
+    decode_file_to_jsonl(
+        &rdw_schema,
+        Cursor::new(rdw_data),
+        &mut rdw_output,
+        &rdw_opts,
+    )
+    .unwrap();
+    let rdw_lines: Vec<_> = String::from_utf8(rdw_output)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+        .collect();
+    assert_eq!(rdw_lines.len(), 2);
+    assert_eq!(rdw_lines[0]["offset"], 0);
+    assert_eq!(rdw_lines[1]["offset"], 9);
+}
+
+#[test]
 fn decode_file_to_jsonl_raw_mode_rdw_strict_reserved_rejects_nonzero() {
     let schema = parse_copybook("01 FIELD PIC X(5).").unwrap();
     let data = b"\x00\x05\x12\x34HELLO";

--- a/docs/reference/LIBRARY_API.md
+++ b/docs/reference/LIBRARY_API.md
@@ -328,8 +328,9 @@ Decoded records are wrapped in a stable JSON envelope:
 - `record_index` – Zero-based record sequence number
 - `codepage` – Decoder code page (e.g., `cp037`)
 - `fields` – Map of decoded field values (nested for groups)
-- `schema_fingerprint`, `__schema_id`, `length`, `__record_index`, `__length` – Added when
-  `emit_meta` is enabled
+- `schema_fingerprint`, `__schema_id`, `offset`, `length`, `__record_index`, `__length` – Added when
+  `emit_meta` is enabled for streaming decode; `offset` is the zero-based physical source offset
+  of the decoded record
 
 When `emit_raw` is enabled, record-level payloads are emitted as **`raw_b64`** (with the canonical
 `__raw_b64` key also present). Field-level capture uses the `<FIELD>__raw_b64` naming pattern:

--- a/tests/e2e/e2e_cli_decode_flags.rs
+++ b/tests/e2e/e2e_cli_decode_flags.rs
@@ -222,6 +222,7 @@ fn decode_rdw_record_raw_cli_preserves_physical_frames() {
     for (index, line) in lines.iter().enumerate() {
         assert!(line.get("raw_b64").is_some());
         assert!(line.get("__raw_b64").is_some());
+        assert_eq!(line["offset"], index * 9);
         assert_eq!(line["length"], 5);
         assert_eq!(line["__length"], 5);
         assert_eq!(line["record_index"], index + 1);


### PR DESCRIPTION
## Summary

Implement the documented `offset` metadata contract for streaming fixed and RDW decode, closing the exact #652/#572 file-offset gap.

Review map = reading order, not file inventory:

1. `crates/copybook-codec/src/lib_api.rs` propagates zero-based physical source offsets through single-worker and threaded fixed/RDW decoding.
2. `crates/copybook-codec/src/lib_api/envelope.rs` emits `offset` when streaming metadata is available.
3. `crates/copybook-codec/tests/streaming_file_tests.rs` proves fixed offsets `0, 5` and RDW offsets `0, 9` with four workers.
4. `tests/e2e/e2e_cli_decode_flags.rs` proves the CLI-visible RDW offset contract.
5. `docs/reference/LIBRARY_API.md` records the streaming-only offset boundary.

## Behavior

- `--emit-meta` now emits zero-based physical source offsets for streamed fixed/RDW records.
- Threaded and single-worker paths use the same offsets and preserve output order.
- Direct single-record APIs do not fabricate a source-stream offset.
- Offset accumulation saturates at `u64::MAX`; production behavior outside metadata is unchanged.

## Verification

| Scope | Proof |
| --- | --- |
| Offset regression | `decode_file_to_jsonl_emit_meta_reports_physical_offsets_across_formats`: 1 passed |
| Codec streaming target | 59 passed, 0 failed |
| CLI regression | `decode_rdw_record_raw_cli_preserves_physical_frames`: 1 passed; full decode-flag target: 8 passed |
| Static checks | Scoped codec/e2e Clippy with `-D warnings`, workspace rustfmt, and `git diff --check` |

Refs #652, #572
