### PR TITLE
docs(cli): align streaming record index contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Rust toolkit for COBOL copybook parsing and fixed-record data conversion. Determ
 Engineering Preview (v0.5.0). Stable CLI and library APIs; feature completeness is preview-level. See [ROADMAP.md](docs/ROADMAP.md) for adoption guidance and known limitations.
 
 <!-- TEST_STATUS:BEGIN -->
-**conformance:** 9916/9916  • **roundtrip:** N/A  • **negative:** N/A  • **skipped:** 0  • **leaks:** 0<br>
+**conformance:** 9920/9920  • **roundtrip:** N/A  • **negative:** N/A  • **skipped:** 0  • **leaks:** 0<br>
 _Source: CI receipts (nextest/junit). This block is updated automatically._
 <!-- TEST_STATUS:END -->
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -657,7 +657,7 @@ Binary field sizes are determined by PIC digits: ≤4→16b, 5–9→32b, 10–1
 
 **Envelope (always present):**
 - `schema` - JSONL schema version (currently `copybook.v1`)
-- `record_index` - Zero-based record number
+- `record_index` - One-based record number in the decoded stream (the first record is `1`)
 - `codepage` - Code page identifier used for decoding
 - `fields` - Object containing decoded field values
 

--- a/docs/REPORT.md
+++ b/docs/REPORT.md
@@ -55,7 +55,7 @@ responsibilities:
 ### Test Coverage
 
 <!-- TEST_STATUS:BEGIN -->
-**conformance:** 9916/9916  • **roundtrip:** N/A  • **negative:** N/A  • **skipped:** 0  • **leaks:** 0<br>
+**conformance:** 9920/9920  • **roundtrip:** N/A  • **negative:** N/A  • **skipped:** 0  • **leaks:** 0<br>
 _Source: CI receipts (nextest/junit). This block is updated automatically._
 <!-- TEST_STATUS:END -->
 

--- a/docs/jsonl-schema.md
+++ b/docs/jsonl-schema.md
@@ -9,7 +9,7 @@ copybook-rs emits a versioned JSON envelope for each decoded record. Each line i
 | Key | Type | Description |
 | --- | ---- | ----------- |
 | `schema` | string | Schema version identifier (`copybook.v1`). |
-| `record_index` | integer | Zero-based record number in the decoded stream. |
+| `record_index` | integer | One-based record number in the decoded stream; the first record is `1`. |
 | `codepage` | string | Decoder code page (e.g., `cp037`, `ascii`). |
 | `fields` | object | Map of decoded field values. Nested groups are represented as objects. |
 | `schema_fingerprint` | string | Optional SHA-256 fingerprint of the copybook (present when `--emit-meta`). |
@@ -320,7 +320,7 @@ uses a non-default encoding (e.g., ASCII zoned decimals in an EBCDIC file).
 ```json
 {
   "schema": "copybook.v1",
-  "record_index": 0,
+  "record_index": 1,
   "codepage": "cp037",
   "fields": {
     "AMOUNT": "123"

--- a/docs/reference/LIBRARY_API.md
+++ b/docs/reference/LIBRARY_API.md
@@ -325,7 +325,8 @@ Decoded records are wrapped in a stable JSON envelope:
 ```
 
 - `schema` – Versioned schema identifier (`copybook.v1`)
-- `record_index` – Zero-based record sequence number
+- `record_index` – One-based record sequence number for streaming JSONL decode (the first
+  record is `1`). Direct library decode APIs preserve the caller-supplied index.
 - `codepage` – Decoder code page (e.g., `cp037`)
 - `fields` – Map of decoded field values (nested for groups)
 - `schema_fingerprint`, `__schema_id`, `offset`, `length`, `__record_index`, `__length` – Added when


### PR DESCRIPTION
## What this does

The CLI JSONL stream emits a one-based `record_index`, but the JSONL schema, CLI reference, and library API prose described it as zero-based. That mismatch makes record-oriented diagnostics and downstream integrations ambiguous.

**Fix:** document the streaming contract as one-based, with the first record equal to `1`. The library API description also states that direct decode APIs preserve the caller-supplied index. Generated test-status blocks are synchronized from the current JUnit receipt.

## Verification

| Check | Result |
| --- | --- |
| streaming record-index regression | 1 passed, confirms one-based output |
| CLI RDW metadata regression | 1 passed |
| `cargo run --offline -p xtask -- docs verify-all` | passed |
| `git diff --check`, `cargo fmt --all -- --check` | clean |

## Review map

- `docs/jsonl-schema.md`, `docs/CLI_REFERENCE.md`: define the user-facing streaming JSONL index contract.
- `docs/reference/LIBRARY_API.md`: distinguishes streaming output from caller-supplied direct-library indices.
- `README.md`, `docs/REPORT.md`: synchronized generated test-status receipts.