### PR TITLE
test(xtask): inventory stable error taxonomy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ Start with **[START_HERE.md](START_HERE.md)** for the hand-maintained navigation
 ### Evidence
 
 - [Fixed/RDW pipeline registry](evidence/fixed-rdw-pipeline.toml) -- current-main scenario and test-anchor evidence
+- [Stable error registry](evidence/stable-errors.toml) -- taxonomy coverage and reserved-code status
 
 ### Diataxis Framework
 Documentation follows [Diataxis](https://diataxis.fr/). Category indexes:

--- a/docs/evidence/stable-errors.toml
+++ b/docs/evidence/stable-errors.toml
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Stable error taxonomy inventory for issue #576.
+#
+# This slice establishes exact taxonomy coverage and distinguishes the two
+# intentionally reserved float identifiers. Direct trigger ownership is
+# recorded incrementally; `pending` is an explicit residual, not proof.
+schema_version = 1
+scope = "stable-errors"
+
+[[errors]]
+code = "CBKP001_SYNTAX"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKP011_UNSUPPORTED_CLAUSE"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKP021_ODO_NOT_TAIL"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKP022_NESTED_ODO"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKP023_ODO_REDEFINES"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKP051_UNSUPPORTED_EDITED_PIC"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKP101_INVALID_PIC"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKS121_COUNTER_NOT_FOUND"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKS141_RECORD_TOO_LARGE"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKS301_ODO_CLIPPED"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKS302_ODO_RAISED"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKS601_RENAME_UNKNOWN_FROM"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKS602_RENAME_UNKNOWN_THRU"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKS603_RENAME_NOT_CONTIGUOUS"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKS604_RENAME_REVERSED_RANGE"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKS605_RENAME_FROM_CROSSES_GROUP"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKS606_RENAME_THRU_CROSSES_GROUP"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKS607_RENAME_CROSSES_OCCURS"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKS608_RENAME_QUALIFIED_NAME_NOT_FOUND"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKS609_RENAME_OVER_REDEFINES"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKS610_RENAME_MULTIPLE_REDEFINES"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKS611_RENAME_PARTIAL_OCCURS"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKS612_RENAME_ODO_NOT_SUPPORTED"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKS701_PROJECTION_INVALID_ODO"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKS702_PROJECTION_UNRESOLVED_ALIAS"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKS703_PROJECTION_FIELD_NOT_FOUND"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKR101_FIXED_RECORD_ERROR"
+stability_class = "stable"
+evidence_status = "direct"
+[[errors]]
+code = "CBKR201_RDW_READ_ERROR"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKR202_RDW_WRITE_ERROR"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKR211_RDW_RESERVED_NONZERO"
+stability_class = "stable"
+evidence_status = "direct"
+[[errors]]
+code = "CBKC201_JSON_WRITE_ERROR"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKC301_INVALID_EBCDIC_BYTE"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKD101_INVALID_FIELD_TYPE"
+stability_class = "stable"
+evidence_status = "direct"
+[[errors]]
+code = "CBKD301_RECORD_TOO_SHORT"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKD302_EDITED_PIC_NOT_IMPLEMENTED"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKD401_COMP3_INVALID_NIBBLE"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKD410_ZONED_OVERFLOW"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKD411_ZONED_BAD_SIGN"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKD412_ZONED_BLANK_IS_ZERO"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKD413_ZONED_INVALID_ENCODING"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKD414_ZONED_MIXED_ENCODING"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKD415_ZONED_ENCODING_AMBIGUOUS"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKD421_EDITED_PIC_INVALID_FORMAT"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKD422_EDITED_PIC_SIGN_MISMATCH"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKD423_EDITED_PIC_BLANK_WHEN_ZERO"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKD431_FLOAT_NAN"
+stability_class = "reserved"
+evidence_status = "pending"
+[[errors]]
+code = "CBKD432_FLOAT_INFINITY"
+stability_class = "reserved"
+evidence_status = "pending"
+[[errors]]
+code = "CBKI001_INVALID_STATE"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKE501_JSON_TYPE_MISMATCH"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKE505_SCALE_MISMATCH"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKE510_NUMERIC_OVERFLOW"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKE515_STRING_LENGTH_VIOLATION"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKE521_ARRAY_LEN_OOB"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKE530_SIGN_SEPARATE_ENCODE_ERROR"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKE531_FLOAT_ENCODE_OVERFLOW"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKF001_FILE_READ_ERROR"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKF102_RECORD_LENGTH_INVALID"
+stability_class = "stable"
+evidence_status = "direct"
+[[errors]]
+code = "CBKF104_RDW_SUSPECT_ASCII"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKF221_RDW_UNDERFLOW"
+stability_class = "stable"
+evidence_status = "direct"
+[[errors]]
+code = "CBKA001_BASELINE_ERROR"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKW001_SCHEMA_CONVERSION"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKW002_TYPE_MAPPING"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKW003_DECIMAL_OVERFLOW"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKW004_BATCH_BUILD"
+stability_class = "stable"
+evidence_status = "pending"
+[[errors]]
+code = "CBKW005_PARQUET_WRITE"
+stability_class = "stable"
+evidence_status = "pending"

--- a/tools/xtask/src/docs_verify.rs
+++ b/tools/xtask/src/docs_verify.rs
@@ -19,7 +19,7 @@ use xtask::perf;
 type Verifier = (&'static str, fn() -> Result<()>);
 
 pub(crate) fn run() -> Result<()> {
-    let checks: [Verifier; 16] = [
+    let checks: [Verifier; 17] = [
         (
             "workspace-version-and-msrv",
             verify_workspace_version_and_msrv,
@@ -30,6 +30,7 @@ pub(crate) fn run() -> Result<()> {
             verify_copybook_rs_redirect_invariant,
         ),
         ("error-code-inventory", verify_error_code_inventory),
+        ("stable-error-registry", verify_stable_error_registry),
         ("record-pipeline-evidence", verify_record_pipeline_evidence),
         ("test-status", verify_test_status_if_present),
         ("support-matrix", verify_support_matrix),
@@ -65,6 +66,10 @@ pub(crate) fn run_contracts_command() -> Result<()> {
 
 pub(crate) fn verify_record_pipeline_command() -> Result<()> {
     verify_record_pipeline_evidence()
+}
+
+pub(crate) fn verify_stable_error_registry_command() -> Result<()> {
+    verify_stable_error_registry()
 }
 
 pub(crate) fn run_freeze_contract_checks() -> Result<()> {
@@ -1718,6 +1723,121 @@ fn verify_error_code_inventory() -> Result<()> {
     Ok(())
 }
 
+const STABLE_ERROR_REGISTRY_PATH: &str = "docs/evidence/stable-errors.toml";
+
+#[derive(Debug, Deserialize)]
+struct StableErrorRegistry {
+    schema_version: u32,
+    scope: String,
+    errors: Vec<StableErrorEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StableErrorEntry {
+    code: String,
+    stability_class: String,
+    evidence_status: String,
+}
+
+fn verify_stable_error_registry() -> Result<()> {
+    let root = workspace_root();
+    let path = root.join(STABLE_ERROR_REGISTRY_PATH);
+    let source = fs::read_to_string(&path)
+        .with_context(|| format!("loading stable error registry {}", path.display()))?;
+    let registry: StableErrorRegistry =
+        toml::from_str(&source).with_context(|| format!("parsing {}", path.display()))?;
+    if registry.schema_version != 1 {
+        bail!(
+            "unsupported stable error registry schema version {}",
+            registry.schema_version
+        );
+    }
+    if registry.scope != "stable-errors" {
+        bail!(
+            "unexpected stable error registry scope `{}`",
+            registry.scope
+        );
+    }
+
+    let error_source = fs::read_to_string(root.join("crates/copybook-error/src/lib.rs"))
+        .context("loading crates/copybook-error/src/lib.rs")?;
+    let expected: BTreeSet<String> = parse_error_code_variants(&error_source)?
+        .into_iter()
+        .collect();
+    validate_stable_error_registry(&registry, &expected)?;
+    println!(
+        "stable error registry verified: {} codes ({} direct, {} pending)",
+        registry.errors.len(),
+        registry
+            .errors
+            .iter()
+            .filter(|entry| entry.evidence_status == "direct")
+            .count(),
+        registry
+            .errors
+            .iter()
+            .filter(|entry| entry.evidence_status == "pending")
+            .count()
+    );
+    Ok(())
+}
+
+fn validate_stable_error_registry(
+    registry: &StableErrorRegistry,
+    expected: &BTreeSet<String>,
+) -> Result<()> {
+    let mut seen = BTreeSet::new();
+    for entry in &registry.errors {
+        if !seen.insert(entry.code.clone()) {
+            bail!("duplicate stable error registry entry `{}`", entry.code);
+        }
+        if !expected.contains(&entry.code) {
+            bail!(
+                "stable error registry references unknown code `{}`",
+                entry.code
+            );
+        }
+        if !matches!(entry.stability_class.as_str(), "stable" | "reserved") {
+            bail!(
+                "stable error registry entry `{}` has invalid stability class `{}`",
+                entry.code,
+                entry.stability_class
+            );
+        }
+        if !matches!(entry.evidence_status.as_str(), "pending" | "direct") {
+            bail!(
+                "stable error registry entry `{}` has invalid evidence status `{}`",
+                entry.code,
+                entry.evidence_status
+            );
+        }
+        let reserved = matches!(
+            entry.code.as_str(),
+            "CBKD431_FLOAT_NAN" | "CBKD432_FLOAT_INFINITY"
+        );
+        if reserved != (entry.stability_class == "reserved") {
+            bail!(
+                "stable error registry entry `{}` disagrees with the reserved-code policy",
+                entry.code
+            );
+        }
+        if reserved && entry.evidence_status == "direct" {
+            bail!(
+                "reserved error `{}` cannot claim direct evidence",
+                entry.code
+            );
+        }
+    }
+    if &seen != expected {
+        let missing: BTreeSet<_> = expected.difference(&seen).collect();
+        let extra: BTreeSet<_> = seen.difference(expected).collect();
+        bail!(
+            "stable error registry coverage drift: missing={missing:?} unknown={extra:?} | authoritative-source=crates/copybook-error/src/lib.rs and {STABLE_ERROR_REGISTRY_PATH}"
+        );
+    }
+    Ok(())
+}
+
 fn verify_performance_floor_and_receipt() -> Result<()> {
     let policy_text = fs::read_to_string("docs/PERFORMANCE_GOVERNANCE.md")
         .context("loading docs/PERFORMANCE_GOVERNANCE.md")?;
@@ -3316,6 +3436,29 @@ mod tests {
 
         verify_record_pipeline_scenarios(root.path(), &scenarios, &[])
             .expect("valid scenario row must be accepted");
+    }
+
+    #[test]
+    fn stable_error_registry_rejects_missing_taxonomy_entry() {
+        let registry: StableErrorRegistry = toml::from_str(
+            "schema_version = 1\nscope = 'stable-errors'\n\n[[errors]]\ncode = 'CBKP001_SYNTAX'\nstability_class = 'stable'\nevidence_status = 'pending'\n",
+        )
+        .expect("parse registry fixture");
+        let expected = BTreeSet::from([
+            "CBKP001_SYNTAX".to_string(),
+            "CBKP011_UNSUPPORTED_CLAUSE".to_string(),
+        ]);
+        assert!(validate_stable_error_registry(&registry, &expected).is_err());
+    }
+
+    #[test]
+    fn stable_error_registry_rejects_direct_reserved_evidence() {
+        let registry: StableErrorRegistry = toml::from_str(
+            "schema_version = 1\nscope = 'stable-errors'\n\n[[errors]]\ncode = 'CBKD431_FLOAT_NAN'\nstability_class = 'reserved'\nevidence_status = 'direct'\n",
+        )
+        .expect("parse registry fixture");
+        let expected = BTreeSet::from(["CBKD431_FLOAT_NAN".to_string()]);
+        assert!(validate_stable_error_registry(&registry, &expected).is_err());
     }
 
     #[test]

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -24,6 +24,7 @@ fn main() -> Result<()> {
         ["docs", "verify-tests"] => verify(),
         ["docs", "verify-all"] => docs_verify::run(),
         ["docs", "verify-record-pipeline"] => docs_verify::verify_record_pipeline_command(),
+        ["docs", "verify-stable-errors"] => docs_verify::verify_stable_error_registry_command(),
         ["docs", "verify-support-matrix"] => verify_support_matrix(),
         ["docs", "freeze", "contracts"] => docs_verify::run_freeze_contract_checks(),
         ["docs", "contracts", "generate"] => docs_verify::run_contracts_command(),
@@ -88,6 +89,7 @@ fn usage() {
          docs verify-tests                   Verify test status is in sync\n\
          docs verify-all                     Verify all source-of-truth documentation invariants\n\
          docs verify-record-pipeline         Verify fixed/RDW evidence registry anchors\n\
+         docs verify-stable-errors            Verify stable error taxonomy registry\n\
          docs freeze contracts               Verify freeze-sensitive contracts (strict, API surface contract guard)\n\
          docs contracts generate             Regenerate stable contract manifest baseline\n\
          docs verify-support-matrix          Verify support matrix registry -> docs\n\

--- a/tools/xtask/tests/xtask_tests.rs
+++ b/tools/xtask/tests/xtask_tests.rs
@@ -80,6 +80,15 @@ fn usage_lists_docs_verify_record_pipeline() {
 }
 
 #[test]
+fn usage_lists_docs_verify_stable_errors() {
+    let output = std::process::Command::new(xtask_bin())
+        .output()
+        .expect("failed to run xtask");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("docs verify-stable-errors"));
+}
+
+#[test]
 fn usage_lists_docs_contracts_generate() {
     let output = std::process::Command::new(xtask_bin())
         .output()


### PR DESCRIPTION
## What this does

The stable-error coordinator currently has no machine-readable inventory that can distinguish emitted identifiers from the two reserved float codes. This makes taxonomy drift and false evidence claims difficult to detect.

**Change:** add a 65-entry registry and an xtask verifier that requires exact coverage of `ErrorCode`, enforces the reserved-code policy, and records whether direct trigger evidence is present or still pending. Existing product behavior and public error identities are unchanged.

## Verification

| Check | Result |
| --- | --- |
| stable registry verifier | 65 codes verified, 5 direct, 60 pending |
| verifier rejection tests | missing taxonomy entry and direct reserved evidence rejected |
| xtask command test | `docs verify-stable-errors` listed and dispatched |
| `cargo clippy --offline -p xtask --all-targets -- -D warnings` | clean |
| `cargo fmt --all`, `git diff --check` | clean |

## Review map

- `docs/evidence/stable-errors.toml`: canonical taxonomy inventory; pending rows are explicit residuals, not completion claims.
- `tools/xtask/src/docs_verify.rs`: exact enum coverage, duplicate/unknown detection, stable/reserved validation, and direct-evidence guard for reserved codes.
- `tools/xtask/src/main.rs`: standalone `docs verify-stable-errors` command and `verify-all` integration.
- `tools/xtask/src/docs_verify.rs` tests: malformed coverage and reserved-code negative controls.

## Out of scope

- Direct trigger metadata for the 60 pending rows remains follow-up work under #576 and related bounded evidence lanes.
- The #653 typed option-parse error contract is not inferred or changed.
