### PR TITLE
test(xtask): anchor remaining taxonomy evidence

### DIFF
--- a/docs/evidence/stable-errors.toml
+++ b/docs/evidence/stable-errors.toml
@@ -51,7 +51,8 @@ evidence_status = "pending"
 [[errors]]
 code = "CBKS301_ODO_CLIPPED"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_error_taxonomy_complete.rs::cbks301_odo_clipped"
 [[errors]]
 code = "CBKS302_ODO_RAISED"
 stability_class = "stable"
@@ -199,7 +200,8 @@ direct_test = "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbkd421_edited_pic_
 [[errors]]
 code = "CBKD422_EDITED_PIC_SIGN_MISMATCH"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_error_taxonomy_complete.rs::cbkd422_edited_pic_sign_mismatch"
 [[errors]]
 code = "CBKD423_EDITED_PIC_BLANK_WHEN_ZERO"
 stability_class = "stable"
@@ -215,7 +217,8 @@ evidence_status = "pending"
 [[errors]]
 code = "CBKI001_INVALID_STATE"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_error_taxonomy_complete.rs::cbki001_invalid_state_no_lrecl"
 [[errors]]
 code = "CBKE501_JSON_TYPE_MISMATCH"
 stability_class = "stable"
@@ -243,11 +246,13 @@ evidence_status = "pending"
 [[errors]]
 code = "CBKE530_SIGN_SEPARATE_ENCODE_ERROR"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_error_taxonomy_complete.rs::cbke530_sign_separate_encode_error"
 [[errors]]
 code = "CBKE531_FLOAT_ENCODE_OVERFLOW"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_error_taxonomy_complete.rs::cbke531_float_encode_overflow"
 [[errors]]
 code = "CBKF001_FILE_READ_ERROR"
 stability_class = "stable"


### PR DESCRIPTION
## Summary\n\nAdd exact direct-trigger anchors for five stable schema/decode/encode/internal identifiers already asserted by taxonomy behavior tests:\n\n- CBKS301_ODO_CLIPPED\n- CBKD422_EDITED_PIC_SIGN_MISMATCH\n- CBKI001_INVALID_STATE\n- CBKE530_SIGN_SEPARATE_ENCODE_ERROR\n- CBKE531_FLOAT_ENCODE_OVERFLOW\n\nReview map = reading order, not file inventory:\n\n- docs/evidence/stable-errors.toml — promote only rows whose behavior tests execute the product path and assert the exact stable identifier.\n- No product or public API behavior changes.\n- CBKD423 remains pending because its current test does not establish a direct emitted-trigger contract.\n\n## Verification\n\n| Check | Result |\n| --- | --- |\n| Five taxonomy direct-trigger tests | pass |\n| cargo run -p xtask -- docs verify-stable-errors | pass: 65 codes, 29 direct, 36 pending |\n| cargo fmt --all -- --check | pass |\n| git diff --check | pass |\n\nResidual: issue #576 remains open. 36 registry rows remain pending direct-trigger evidence or truthful reserved classification, with scenario links, CLI exit/remediation mapping, and taxonomy-wide reconciliation still outstanding. This PR does not alter the maintainer-owned #653 option-parse contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated evidence records for five stable error scenarios.
  * Added end-to-end test references covering clipped data, signature mismatches, invalid states, encoding errors, and floating-point overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->