### PR TITLE
fix(codec): preserve iterator record indices

### DIFF
--- a/crates/copybook-codec/src/iterator.rs
+++ b/crates/copybook-codec/src/iterator.rs
@@ -211,6 +211,7 @@
 //! # }
 //! ```
 
+use crate::lib_api::decode_record_with_raw_data;
 use crate::options::{DecodeOptions, RecordFormat};
 use copybook_core::{Error, ErrorCode, ErrorContext, Result, Schema};
 use copybook_rdw::RdwHeader;
@@ -523,7 +524,13 @@ impl<R: Read> RecordIterator<R> {
     fn decode_next_record(&mut self) -> Result<Option<Value>> {
         match self.read_raw_record()? {
             Some(record_bytes) => {
-                let json_value = crate::decode_record(&self.schema, &record_bytes, &self.options)?;
+                let json_value = decode_record_with_raw_data(
+                    &self.schema,
+                    &record_bytes,
+                    &self.options,
+                    None,
+                    self.record_index,
+                )?;
                 Ok(Some(json_value))
             }
             None => Ok(None),

--- a/crates/copybook-codec/src/iterator.rs
+++ b/crates/copybook-codec/src/iterator.rs
@@ -307,6 +307,8 @@ pub struct RecordIterator<R: Read> {
     eof_reached: bool,
     /// Buffer for reading record data
     buffer: Vec<u8>,
+    /// Complete RDW frame for `RawMode::RecordRDW` envelope capture.
+    raw_data_with_header: Option<Vec<u8>>,
 }
 
 impl<R: Read> RecordIterator<R> {
@@ -330,6 +332,7 @@ impl<R: Read> RecordIterator<R> {
             record_index: 0,
             eof_reached: false,
             buffer: Vec::new(),
+            raw_data_with_header: None,
         })
     }
 
@@ -421,6 +424,7 @@ impl<R: Read> RecordIterator<R> {
         }
 
         self.buffer.clear();
+        self.raw_data_with_header = None;
 
         let record_data = match self.options.format {
             RecordFormat::Fixed => {
@@ -500,6 +504,10 @@ impl<R: Read> RecordIterator<R> {
                 self.buffer.resize(length, 0);
                 match self.reader.read_exact(&mut self.buffer) {
                     Ok(()) => {
+                        let mut raw_data_with_header = Vec::with_capacity(4 + length);
+                        raw_data_with_header.extend_from_slice(&rdw_header);
+                        raw_data_with_header.extend_from_slice(&self.buffer);
+                        self.raw_data_with_header = Some(raw_data_with_header);
                         self.record_index += 1;
                         Some(self.buffer.clone())
                     }
@@ -524,11 +532,12 @@ impl<R: Read> RecordIterator<R> {
     fn decode_next_record(&mut self) -> Result<Option<Value>> {
         match self.read_raw_record()? {
             Some(record_bytes) => {
+                let raw_data_with_header = self.raw_data_with_header.take();
                 let json_value = decode_record_with_raw_data(
                     &self.schema,
                     &record_bytes,
                     &self.options,
-                    None,
+                    raw_data_with_header.as_deref(),
                     self.record_index,
                 )?;
                 Ok(Some(json_value))

--- a/crates/copybook-codec/tests/streaming_file_tests.rs
+++ b/crates/copybook-codec/tests/streaming_file_tests.rs
@@ -203,6 +203,20 @@ fn iter_records_does_not_buffer_all() {
 }
 
 #[test]
+fn record_iterator_decode_emits_one_based_indices() {
+    let schema = parse_copybook(SIMPLE_SCHEMA).unwrap();
+    let data = build_pic9_5_data(2);
+    let opts = ascii_decode_opts();
+    let mut iter = copybook_codec::RecordIterator::new(Cursor::new(data), &schema, &opts).unwrap();
+
+    let first = iter.next().unwrap().unwrap();
+    assert_eq!(first["record_index"], 1);
+
+    let second = iter.next().unwrap().unwrap();
+    assert_eq!(second["record_index"], 2);
+}
+
+#[test]
 fn record_iterator_raw_record_access() {
     let schema = parse_copybook(SIMPLE_SCHEMA).unwrap();
     let data = b"0000100002";

--- a/crates/copybook-codec/tests/streaming_file_tests.rs
+++ b/crates/copybook-codec/tests/streaming_file_tests.rs
@@ -203,17 +203,61 @@ fn iter_records_does_not_buffer_all() {
 }
 
 #[test]
-fn record_iterator_decode_emits_one_based_indices() {
-    let schema = parse_copybook(SIMPLE_SCHEMA).unwrap();
+fn cobol_record_iterator_decode_emits_one_based_indices() -> Result<(), Box<dyn std::error::Error>>
+{
+    let schema = parse_copybook(SIMPLE_SCHEMA)?;
     let data = build_pic9_5_data(2);
     let opts = ascii_decode_opts();
-    let mut iter = copybook_codec::RecordIterator::new(Cursor::new(data), &schema, &opts).unwrap();
+    let mut iter = copybook_codec::RecordIterator::new(Cursor::new(data), &schema, &opts)?;
 
-    let first = iter.next().unwrap().unwrap();
+    let first = iter
+        .next()
+        .ok_or_else(|| std::io::Error::other("missing first iterator record"))??;
     assert_eq!(first["record_index"], 1);
 
-    let second = iter.next().unwrap().unwrap();
+    let second = iter
+        .next()
+        .ok_or_else(|| std::io::Error::other("missing second iterator record"))??;
     assert_eq!(second["record_index"], 2);
+
+    Ok(())
+}
+
+#[test]
+fn cobol_record_iterator_truncated_record_returns_typed_error()
+-> Result<(), Box<dyn std::error::Error>> {
+    let schema = parse_copybook(SIMPLE_SCHEMA)?;
+    let opts = ascii_decode_opts();
+    let mut iter = copybook_codec::RecordIterator::new(Cursor::new(b"1234"), &schema, &opts)?;
+
+    let error = match iter.next() {
+        Some(Err(error)) => error,
+        Some(Ok(_)) => return Err("truncated record unexpectedly decoded".into()),
+        None => return Err("truncated record was silently treated as EOF".into()),
+    };
+    assert_eq!(error.code, ErrorCode::CBKR101_FIXED_RECORD_ERROR);
+
+    Ok(())
+}
+
+#[test]
+fn cobol_record_iterator_rdw_raw_mode_preserves_header() -> Result<(), Box<dyn std::error::Error>> {
+    let schema = parse_copybook("01 RECORD PIC X(5).")?;
+    let frame = [0x00, 0x05, 0xA5, 0x5A, b'H', b'E', b'L', b'L', b'O'];
+    let opts = DecodeOptions::new()
+        .with_format(RecordFormat::RDW)
+        .with_codepage(Codepage::ASCII)
+        .with_emit_raw(RawMode::RecordRDW);
+    let mut iter = copybook_codec::RecordIterator::new(Cursor::new(frame), &schema, &opts)?;
+
+    let decoded = iter
+        .next()
+        .ok_or_else(|| std::io::Error::other("missing RDW iterator record"))??;
+    let expected = base64::engine::general_purpose::STANDARD.encode(frame);
+    assert_eq!(decoded["raw_b64"], expected);
+    assert_eq!(decoded["__raw_b64"], expected);
+
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
## What this does

`RecordIterator` reports a one-based current record, but its decoded JSON envelope previously called the single-record helper and emitted `record_index: 0` for every record. Its RDW path also discarded the four-byte header before `RecordRDW` raw capture.

**Fix:** iterator decoding now passes the one-based index through the indexed decode API and retains the complete RDW frame for canonical and compatibility raw capture. Direct single-record APIs and public raw-payload access remain unchanged.

## Verification

| Check | Result |
| --- | --- |
| iterator index, RDW raw, and truncated-record regressions | 3 passed |
| codec streaming suite | 62 passed |
| scoped Clippy | clean |
| rustfmt and diff checks | clean |

## Review map

- `crates/copybook-codec/src/iterator.rs`: carries the iterator index and complete RDW frame into envelope construction.
- `crates/copybook-codec/tests/streaming_file_tests.rs`: proves one-based indices, full RDW raw fidelity, and typed fixed-record truncation failure.