### PR TITLE
test(xtask): anchor projection error evidence

### DIFF
--- a/docs/evidence/stable-errors.toml
+++ b/docs/evidence/stable-errors.toml
@@ -19,7 +19,8 @@ evidence_status = "pending"
 [[errors]]
 code = "CBKP021_ODO_NOT_TAIL"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbkp021_odo_not_tail"
 [[errors]]
 code = "CBKP022_NESTED_ODO"
 stability_class = "stable"
@@ -28,7 +29,8 @@ direct_test = "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbkp022_nested_odo"
 [[errors]]
 code = "CBKP023_ODO_REDEFINES"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbkp023_odo_redefines"
 [[errors]]
 code = "CBKP051_UNSUPPORTED_EDITED_PIC"
 stability_class = "stable"
@@ -71,7 +73,8 @@ evidence_status = "pending"
 [[errors]]
 code = "CBKS604_RENAME_REVERSED_RANGE"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbks604_rename_reversed_range"
 [[errors]]
 code = "CBKS605_RENAME_FROM_CROSSES_GROUP"
 stability_class = "stable"
@@ -83,7 +86,8 @@ evidence_status = "pending"
 [[errors]]
 code = "CBKS607_RENAME_CROSSES_OCCURS"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbks607_rename_crosses_occurs"
 [[errors]]
 code = "CBKS608_RENAME_QUALIFIED_NAME_NOT_FOUND"
 stability_class = "stable"
@@ -115,7 +119,8 @@ evidence_status = "pending"
 [[errors]]
 code = "CBKS703_PROJECTION_FIELD_NOT_FOUND"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbks703_projection_not_found_decode"
 [[errors]]
 code = "CBKR101_FIXED_RECORD_ERROR"
 stability_class = "stable"


### PR DESCRIPTION
## Summary\n\nAdd exact direct-trigger anchors for five stable parser/schema/projection identifiers already asserted by CLI behavior tests:\n\n- CBKP021_ODO_NOT_TAIL\n- CBKP023_ODO_REDEFINES\n- CBKS604_RENAME_REVERSED_RANGE\n- CBKS607_RENAME_CROSSES_OCCURS\n- CBKS703_PROJECTION_FIELD_NOT_FOUND\n\nReview map = reading order, not file inventory:\n\n- docs/evidence/stable-errors.toml — promote only rows whose CLI tests execute the product path and assert the exact stable identifier.\n- No product or public API behavior changes.\n\n## Verification\n\n| Check | Result |\n| --- | --- |\n| Five CLI direct-trigger tests with canonical copybook binary path | pass |\n| cargo run -p xtask -- docs verify-stable-errors | pass: 65 codes, 15 direct, 50 pending |\n| cargo fmt --all -- --check | pass |\n| git diff --check | pass |\n\nResidual: issue #576 remains open. 50 registry rows remain pending direct-trigger evidence or truthful reserved classification, with scenario links, CLI exit/remediation mapping, and taxonomy-wide reconciliation still outstanding. This PR does not alter the maintainer-owned #653 option-parse contract.