### PR TITLE
test(xtask): anchor zoned overflow evidence

### DIFF
--- a/docs/evidence/stable-errors.toml
+++ b/docs/evidence/stable-errors.toml
@@ -186,7 +186,8 @@ direct_test = "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbkd401_comp3_inval
 [[errors]]
 code = "CBKD410_ZONED_OVERFLOW"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "crates/copybook-codec/tests/numeric_sign_separate_comprehensive.rs::test_sign_separate_large_number"
 [[errors]]
 code = "CBKD411_ZONED_BAD_SIGN"
 stability_class = "stable"


### PR DESCRIPTION
## Summary

Promote the existing exact SIGN SEPARATE zoned-decimal overflow trigger into the stable-error evidence registry. No runtime behavior changes.

## Review map

- `docs/evidence/stable-errors.toml`: mark `CBKD410_ZONED_OVERFLOW` direct and record its exact test anchor.

## Verification

| Proof | Result |
| --- | --- |
| `cargo test -p copybook-codec --features comprehensive-tests --test numeric_sign_separate_comprehensive test_sign_separate_large_number` | pass |
| `cargo run -p xtask -- docs verify-stable-errors` | pass: 65 codes, 51 direct, 14 pending |
| `cargo fmt --all -- --check` | pass |
| `git diff --check` | pass |

Warning-only, reserved, vestigial, non-emitted, and Arrow-specific entries remain pending.