### PR TITLE
test(xtask): anchor encode taxonomy evidence

### DIFF
--- a/docs/evidence/stable-errors.toml
+++ b/docs/evidence/stable-errors.toml
@@ -155,7 +155,8 @@ direct_test = "tests/e2e/e2e_error_code_coverage.rs::error_cbkd101_invalid_field
 [[errors]]
 code = "CBKD301_RECORD_TOO_SHORT"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_error_taxonomy_complete.rs::cbkd301_record_too_short"
 [[errors]]
 code = "CBKD302_EDITED_PIC_NOT_IMPLEMENTED"
 stability_class = "stable"
@@ -218,19 +219,23 @@ evidence_status = "pending"
 [[errors]]
 code = "CBKE501_JSON_TYPE_MISMATCH"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_error_taxonomy_complete.rs::cbke501_json_type_mismatch"
 [[errors]]
 code = "CBKE505_SCALE_MISMATCH"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_error_taxonomy_complete.rs::cbke505_scale_mismatch"
 [[errors]]
 code = "CBKE510_NUMERIC_OVERFLOW"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_error_taxonomy_complete.rs::cbke510_numeric_overflow"
 [[errors]]
 code = "CBKE515_STRING_LENGTH_VIOLATION"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_error_taxonomy_complete.rs::cbke515_string_length_violation"
 [[errors]]
 code = "CBKE521_ARRAY_LEN_OOB"
 stability_class = "stable"


### PR DESCRIPTION
## Summary\n\nAdd exact direct-trigger anchors for five stable decode/encode identifiers already asserted by taxonomy behavior tests:\n\n- CBKD301_RECORD_TOO_SHORT\n- CBKE501_JSON_TYPE_MISMATCH\n- CBKE505_SCALE_MISMATCH\n- CBKE510_NUMERIC_OVERFLOW\n- CBKE515_STRING_LENGTH_VIOLATION\n\nReview map = reading order, not file inventory:\n\n- docs/evidence/stable-errors.toml — promote only rows whose behavior tests execute the product path and assert the exact stable identifier.\n- No product or public API behavior changes.\n\n## Verification\n\n| Check | Result |\n| --- | --- |\n| Five taxonomy direct-trigger tests | pass |\n| cargo run -p xtask -- docs verify-stable-errors | pass: 65 codes, 24 direct, 41 pending |\n| cargo fmt --all -- --check | pass |\n| git diff --check | pass |\n\nResidual: issue #576 remains open. 41 registry rows remain pending direct-trigger evidence or truthful reserved classification, with scenario links, CLI exit/remediation mapping, and taxonomy-wide reconciliation still outstanding. This PR does not alter the maintainer-owned #653 option-parse contract.