### PR TITLE
test(xtask): anchor io charset error evidence

### DIFF
--- a/docs/evidence/stable-errors.toml
+++ b/docs/evidence/stable-errors.toml
@@ -56,7 +56,8 @@ direct_test = "tests/e2e/e2e_error_taxonomy_complete.rs::cbks301_odo_clipped"
 [[errors]]
 code = "CBKS302_ODO_RAISED"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "crates/copybook-codec/src/odo_redefines.rs::test_odo_validation_lenient_mode_raise_min"
 [[errors]]
 code = "CBKS601_RENAME_UNKNOWN_FROM"
 stability_class = "stable"
@@ -130,11 +131,13 @@ direct_test = "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbkr101_fixed_recor
 [[errors]]
 code = "CBKR201_RDW_READ_ERROR"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "crates/copybook-record-io/tests/dispatch_deep.rs::error_rdw_read_io_failure"
 [[errors]]
 code = "CBKR202_RDW_WRITE_ERROR"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "crates/copybook-record-io/tests/dispatch_deep.rs::error_rdw_write_io_failure"
 [[errors]]
 code = "CBKR211_RDW_RESERVED_NONZERO"
 stability_class = "stable"
@@ -147,7 +150,8 @@ evidence_status = "pending"
 [[errors]]
 code = "CBKC301_INVALID_EBCDIC_BYTE"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "crates/copybook-charset/tests/charset_edge_cases.rs::non_printable_byte_0x00_error_policy_fails_cp037"
 [[errors]]
 code = "CBKD101_INVALID_FIELD_TYPE"
 stability_class = "stable"
@@ -256,7 +260,8 @@ direct_test = "tests/e2e/e2e_error_taxonomy_complete.rs::cbke531_float_encode_ov
 [[errors]]
 code = "CBKF001_FILE_READ_ERROR"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_cli_exit_codes.rs::missing_copybook_names_the_file_and_exits_4"
 [[errors]]
 code = "CBKF102_RECORD_LENGTH_INVALID"
 stability_class = "stable"


### PR DESCRIPTION
## Summary

Anchors five existing stable error contracts in the canonical evidence registry:

- `CBKS302_ODO_RAISED`
- `CBKR201_RDW_READ_ERROR`
- `CBKR202_RDW_WRITE_ERROR`
- `CBKC301_INVALID_EBCDIC_BYTE`
- `CBKF001_FILE_READ_ERROR`

No product or public API behavior changes.

## Review map

Review map = reading order, not file inventory:

1. `docs/evidence/stable-errors.toml` — registry transitions and exact test anchors.
2. `crates/copybook-codec/src/odo_redefines.rs` — direct ODO raise assertion.
3. `crates/copybook-record-io/tests/dispatch_deep.rs` — direct RDW read/write I/O assertions.
4. `crates/copybook-charset/tests/charset_edge_cases.rs` — direct invalid EBCDIC-byte assertion.
5. `tests/e2e/e2e_cli_exit_codes.rs` — direct file-read code and exit-4 assertion.

## Verification

| Proof | Result |
| --- | --- |
| `cargo run -p xtask -- docs verify-stable-errors` | pass: 65 codes, 34 direct, 31 pending |
| Focused record-I/O tests | pass: RDW read and write |
| Focused charset test | pass: invalid EBCDIC byte |
| Focused codec test | pass: ODO lenient raise-min |
| Focused e2e test | pass: missing copybook file-read/exit-4 |
| `cargo fmt --all -- --check` | pass |
| `git diff --check` | pass |

Residual work remains tracked in issue #576; this PR only advances the registry evidence boundary.