### PR TITLE
test(xtask): anchor parser schema error evidence

### DIFF
--- a/docs/evidence/stable-errors.toml
+++ b/docs/evidence/stable-errors.toml
@@ -10,7 +10,8 @@ scope = "stable-errors"
 [[errors]]
 code = "CBKP001_SYNTAX"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbkp001_syntax_garbage_parse"
 [[errors]]
 code = "CBKP011_UNSUPPORTED_CLAUSE"
 stability_class = "stable"
@@ -22,7 +23,8 @@ evidence_status = "pending"
 [[errors]]
 code = "CBKP022_NESTED_ODO"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbkp022_nested_odo"
 [[errors]]
 code = "CBKP023_ODO_REDEFINES"
 stability_class = "stable"
@@ -38,7 +40,8 @@ evidence_status = "pending"
 [[errors]]
 code = "CBKS121_COUNTER_NOT_FOUND"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbks121_counter_not_found"
 [[errors]]
 code = "CBKS141_RECORD_TOO_LARGE"
 stability_class = "stable"
@@ -54,11 +57,13 @@ evidence_status = "pending"
 [[errors]]
 code = "CBKS601_RENAME_UNKNOWN_FROM"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbks601_rename_unknown_from"
 [[errors]]
 code = "CBKS602_RENAME_UNKNOWN_THRU"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbks602_rename_unknown_thru"
 [[errors]]
 code = "CBKS603_RENAME_NOT_CONTIGUOUS"
 stability_class = "stable"


### PR DESCRIPTION
## Summary\n\nAdd exact direct-trigger anchors for five stable parser/schema errors already covered by CLI behavior tests:\n\n- CBKP001_SYNTAX\n- CBKP022_NESTED_ODO\n- CBKS121_COUNTER_NOT_FOUND\n- CBKS601_RENAME_UNKNOWN_FROM\n- CBKS602_RENAME_UNKNOWN_THRU\n\nReview map = reading order, not file inventory:\n\n- docs/evidence/stable-errors.toml — promote only rows whose tests execute copybook and assert the exact emitted identifier.\n- No product/API behavior changes.\n\n## Verification\n\n| Check | Result |\n| --- | --- |\n| Five CLI direct-trigger tests with the canonical copybook binary path | pass |\n| cargo test -p xtask --lib docs_verify -- --nocapture | pass |\n| cargo run -p xtask -- docs verify-stable-errors | pass: 65 codes, 10 direct, 55 pending |\n| cargo fmt --all -- --check | pass |\n| git diff --check | pass |\n\nResidual: issue #576 remains open. 55 registry rows remain pending direct-trigger evidence, with scenario links, CLI exit/remediation mapping, and taxonomy-wide reconciliation still outstanding. This PR does not alter the maintainer-owned #653 option-parse contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved stable error documentation for five syntax, nesting, counter, and rename-related errors.
  * Added direct evidence references and corresponding end-to-end coverage information to make error behavior easier to verify.
  * Replaced duplicate information for one rename-related error with the correct supporting details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->