### PR TITLE
test(xtask): anchor numeric format error evidence

### DIFF
--- a/docs/evidence/stable-errors.toml
+++ b/docs/evidence/stable-errors.toml
@@ -163,7 +163,8 @@ evidence_status = "pending"
 [[errors]]
 code = "CBKD401_COMP3_INVALID_NIBBLE"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbkd401_comp3_invalid_nibble_decode"
 [[errors]]
 code = "CBKD410_ZONED_OVERFLOW"
 stability_class = "stable"
@@ -171,7 +172,8 @@ evidence_status = "pending"
 [[errors]]
 code = "CBKD411_ZONED_BAD_SIGN"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbkd411_zoned_bad_sign_decode"
 [[errors]]
 code = "CBKD412_ZONED_BLANK_IS_ZERO"
 stability_class = "stable"
@@ -191,7 +193,8 @@ evidence_status = "pending"
 [[errors]]
 code = "CBKD421_EDITED_PIC_INVALID_FORMAT"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbkd421_edited_pic_invalid_decode"
 [[errors]]
 code = "CBKD422_EDITED_PIC_SIGN_MISMATCH"
 stability_class = "stable"
@@ -252,7 +255,8 @@ direct_test = "tests/e2e/e2e_error_codes.rs::cbkf102_record_length_invalid"
 [[errors]]
 code = "CBKF104_RDW_SUSPECT_ASCII"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbkf104_rdw_suspect_ascii"
 [[errors]]
 code = "CBKF221_RDW_UNDERFLOW"
 stability_class = "stable"


### PR DESCRIPTION
## Summary\n\nAdd exact direct-trigger anchors for four stable numeric/record-format identifiers already asserted by CLI behavior tests:\n\n- CBKD401_COMP3_INVALID_NIBBLE\n- CBKD411_ZONED_BAD_SIGN\n- CBKD421_EDITED_PIC_INVALID_FORMAT\n- CBKF104_RDW_SUSPECT_ASCII\n\nReview map = reading order, not file inventory:\n\n- docs/evidence/stable-errors.toml — promote only rows whose CLI tests execute the product path and assert the exact stable identifier.\n- No product or public API behavior changes.\n- Generic encode-error tests remain pending because they currently assert only generic failure summaries, not stable identifiers.\n\n## Verification\n\n| Check | Result |\n| --- | --- |\n| Four CLI direct-trigger tests with canonical copybook binary path | pass |\n| cargo run -p xtask -- docs verify-stable-errors | pass: 65 codes, 19 direct, 46 pending |\n| cargo fmt --all -- --check | pass |\n| git diff --check | pass |\n\nResidual: issue #576 remains open. 46 registry rows remain pending direct-trigger evidence or truthful reserved classification, with scenario links, CLI exit/remediation mapping, and taxonomy-wide reconciliation still outstanding. This PR does not alter the maintainer-owned #653 option-parse contract.