### PR TITLE
test(xtask): anchor parser output error evidence

### DIFF
--- a/crates/copybook-codec/tests/record_io_microcrate_integration.rs
+++ b/crates/copybook-codec/tests/record_io_microcrate_integration.rs
@@ -144,6 +144,32 @@ fn codec_dispatch_output_decodes_with_codec() {
 }
 
 #[test]
+fn decode_jsonl_output_write_failure_reports_cbkc201() {
+    let schema = parse_copybook(
+        r"
+        01 SIMPLE-RECORD PIC X(5).
+    ",
+    )
+    .expect("schema should parse");
+
+    let options = DecodeOptions::new()
+        .with_format(RecordFormat::Fixed)
+        .with_codepage(Codepage::ASCII);
+    let mut output = FailingWriter;
+
+    let error = decode_file_to_jsonl(
+        &schema,
+        Cursor::new(b"HELLO".as_slice()),
+        &mut output,
+        &options,
+    )
+    .expect_err("JSONL output failure should be surfaced");
+
+    assert_eq!(error.code, ErrorCode::CBKC201_JSON_WRITE_ERROR);
+    assert!(error.message.contains("simulated write failure"));
+}
+
+#[test]
 fn codec_lossless_rdw_dispatch_preserves_reserved_header_bytes() {
     let wire = [0x00, 0x05, 0x12, 0x34, b'H', b'E', b'L', b'L', b'O'];
     let mut input = Cursor::new(wire);

--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -4,7 +4,7 @@
 # the complete stable-error registry requested by issue #576.
 schema_version = 1
 scope = "fixed-rdw-pipeline"
-verified_against = "87e6f1986e7b894412480359cb50baea8c406645"
+verified_against = "2af3faccb82216580a21677cb25ad124aa4c54ea"
 
 [[scenarios]]
 id = "format.fixed.basic"

--- a/docs/evidence/stable-errors.toml
+++ b/docs/evidence/stable-errors.toml
@@ -15,7 +15,8 @@ direct_test = "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbkp001_syntax_garb
 [[errors]]
 code = "CBKP011_UNSUPPORTED_CLAUSE"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_cli_feature_flags.rs::disable_comp1_rejects_comp1_copybook"
 [[errors]]
 code = "CBKP021_ODO_NOT_TAIL"
 stability_class = "stable"
@@ -34,7 +35,8 @@ direct_test = "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbkp023_odo_redefin
 [[errors]]
 code = "CBKP051_UNSUPPORTED_EDITED_PIC"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "tests/e2e/e2e_cli_feature_flags.rs::disable_sign_separate_rejects_sign_separate_copybook"
 [[errors]]
 code = "CBKP101_INVALID_PIC"
 stability_class = "stable"
@@ -155,7 +157,8 @@ direct_test = "tests/e2e/e2e_error_codes.rs::cbkr211_rdw_reserved_nonzero"
 [[errors]]
 code = "CBKC201_JSON_WRITE_ERROR"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "crates/copybook-codec/tests/record_io_microcrate_integration.rs::decode_jsonl_output_write_failure_reports_cbkc201"
 [[errors]]
 code = "CBKC301_INVALID_EBCDIC_BYTE"
 stability_class = "stable"

--- a/tests/e2e/e2e_cli_feature_flags.rs
+++ b/tests/e2e/e2e_cli_feature_flags.rs
@@ -166,6 +166,10 @@ fn disable_comp1_rejects_comp1_copybook() {
     );
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
+        stderr.contains("CBKP011_UNSUPPORTED_CLAUSE"),
+        "disabled COMP-1 must report CBKP011, got: {stderr}"
+    );
+    assert!(
         stderr.contains("COMP-1") || stderr.contains("comp_1"),
         "error should mention COMP-1 or comp_1, got: {stderr}"
     );
@@ -185,6 +189,10 @@ fn disable_sign_separate_rejects_sign_separate_copybook() {
         "parse should fail when sign_separate is disabled"
     );
     let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("CBKP051_UNSUPPORTED_EDITED_PIC"),
+        "disabled SIGN SEPARATE must report CBKP051, got: {stderr}"
+    );
     assert!(
         stderr.contains("SIGN") || stderr.contains("sign_separate"),
         "error should mention SIGN, got: {stderr}"


### PR DESCRIPTION
## Summary

Make three existing user-visible error paths assert their exact stable codes and register those anchors as direct evidence. No runtime behavior changes.

## Review map

- `tests/e2e/e2e_cli_feature_flags.rs`: assert exact `CBKP011_UNSUPPORTED_CLAUSE` for disabled `COMP-1` and `CBKP051_UNSUPPORTED_EDITED_PIC` for disabled `SIGN SEPARATE`.
- `crates/copybook-codec/tests/record_io_microcrate_integration.rs`: add a failing-output-writer regression for exact `CBKC201_JSON_WRITE_ERROR`.
- `docs/evidence/stable-errors.toml`: register the three exact anchors.

## Verification

| Proof | Result |
| --- | --- |
| `cargo test -p copybook-e2e --test e2e_cli_feature_flags disable_comp1_rejects_comp1_copybook` with `CARGO_BIN_EXE_copybook` | pass |
| `cargo test -p copybook-e2e --test e2e_cli_feature_flags disable_sign_separate_rejects_sign_separate_copybook` with `CARGO_BIN_EXE_copybook` | pass |
| `cargo test -p copybook-codec --test record_io_microcrate_integration decode_jsonl_output_write_failure_reports_cbkc201` | pass |
| `cargo run -p xtask -- docs verify-stable-errors` | pass: 65 codes, 50 direct, 15 pending |
| `cargo fmt --all -- --check` | pass |
| `git diff --check` | pass |

`CBKP101` remains pending because current production code does not emit it; non-emitted, warning-only, reserved, and Arrow-specific entries remain outside this lane.