### PR TITLE
test(xtask): anchor rename projection error evidence

### DIFF
--- a/docs/evidence/stable-errors.toml
+++ b/docs/evidence/stable-errors.toml
@@ -80,7 +80,8 @@ direct_test = "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbks604_rename_reve
 [[errors]]
 code = "CBKS605_RENAME_FROM_CROSSES_GROUP"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "crates/copybook-core/tests/renames_resolver_negative_tests.rs::renames_from_crosses_group"
 [[errors]]
 code = "CBKS606_RENAME_THRU_CROSSES_GROUP"
 stability_class = "stable"
@@ -101,7 +102,8 @@ evidence_status = "pending"
 [[errors]]
 code = "CBKS610_RENAME_MULTIPLE_REDEFINES"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "crates/copybook-core/tests/error_code_coverage_tests.rs::test_cbks610_multiple_redefines_with_r4r6_flag"
 [[errors]]
 code = "CBKS611_RENAME_PARTIAL_OCCURS"
 stability_class = "stable"
@@ -109,15 +111,18 @@ evidence_status = "pending"
 [[errors]]
 code = "CBKS612_RENAME_ODO_NOT_SUPPORTED"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "crates/copybook-core/tests/renames_r4_r6_bdd_tests.rs::test_r5_renames_odo_rejected"
 [[errors]]
 code = "CBKS701_PROJECTION_INVALID_ODO"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_error_taxonomy_complete.rs::cbks701_projection_invalid_odo"
 [[errors]]
 code = "CBKS702_PROJECTION_UNRESOLVED_ALIAS"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_error_taxonomy_complete.rs::cbks702_projection_unresolved_alias"
 [[errors]]
 code = "CBKS703_PROJECTION_FIELD_NOT_FOUND"
 stability_class = "stable"


### PR DESCRIPTION
## Summary

Anchors five existing parser and projection error contracts in the canonical evidence registry:

- `CBKS605_RENAME_FROM_CROSSES_GROUP`
- `CBKS610_RENAME_MULTIPLE_REDEFINES`
- `CBKS612_RENAME_ODO_NOT_SUPPORTED`
- `CBKS701_PROJECTION_INVALID_ODO`
- `CBKS702_PROJECTION_UNRESOLVED_ALIAS`

No product or public API behavior changes.

## Review map

Review map = reading order, not file inventory:

1. `docs/evidence/stable-errors.toml` — registry transitions and exact anchors.
2. `crates/copybook-core/tests/renames_resolver_negative_tests.rs` — group-boundary rejection.
3. `crates/copybook-core/tests/error_code_coverage_tests.rs` — multiple-REDEFINES rejection.
4. `crates/copybook-core/tests/renames_r4_r6_bdd_tests.rs` — ODO RENAMES rejection.
5. `tests/e2e/e2e_error_taxonomy_complete.rs` — projection invalid-ODO and unresolved-alias errors.

## Verification

| Proof | Result |
| --- | --- |
| `cargo run -p xtask -- docs verify-stable-errors` | pass: 65 codes, 39 direct, 26 pending |
| Focused parser/core tests | pass: CBKS605, CBKS610, CBKS612 |
| Focused projection e2e tests | pass: CBKS701, CBKS702 |
| `cargo fmt --all -- --check` | pass |
| `git diff --check` | pass |

Residual work remains tracked in issue #576; this PR only advances the registry evidence boundary.