### PR TITLE
docs(xtask): anchor fixed-rdw evidence to main

### DIFF
--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -4,7 +4,7 @@
 # the complete stable-error registry requested by issue #576.
 schema_version = 1
 scope = "fixed-rdw-pipeline"
-verified_against = "2af3faccb82216580a21677cb25ad124aa4c54ea"
+verified_against = "63dbeb52b1348d46fb77ab32681394fc29382075"
 
 [[scenarios]]
 id = "format.fixed.basic"


### PR DESCRIPTION
## Summary

Refresh the fixed/RDW evidence registry anchor to the actual squash-merge commit on `main` after PR #735. This is source-truth metadata only.

## Review map

- `docs/evidence/fixed-rdw-pipeline.toml`: set `verified_against` to `63dbeb52b1348d46fb77ab32681394fc29382075`, the current-main commit containing the covered source changes.

## Verification

| Proof | Result |
| --- | --- |
| `cargo run -p xtask -- docs verify-record-pipeline` | pass: 9 scenarios at current main |
| `cargo run -p xtask -- docs verify-stable-errors` | pass: 65 codes, 50 direct, 15 pending |
| `cargo fmt --all -- --check` | pass |
| `git diff --check` | pass |

This closes the ancestry drift detected by the docs-truth gate after PR #735.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the verified commit reference for the fixed RDW pipeline documentation.
  * No changes were made to exported or public functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->