### PR TITLE
docs: add fixed-rdw evidence registry

### DIFF
--- a/.github/workflows/docs-truth.yml
+++ b/.github/workflows/docs-truth.yml
@@ -33,6 +33,10 @@ jobs:
               - 'crates/copybook/**'
               - 'crates/copybook-rs/**'
               - 'crates/copybook-codec/**'
+              - 'crates/copybook-fixed/**'
+              - 'crates/copybook-rdw/**'
+              - 'crates/copybook-cli/**'
+              - 'crates/copybook-record-io/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'scripts/bench/**'
@@ -46,6 +50,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Install nextest

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Rust toolkit for COBOL copybook parsing and fixed-record data conversion. Determ
 Engineering Preview (v0.5.0). Stable CLI and library APIs; feature completeness is preview-level. See [ROADMAP.md](docs/ROADMAP.md) for adoption guidance and known limitations.
 
 <!-- TEST_STATUS:BEGIN -->
-**conformance:** 9920/9920  • **roundtrip:** N/A  • **negative:** N/A  • **skipped:** 0  • **leaks:** 0<br>
+**conformance:** 9928/9928  • **roundtrip:** N/A  • **negative:** N/A  • **skipped:** 0  • **leaks:** 0<br>
 _Source: CI receipts (nextest/junit). This block is updated automatically._
 <!-- TEST_STATUS:END -->
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Rust toolkit for COBOL copybook parsing and fixed-record data conversion. Determ
 Engineering Preview (v0.5.0). Stable CLI and library APIs; feature completeness is preview-level. See [ROADMAP.md](docs/ROADMAP.md) for adoption guidance and known limitations.
 
 <!-- TEST_STATUS:BEGIN -->
-**conformance:** 9928/9928  • **roundtrip:** N/A  • **negative:** N/A  • **skipped:** 0  • **leaks:** 0<br>
+**conformance:** 9930/9930  • **roundtrip:** N/A  • **negative:** N/A  • **skipped:** 0  • **leaks:** 0<br>
 _Source: CI receipts (nextest/junit). This block is updated automatically._
 <!-- TEST_STATUS:END -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,9 @@ Start with **[START_HERE.md](START_HERE.md)** for the hand-maintained navigation
 - [Agentic PR Operations](design/AGENTIC_PR_OPERATIONS.md) -- delegated lane authority and review-to-merge state machine
 - [Internal feature specs](internal/features/) -- dialect lever, edited PIC
 
+### Evidence
+- [Fixed/RDW pipeline registry](evidence/fixed-rdw-pipeline.toml) -- current-main scenario and test-anchor evidence
+
 ### Diataxis Framework
 Documentation follows [Diataxis](https://diataxis.fr/). Category indexes:
 [tutorials/](tutorials/README.md) | [how-to/](how-to/README.md) | [explanation/](explanation/README.md) | [reference/](reference/README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ Start with **[START_HERE.md](START_HERE.md)** for the hand-maintained navigation
 - [Internal feature specs](internal/features/) -- dialect lever, edited PIC
 
 ### Evidence
+
 - [Fixed/RDW pipeline registry](evidence/fixed-rdw-pipeline.toml) -- current-main scenario and test-anchor evidence
 
 ### Diataxis Framework

--- a/docs/REPORT.md
+++ b/docs/REPORT.md
@@ -55,7 +55,7 @@ responsibilities:
 ### Test Coverage
 
 <!-- TEST_STATUS:BEGIN -->
-**conformance:** 9928/9928  • **roundtrip:** N/A  • **negative:** N/A  • **skipped:** 0  • **leaks:** 0<br>
+**conformance:** 9930/9930  • **roundtrip:** N/A  • **negative:** N/A  • **skipped:** 0  • **leaks:** 0<br>
 _Source: CI receipts (nextest/junit). This block is updated automatically._
 <!-- TEST_STATUS:END -->
 

--- a/docs/REPORT.md
+++ b/docs/REPORT.md
@@ -55,7 +55,7 @@ responsibilities:
 ### Test Coverage
 
 <!-- TEST_STATUS:BEGIN -->
-**conformance:** 9920/9920  • **roundtrip:** N/A  • **negative:** N/A  • **skipped:** 0  • **leaks:** 0<br>
+**conformance:** 9928/9928  • **roundtrip:** N/A  • **negative:** N/A  • **skipped:** 0  • **leaks:** 0<br>
 _Source: CI receipts (nextest/junit). This block is updated automatically._
 <!-- TEST_STATUS:END -->
 

--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Current-main evidence coordinator for issue #572.
+# This registry covers the fixed/RDW pipeline plane. It is intentionally not
+# the complete stable-error registry requested by issue #576.
+schema_version = 1
+scope = "fixed-rdw-pipeline"
+verified_against = "87e6f1986e7b894412480359cb50baea8c406645"
+
+[[scenarios]]
+id = "format.fixed.basic"
+record_formats = ["fixed"]
+api_tests = ["crates/copybook-codec/tests/streaming_file_tests.rs::decode_file_jsonl_format_lines"]
+cli_tests = ["tests/e2e/e2e_decode_option_interactions.rs::decode_multi_record_with_threads"]
+error_codes = []
+cli_commands = ["decode --format fixed"]
+known_limitation = "The registry anchor proves the normal streaming decode path; fixture breadth remains in the codec and e2e suites."
+
+[[scenarios]]
+id = "format.fixed.framing.rejection"
+record_formats = ["fixed"]
+api_tests = ["crates/copybook-codec/tests/streaming_file_tests.rs::cobol_record_iterator_truncated_record_returns_typed_error"]
+cli_tests = ["tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbkr101_fixed_record_error_for_truncated_fixed_record"]
+error_codes = ["CBKR101_FIXED_RECORD_ERROR"]
+cli_commands = ["decode --format fixed --fail-fast"]
+known_limitation = "The direct trigger covers a truncated fixed input; oversized and IO variants remain linked to their focused crate tests."
+
+[[scenarios]]
+id = "format.rdw.basic"
+record_formats = ["rdw"]
+api_tests = ["crates/copybook-codec/tests/comprehensive_rdw_tests.rs::test_rdw_multiple_records"]
+cli_tests = ["tests/e2e/e2e_cli_decode_flags.rs::decode_rdw_record_raw_cli_preserves_physical_frames"]
+error_codes = []
+cli_commands = ["decode --format rdw"]
+known_limitation = "Encode and round-trip anchors remain in the comprehensive RDW suite and are not duplicated here."
+
+[[scenarios]]
+id = "format.rdw.header.rejection"
+record_formats = ["rdw"]
+api_tests = [
+  "crates/copybook-codec/tests/comprehensive_rdw_tests.rs::test_rdw_underflow_error",
+  "crates/copybook-codec/tests/streaming_file_tests.rs::decode_rdw_suspect_ascii_header_is_fatal",
+]
+cli_tests = [
+  "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbkf221_rdw_short_header_exits_format",
+  "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbkf102_rdw_truncated_payload_exits_format",
+]
+error_codes = ["CBKF102_RECORD_LENGTH_INVALID", "CBKF104_RDW_SUSPECT_ASCII", "CBKF221_RDW_UNDERFLOW"]
+cli_commands = ["decode --format rdw --fail-fast"]
+known_limitation = "Reserved-byte strict and lenient policy anchors are recorded in the raw-mode scenario and focused streaming tests."
+
+[[scenarios]]
+id = "format.rdw.odo_variable"
+record_formats = ["rdw"]
+api_tests = [
+  "crates/copybook-codec/tests/comprehensive_rdw_tests.rs::test_rdw_with_odo_variable_length",
+  "crates/copybook-codec/tests/comprehensive_rdw_tests.rs::test_rdw_with_odo_variable_length_parallel",
+]
+cli_tests = []
+error_codes = []
+cli_commands = []
+known_limitation = "The current coordinator anchors library sequential and parallel RDW+ODO behavior; CLI coverage is not claimed by this row."
+
+[[scenarios]]
+id = "format.fixed_rdw.raw_mode"
+record_formats = ["fixed", "rdw"]
+api_tests = [
+  "crates/copybook-codec/tests/streaming_file_tests.rs::decode_file_to_jsonl_raw_mode_records_emit_fixed_raw_payload",
+  "crates/copybook-codec/tests/streaming_file_tests.rs::decode_file_to_jsonl_raw_mode_rdw_emits_header_and_payload",
+]
+cli_tests = ["tests/e2e/e2e_cli_decode_flags.rs::decode_rdw_record_raw_cli_preserves_physical_frames"]
+error_codes = []
+cli_commands = ["decode --format rdw --emit-raw record+rdw"]
+known_limitation = "Field raw-mode coverage remains in the codec streaming suite and is not duplicated in this registry row."
+
+[[scenarios]]
+id = "format.fixed_rdw.accounting"
+record_formats = ["fixed", "rdw"]
+api_tests = ["crates/copybook-codec/tests/streaming_file_tests.rs::decode_file_to_jsonl_emit_meta_reports_physical_offsets_across_formats"]
+cli_tests = ["tests/e2e/e2e_cli_decode_flags.rs::decode_rdw_record_raw_cli_preserves_physical_frames"]
+error_codes = []
+cli_commands = ["decode --format rdw --emit-meta"]
+known_limitation = "The aggregate summary and worker accounting contracts are linked by separate issue #652 evidence comments."
+
+[[scenarios]]
+id = "format.fixed_rdw.workers"
+record_formats = ["fixed", "rdw"]
+api_tests = [
+  "crates/copybook-codec/tests/streaming_file_tests.rs::decode_fixed_threaded_deterministic",
+  "crates/copybook-codec/tests/streaming_file_tests.rs::decode_rdw_threaded_deterministic",
+]
+cli_tests = [
+  "tests/e2e/e2e_parallel_determinism.rs::test_decode_deterministic_across_thread_counts",
+  "tests/e2e/e2e_parallel_determinism.rs::test_encode_deterministic_across_thread_counts",
+]
+error_codes = []
+cli_commands = ["decode --threads 1", "decode --threads 8"]
+known_limitation = "The current anchors prove ordered deterministic output across worker configurations; throughput is governed by the performance receipt, not this registry."
+
+[[scenarios]]
+id = "format.fixed_rdw.cli"
+record_formats = ["fixed", "rdw"]
+api_tests = []
+cli_tests = [
+  "tests/e2e/e2e_cli_decode_flags.rs::decode_emit_meta_includes_metadata_fields",
+  "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbkf102_rdw_truncated_payload_exits_format",
+]
+error_codes = ["CBKF102_RECORD_LENGTH_INVALID"]
+cli_commands = ["decode --format fixed", "decode --format rdw"]
+known_limitation = "Verify, encode, projection, and determinism command rows remain separate CLI evidence planes."

--- a/tools/xtask/src/docs_verify.rs
+++ b/tools/xtask/src/docs_verify.rs
@@ -193,6 +193,14 @@ fn workspace_root() -> PathBuf {
 const STABILITY_SCHEMA_VERSION: &str = "1.0.0";
 const STABILITY_REGISTRY_PATH: &str = "docs/stability/surface-registry.json";
 const RECORD_PIPELINE_EVIDENCE_PATH: &str = "docs/evidence/fixed-rdw-pipeline.toml";
+const RECORD_PIPELINE_SOURCE_PATHS: [&str; 6] = [
+    "crates/copybook-codec",
+    "crates/copybook-fixed",
+    "crates/copybook-rdw",
+    "crates/copybook-cli",
+    "crates/copybook-record-io",
+    "tests/e2e",
+];
 const STABLE_CONTRACT_SCHEMA_VERSION: &str = "1.0.0";
 const STABLE_CONTRACT_MANIFEST_PATH: &str = "docs/contracts/stable-surface-contract.json";
 const STABLE_CONTRACT_SOURCE_PATHS: [&str; 6] = [
@@ -287,23 +295,29 @@ fn verify_record_pipeline_evidence() -> Result<()> {
         bail!("verified_against must be a 40-character commit SHA, found `{sha}`");
     }
 
-    let commit_exists = Command::new("git")
+    let commit_check = Command::new("git")
         .current_dir(&root)
         .args(["cat-file", "-e", &format!("{sha}^{{commit}}")])
-        .status()
-        .context("checking fixed/RDW evidence registry commit")?
-        .success();
-    if commit_exists {
-        verify_record_pipeline_commit_ancestry(&root, sha)?;
-    } else if !is_shallow_repository(&root)? {
-        bail!("fixed/RDW evidence registry commit `{sha}` is not available");
-    } else {
-        println!(
-            "fixed/RDW evidence commit `{sha}` unavailable in shallow checkout; ancestry and drift checks skipped"
-        );
+        .output()
+        .context("checking fixed/RDW evidence registry commit")?;
+    match commit_check.status.code() {
+        Some(0) => verify_record_pipeline_commit_ancestry(&root, sha)?,
+        Some(1) if is_shallow_repository(&root)? => {
+            println!(
+                "fixed/RDW evidence commit `{sha}` unavailable in shallow checkout; ancestry and drift checks skipped"
+            );
+        }
+        Some(1) => bail!("fixed/RDW evidence registry commit `{sha}` is not available"),
+        other => bail!(
+            "git cat-file failed while checking fixed/RDW evidence registry commit (exit {other:?}): {}",
+            String::from_utf8_lossy(&commit_check.stderr).trim()
+        ),
     }
 
-    verify_record_pipeline_scenarios(&root, &registry.scenarios)?;
+    let error_code_source = fs::read_to_string(root.join("crates/copybook-error/src/lib.rs"))
+        .context("loading crates/copybook-error/src/lib.rs")?;
+    let error_codes = parse_error_code_variants(&error_code_source)?;
+    verify_record_pipeline_scenarios(&root, &registry.scenarios, &error_codes)?;
 
     println!(
         "fixed/RDW evidence registry verified: {} scenarios at {}",
@@ -314,33 +328,39 @@ fn verify_record_pipeline_evidence() -> Result<()> {
 }
 
 fn verify_record_pipeline_commit_ancestry(root: &Path, sha: &str) -> Result<()> {
-    let verified_commit_is_ancestor = Command::new("git")
+    let ancestor_check = Command::new("git")
         .current_dir(root)
         .args(["merge-base", "--is-ancestor", sha, "HEAD"])
-        .status()
-        .context("checking fixed/RDW evidence registry commit ancestry")?
-        .success();
-    if !verified_commit_is_ancestor {
-        bail!("fixed/RDW evidence was verified against `{sha}`, which is not an ancestor of HEAD");
+        .output()
+        .context("checking fixed/RDW evidence registry commit ancestry")?;
+    match ancestor_check.status.code() {
+        Some(0) => {}
+        Some(1) => {
+            bail!(
+                "fixed/RDW evidence was verified against `{sha}`, which is not an ancestor of HEAD"
+            )
+        }
+        other => bail!(
+            "git merge-base failed while checking fixed/RDW evidence ancestry (exit {other:?}): {}",
+            String::from_utf8_lossy(&ancestor_check.stderr).trim()
+        ),
     }
 
-    let relevant_paths_changed = !Command::new("git")
+    let diff_check = Command::new("git")
         .current_dir(root)
-        .args([
-            "diff",
-            "--quiet",
-            &format!("{sha}..HEAD"),
-            "--",
-            "crates/copybook-codec",
-            "tests/e2e",
-        ])
-        .status()
-        .context("checking fixed/RDW evidence source drift")?
-        .success();
-    if relevant_paths_changed {
-        bail!(
+        .args(["diff", "--quiet", &format!("{sha}..HEAD"), "--"])
+        .args(RECORD_PIPELINE_SOURCE_PATHS)
+        .output()
+        .context("checking fixed/RDW evidence source drift")?;
+    match diff_check.status.code() {
+        Some(0) => {}
+        Some(1) => bail!(
             "fixed/RDW evidence source paths changed after verified commit `{sha}`; update the registry"
-        );
+        ),
+        other => bail!(
+            "git diff failed while checking fixed/RDW evidence source drift (exit {other:?}): {}",
+            String::from_utf8_lossy(&diff_check.stderr).trim()
+        ),
     }
     Ok(())
 }
@@ -357,6 +377,7 @@ fn is_shallow_repository(root: &Path) -> Result<bool> {
 fn verify_record_pipeline_scenarios(
     root: &Path,
     scenarios: &[RecordPipelineScenario],
+    error_codes: &[String],
 ) -> Result<()> {
     let mut scenario_ids = BTreeSet::new();
     for scenario in scenarios {
@@ -365,6 +386,16 @@ fn verify_record_pipeline_scenarios(
         }
         if scenario.record_formats.is_empty() {
             bail!("scenario `{}` has no record format", scenario.id);
+        }
+        if scenario
+            .record_formats
+            .iter()
+            .any(|format| !matches!(format.as_str(), "fixed" | "rdw"))
+        {
+            bail!(
+                "scenario `{}` contains a record format outside the fixed/RDW scope",
+                scenario.id
+            );
         }
         if scenario.api_tests.is_empty() && scenario.cli_tests.is_empty() {
             bail!("scenario `{}` has no test anchor", scenario.id);
@@ -382,9 +413,9 @@ fn verify_record_pipeline_scenarios(
             verify_test_anchor(root, anchor, &scenario.id)?;
         }
         for error_code in &scenario.error_codes {
-            if error_code.len() < 7 || !error_code.starts_with("CBK") {
+            if !error_codes.contains(error_code) {
                 bail!(
-                    "scenario `{}` has malformed stable error code `{error_code}`",
+                    "scenario `{}` references unknown stable error code `{error_code}`",
                     scenario.id
                 );
             }
@@ -403,7 +434,13 @@ fn verify_test_anchor(root: &Path, anchor: &str, scenario_id: &str) -> Result<()
     let source = fs::read_to_string(&source_path)
         .with_context(|| format!("loading test anchor `{anchor}` for scenario `{scenario_id}`"))?;
     let function_anchor = format!("fn {symbol}");
-    if !source.contains(&function_anchor) {
+    let declares_function = source.match_indices(&function_anchor).any(|(index, _)| {
+        source[index + function_anchor.len()..]
+            .chars()
+            .next()
+            .is_none_or(|next| !next.is_alphanumeric() && next != '_')
+    });
+    if !declares_function {
         bail!("scenario `{scenario_id}` anchor `{anchor}` does not name an existing function");
     }
     Ok(())
@@ -3231,6 +3268,54 @@ mod tests {
             "format.fixed.basic",
         );
         assert!(result.is_err(), "missing test anchor must be rejected");
+    }
+
+    #[test]
+    fn record_pipeline_anchor_accepts_exact_function_name() {
+        let root = tempfile::tempdir().expect("create temporary workspace");
+        fs::create_dir_all(root.path().join("tests")).expect("create anchor fixture directory");
+        let source_path = root.path().join("tests/anchors.rs");
+        fs::write(
+            &source_path,
+            "fn exact_anchor() {}\nfn exact_anchor_parallel() {}\n",
+        )
+        .expect("write anchor fixture");
+
+        verify_test_anchor(
+            root.path(),
+            "tests/anchors.rs::exact_anchor",
+            "format.rdw.odo_variable",
+        )
+        .expect("exact function anchor must be accepted");
+        assert!(
+            verify_test_anchor(
+                root.path(),
+                "tests/anchors.rs::exact_anchor_missing",
+                "format.rdw.odo_variable",
+            )
+            .is_err(),
+            "prefix collision must not satisfy an anchor"
+        );
+    }
+
+    #[test]
+    fn record_pipeline_scenarios_accept_valid_row() {
+        let root = tempfile::tempdir().expect("create temporary workspace");
+        fs::create_dir_all(root.path().join("tests")).expect("create anchor fixture directory");
+        let source_path = root.path().join("tests/anchors.rs");
+        fs::write(&source_path, "fn valid_anchor() {}\n").expect("write anchor fixture");
+        let scenarios = vec![RecordPipelineScenario {
+            id: "format.fixed.basic".to_string(),
+            record_formats: vec!["fixed".to_string()],
+            api_tests: vec!["tests/anchors.rs::valid_anchor".to_string()],
+            cli_tests: Vec::new(),
+            error_codes: Vec::new(),
+            cli_commands: Vec::new(),
+            known_limitation: "fixture-only acceptance row".to_string(),
+        }];
+
+        verify_record_pipeline_scenarios(root.path(), &scenarios, &[])
+            .expect("valid scenario row must be accepted");
     }
 
     #[test]

--- a/tools/xtask/src/docs_verify.rs
+++ b/tools/xtask/src/docs_verify.rs
@@ -19,7 +19,7 @@ use xtask::perf;
 type Verifier = (&'static str, fn() -> Result<()>);
 
 pub(crate) fn run() -> Result<()> {
-    let checks: [Verifier; 15] = [
+    let checks: [Verifier; 16] = [
         (
             "workspace-version-and-msrv",
             verify_workspace_version_and_msrv,
@@ -30,6 +30,7 @@ pub(crate) fn run() -> Result<()> {
             verify_copybook_rs_redirect_invariant,
         ),
         ("error-code-inventory", verify_error_code_inventory),
+        ("record-pipeline-evidence", verify_record_pipeline_evidence),
         ("test-status", verify_test_status_if_present),
         ("support-matrix", verify_support_matrix),
         (
@@ -60,6 +61,10 @@ pub(crate) fn run() -> Result<()> {
 pub(crate) fn run_contracts_command() -> Result<()> {
     generate_stable_contract_manifest()
         .and_then(|manifest| persist_stable_contract_manifest(&manifest))
+}
+
+pub(crate) fn verify_record_pipeline_command() -> Result<()> {
+    verify_record_pipeline_evidence()
 }
 
 pub(crate) fn run_freeze_contract_checks() -> Result<()> {
@@ -187,6 +192,7 @@ fn workspace_root() -> PathBuf {
 
 const STABILITY_SCHEMA_VERSION: &str = "1.0.0";
 const STABILITY_REGISTRY_PATH: &str = "docs/stability/surface-registry.json";
+const RECORD_PIPELINE_EVIDENCE_PATH: &str = "docs/evidence/fixed-rdw-pipeline.toml";
 const STABLE_CONTRACT_SCHEMA_VERSION: &str = "1.0.0";
 const STABLE_CONTRACT_MANIFEST_PATH: &str = "docs/contracts/stable-surface-contract.json";
 const STABLE_CONTRACT_SOURCE_PATHS: [&str; 6] = [
@@ -227,6 +233,180 @@ struct ContractCliInventory {
 #[derive(Debug, Serialize, Deserialize)]
 struct ContractErrorInventory {
     variants: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RecordPipelineEvidence {
+    schema_version: u32,
+    scope: String,
+    verified_against: String,
+    scenarios: Vec<RecordPipelineScenario>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RecordPipelineScenario {
+    id: String,
+    record_formats: Vec<String>,
+    api_tests: Vec<String>,
+    cli_tests: Vec<String>,
+    error_codes: Vec<String>,
+    cli_commands: Vec<String>,
+    known_limitation: String,
+}
+
+fn verify_record_pipeline_evidence() -> Result<()> {
+    let root = workspace_root();
+    let registry_path = root.join(RECORD_PIPELINE_EVIDENCE_PATH);
+    let source = fs::read_to_string(&registry_path).with_context(|| {
+        format!(
+            "loading fixed/RDW evidence registry {}",
+            registry_path.display()
+        )
+    })?;
+    let registry: RecordPipelineEvidence =
+        toml::from_str(&source).with_context(|| format!("parsing {}", registry_path.display()))?;
+
+    if registry.schema_version != 1 {
+        bail!(
+            "unsupported fixed/RDW evidence registry schema version {}",
+            registry.schema_version
+        );
+    }
+    if registry.scope != "fixed-rdw-pipeline" {
+        bail!(
+            "unexpected fixed/RDW evidence registry scope `{}`",
+            registry.scope
+        );
+    }
+    if registry.scenarios.is_empty() {
+        bail!("fixed/RDW evidence registry contains no scenarios");
+    }
+
+    let sha = registry.verified_against.trim();
+    if sha.len() != 40 || !sha.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        bail!("verified_against must be a 40-character commit SHA, found `{sha}`");
+    }
+
+    let commit_exists = Command::new("git")
+        .current_dir(&root)
+        .args(["cat-file", "-e", &format!("{sha}^{{commit}}")])
+        .status()
+        .context("checking fixed/RDW evidence registry commit")?
+        .success();
+    if commit_exists {
+        verify_record_pipeline_commit_ancestry(&root, sha)?;
+    } else if !is_shallow_repository(&root)? {
+        bail!("fixed/RDW evidence registry commit `{sha}` is not available");
+    } else {
+        println!(
+            "fixed/RDW evidence commit `{sha}` unavailable in shallow checkout; ancestry and drift checks skipped"
+        );
+    }
+
+    verify_record_pipeline_scenarios(&root, &registry.scenarios)?;
+
+    println!(
+        "fixed/RDW evidence registry verified: {} scenarios at {}",
+        registry.scenarios.len(),
+        sha
+    );
+    Ok(())
+}
+
+fn verify_record_pipeline_commit_ancestry(root: &Path, sha: &str) -> Result<()> {
+    let verified_commit_is_ancestor = Command::new("git")
+        .current_dir(root)
+        .args(["merge-base", "--is-ancestor", sha, "HEAD"])
+        .status()
+        .context("checking fixed/RDW evidence registry commit ancestry")?
+        .success();
+    if !verified_commit_is_ancestor {
+        bail!("fixed/RDW evidence was verified against `{sha}`, which is not an ancestor of HEAD");
+    }
+
+    let relevant_paths_changed = !Command::new("git")
+        .current_dir(root)
+        .args([
+            "diff",
+            "--quiet",
+            &format!("{sha}..HEAD"),
+            "--",
+            "crates/copybook-codec",
+            "tests/e2e",
+        ])
+        .status()
+        .context("checking fixed/RDW evidence source drift")?
+        .success();
+    if relevant_paths_changed {
+        bail!(
+            "fixed/RDW evidence source paths changed after verified commit `{sha}`; update the registry"
+        );
+    }
+    Ok(())
+}
+
+fn is_shallow_repository(root: &Path) -> Result<bool> {
+    let output = Command::new("git")
+        .current_dir(root)
+        .args(["rev-parse", "--is-shallow-repository"])
+        .output()
+        .context("checking repository depth for fixed/RDW evidence")?;
+    Ok(output.status.success() && String::from_utf8_lossy(&output.stdout).trim() == "true")
+}
+
+fn verify_record_pipeline_scenarios(
+    root: &Path,
+    scenarios: &[RecordPipelineScenario],
+) -> Result<()> {
+    let mut scenario_ids = BTreeSet::new();
+    for scenario in scenarios {
+        if !scenario_ids.insert(&scenario.id) {
+            bail!("duplicate fixed/RDW evidence scenario `{}`", scenario.id);
+        }
+        if scenario.record_formats.is_empty() {
+            bail!("scenario `{}` has no record format", scenario.id);
+        }
+        if scenario.api_tests.is_empty() && scenario.cli_tests.is_empty() {
+            bail!("scenario `{}` has no test anchor", scenario.id);
+        }
+        if scenario.cli_tests.is_empty() != scenario.cli_commands.is_empty() {
+            bail!(
+                "scenario `{}` must keep CLI command and CLI test anchors in sync",
+                scenario.id
+            );
+        }
+        if scenario.known_limitation.trim().is_empty() {
+            bail!("scenario `{}` has no limitation statement", scenario.id);
+        }
+        for anchor in scenario.api_tests.iter().chain(&scenario.cli_tests) {
+            verify_test_anchor(root, anchor, &scenario.id)?;
+        }
+        for error_code in &scenario.error_codes {
+            if error_code.len() < 7 || !error_code.starts_with("CBK") {
+                bail!(
+                    "scenario `{}` has malformed stable error code `{error_code}`",
+                    scenario.id
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn verify_test_anchor(root: &Path, anchor: &str, scenario_id: &str) -> Result<()> {
+    let (path, symbol) = anchor.rsplit_once("::").ok_or_else(|| {
+        anyhow::anyhow!(
+            "scenario `{scenario_id}` has malformed test anchor `{anchor}`; expected path::function"
+        )
+    })?;
+    let source_path = root.join(path);
+    let source = fs::read_to_string(&source_path)
+        .with_context(|| format!("loading test anchor `{anchor}` for scenario `{scenario_id}`"))?;
+    let function_anchor = format!("fn {symbol}");
+    if !source.contains(&function_anchor) {
+        bail!("scenario `{scenario_id}` anchor `{anchor}` does not name an existing function");
+    }
+    Ok(())
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -3029,6 +3209,28 @@ mod tests {
             output_deprecated_keys.contains("__raw_b64"),
             "surface deprecation audit missing deprecated output key `__raw_b64`"
         );
+    }
+
+    #[test]
+    fn record_pipeline_registry_rejects_missing_required_fields() {
+        let result = toml::from_str::<RecordPipelineEvidence>(
+            "schema_version = 1\nscope = 'fixed-rdw-pipeline'\n",
+        );
+        assert!(
+            result.is_err(),
+            "incomplete evidence registry must be rejected"
+        );
+    }
+
+    #[test]
+    fn record_pipeline_anchor_rejects_missing_file() {
+        let root = tempfile::tempdir().expect("create temporary workspace");
+        let result = verify_test_anchor(
+            root.path(),
+            "tests/missing.rs::missing_test",
+            "format.fixed.basic",
+        );
+        assert!(result.is_err(), "missing test anchor must be rejected");
     }
 
     #[test]

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -23,6 +23,7 @@ fn main() -> Result<()> {
         ["docs", "sync-tests"] => sync(),
         ["docs", "verify-tests"] => verify(),
         ["docs", "verify-all"] => docs_verify::run(),
+        ["docs", "verify-record-pipeline"] => docs_verify::verify_record_pipeline_command(),
         ["docs", "verify-support-matrix"] => verify_support_matrix(),
         ["docs", "freeze", "contracts"] => docs_verify::run_freeze_contract_checks(),
         ["docs", "contracts", "generate"] => docs_verify::run_contracts_command(),
@@ -86,6 +87,7 @@ fn usage() {
          docs sync-tests                     Sync test status from junit.xml\n\
          docs verify-tests                   Verify test status is in sync\n\
          docs verify-all                     Verify all source-of-truth documentation invariants\n\
+         docs verify-record-pipeline         Verify fixed/RDW evidence registry anchors\n\
          docs freeze contracts               Verify freeze-sensitive contracts (strict, API surface contract guard)\n\
          docs contracts generate             Regenerate stable contract manifest baseline\n\
          docs verify-support-matrix          Verify support matrix registry -> docs\n\

--- a/tools/xtask/tests/xtask_tests.rs
+++ b/tools/xtask/tests/xtask_tests.rs
@@ -71,6 +71,15 @@ fn usage_lists_docs_verify_support_matrix() {
 }
 
 #[test]
+fn usage_lists_docs_verify_record_pipeline() {
+    let output = std::process::Command::new(xtask_bin())
+        .output()
+        .expect("failed to run xtask");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("docs verify-record-pipeline"));
+}
+
+#[test]
 fn usage_lists_docs_contracts_generate() {
     let output = std::process::Command::new(xtask_bin())
         .output()


### PR DESCRIPTION
## What this does

Adds a machine-verifiable fixed/RDW pipeline evidence registry for the current-main reconciliation lane behind issues #572 and #652.

The registry makes nine bounded scenario rows explicit, verifies their exact API/CLI test anchors, checks the recorded commit ancestry and source-path drift, and runs as part of `docs verify-all`. It is intentionally not a replacement for the complete stable-error registry requested by #576.

## Review map

Read `docs/evidence/fixed-rdw-pipeline.toml` first for the nine scenario rows, then `tools/xtask/src/docs_verify.rs` for schema, anchor, ancestry, and drift validation. The README/index changes expose the source-truth artifact, and the generated report updates the current test receipt.

## Verification

| Check | Result |
| --- | --- |
| `cargo run --offline -p xtask -- docs verify-record-pipeline` | 9 scenarios verified at `87e6f1986e7b894412480359cb50baea8c406645` |
| `cargo run --offline -p xtask -- docs verify-all` | passed |
| `cargo test --offline -p xtask --test xtask_tests` | passed |
| `cargo clippy --offline -p xtask --all-targets -- -D warnings` | passed |
| `cargo nextest run --offline --workspace --exclude copybook-bdd --exclude copybook-bench --profile ci --no-fail-fast` | 9,928 passed, 6 skipped |
| `cargo fmt --all -- --check` and `git diff --check` | passed |

The full workspace nextest invocation still cannot list the existing Cucumber BDD harness because two scenario names do not use the harness's required `: test`/`: benchmark` suffix; the bounded canonical workspace receipt above excludes that harness and the benchmark crate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated conformance results to reflect 9,928/9,928 passing tests.
  * Added evidence links and a registry documenting fixed/RDW pipeline coverage and limitations.

* **New Features**
  * Added the `docs verify-record-pipeline` command to validate pipeline evidence, test coverage, formats, and error-code consistency.

* **Tests**
  * Added coverage for malformed evidence registries, missing test anchors, and command help output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->