### PR TITLE
test(xtask): anchor rename zoned error evidence

### DIFF
--- a/docs/evidence/stable-errors.toml
+++ b/docs/evidence/stable-errors.toml
@@ -85,7 +85,8 @@ direct_test = "crates/copybook-core/tests/renames_resolver_negative_tests.rs::re
 [[errors]]
 code = "CBKS606_RENAME_THRU_CROSSES_GROUP"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "crates/copybook-core/tests/renames_resolver_negative_tests.rs::renames_thru_crosses_group"
 [[errors]]
 code = "CBKS607_RENAME_CROSSES_OCCURS"
 stability_class = "stable"
@@ -98,7 +99,8 @@ evidence_status = "pending"
 [[errors]]
 code = "CBKS609_RENAME_OVER_REDEFINES"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "crates/copybook-core/tests/renames_r4_r6_bdd_tests.rs::test_r4_renames_over_redefines_rejected_when_flag_disabled"
 [[errors]]
 code = "CBKS610_RENAME_MULTIPLE_REDEFINES"
 stability_class = "stable"
@@ -107,7 +109,8 @@ direct_test = "crates/copybook-core/tests/error_code_coverage_tests.rs::test_cbk
 [[errors]]
 code = "CBKS611_RENAME_PARTIAL_OCCURS"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "crates/copybook-core/tests/error_code_coverage_tests.rs::test_cbks611_partial_occurs_with_r4r6_flag"
 [[errors]]
 code = "CBKS612_RENAME_ODO_NOT_SUPPORTED"
 stability_class = "stable"
@@ -192,11 +195,13 @@ evidence_status = "pending"
 [[errors]]
 code = "CBKD413_ZONED_INVALID_ENCODING"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "crates/copybook-core/tests/zoned_encoding_error_codes_tests.rs::test_cbkd413_zoned_invalid_encoding"
 [[errors]]
 code = "CBKD414_ZONED_MIXED_ENCODING"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "crates/copybook-core/tests/zoned_encoding_error_codes_tests.rs::test_cbkd414_zoned_mixed_encoding"
 [[errors]]
 code = "CBKD415_ZONED_ENCODING_AMBIGUOUS"
 stability_class = "stable"


### PR DESCRIPTION
## Summary

Anchors five existing rename and zoned-decoding error contracts in the canonical evidence registry:

- `CBKS606_RENAME_THRU_CROSSES_GROUP`
- `CBKS609_RENAME_OVER_REDEFINES`
- `CBKS611_RENAME_PARTIAL_OCCURS`
- `CBKD413_ZONED_INVALID_ENCODING`
- `CBKD414_ZONED_MIXED_ENCODING`

No product or public API behavior changes.

## Review map

Review map = reading order, not file inventory:

1. `docs/evidence/stable-errors.toml` — registry transitions and exact anchors.
2. `crates/copybook-core/tests/renames_resolver_negative_tests.rs` — RENAMES thru-group rejection.
3. `crates/copybook-core/tests/renames_r4_r6_bdd_tests.rs` — RENAMES over REDEFINES rejection.
4. `crates/copybook-core/tests/error_code_coverage_tests.rs` — partial OCCURS rejection.
5. `crates/copybook-core/tests/zoned_encoding_error_codes_tests.rs` — invalid and mixed zoned encoding identifiers.

## Verification

| Proof | Result |
| --- | --- |
| `cargo run -p xtask -- docs verify-stable-errors` | pass: 65 codes, 44 direct, 21 pending |
| Focused parser/core tests | pass: CBKS606, CBKS609, CBKS611 |
| Focused zoned-code tests | pass: CBKD413, CBKD414 |
| `cargo fmt --all -- --check` | pass |
| `git diff --check` | pass |

Residual work remains tracked in issue #576; this PR only advances the registry evidence boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated stable error classifications for five validation scenarios.
  * Added direct test references supporting the documented error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->