### PR TITLE
fix(core): honor qualified renames paths

### DIFF
--- a/crates/copybook-core/src/layout.rs
+++ b/crates/copybook-core/src/layout.rs
@@ -688,18 +688,39 @@ fn detect_tail_odo(schema: &mut Schema, context: &LayoutContext, dialect: Dialec
     }
 }
 
-fn head_ident_of_qname(q: &str) -> &str {
-    // QNAME ::= IDENT ('OF' IDENT)* — current implementation uses only the head IDENT.
-    q.split_whitespace().next().unwrap_or(q)
+fn qname_parts(q: &str) -> Vec<&str> {
+    q.split_whitespace()
+        .filter(|part| !part.eq_ignore_ascii_case("OF"))
+        .collect()
+}
+
+fn qname_matches_field(qname: &str, field: &crate::schema::Field) -> bool {
+    let parts = qname_parts(qname);
+    if parts.len() == 1 {
+        return field.name.trim().eq_ignore_ascii_case(parts[0].trim());
+    }
+
+    let path_parts: Vec<&str> = field.path.split('.').collect();
+    if parts.len() > path_parts.len() {
+        return false;
+    }
+
+    parts
+        .iter()
+        .zip(path_parts.iter().rev())
+        .all(|(requested, actual)| requested.eq_ignore_ascii_case(actual))
+}
+
+fn is_qualified_qname(q: &str) -> bool {
+    qname_parts(q).len() > 1
 }
 
 fn find_sibling_index_by_qname(siblings: &[crate::schema::Field], qname: &str) -> Option<usize> {
-    let needle = head_ident_of_qname(qname).trim();
     siblings
         .iter()
         .enumerate()
         .filter(|(_, f)| f.level != 66 && f.level != 88) // storage-bearing fields only
-        .find(|(_, f)| f.name.trim().eq_ignore_ascii_case(needle))
+        .find(|(_, f)| qname_matches_field(qname, f))
         .map(|(i, _)| i)
 }
 
@@ -709,12 +730,9 @@ fn find_field_by_name<'a>(
     fields: &'a [crate::schema::Field],
     name: &str,
 ) -> Option<&'a crate::schema::Field> {
-    let needle = head_ident_of_qname(name).trim();
-
     for field in fields {
         // Check current field (exclude non-storage: 66, 88)
-        if field.level != 66 && field.level != 88 && field.name.trim().eq_ignore_ascii_case(needle)
-        {
+        if field.level != 66 && field.level != 88 && qname_matches_field(name, field) {
             return Some(field);
         }
 
@@ -837,8 +855,13 @@ fn resolve_renames_aliases(
             if is_nested_single_group {
                 // R3: Nested group RENAMES - find target anywhere in subtree
                 let target_field = find_field_by_name(fields, from_field).ok_or_else(|| {
+                    let code = if is_qualified_qname(from_field) {
+                        ErrorCode::CBKS608_RENAME_QUALIFIED_NAME_NOT_FOUND
+                    } else {
+                        ErrorCode::CBKS601_RENAME_UNKNOWN_FROM
+                    };
                     error!(
-                        ErrorCode::CBKS601_RENAME_UNKNOWN_FROM,
+                        code,
                         "RENAMES nested target field '{}' not found", from_field
                     )
                 })?;
@@ -859,16 +882,20 @@ fn resolve_renames_aliases(
 
             // R1/R2: Same-scope RENAMES - use sibling lookup
             let from_i = from_i_opt.ok_or_else(|| {
-                error!(
-                    ErrorCode::CBKS601_RENAME_UNKNOWN_FROM,
-                    "RENAMES from field '{}' not found", from_field
-                )
+                let code = if is_qualified_qname(from_field) {
+                    ErrorCode::CBKS608_RENAME_QUALIFIED_NAME_NOT_FOUND
+                } else {
+                    ErrorCode::CBKS601_RENAME_UNKNOWN_FROM
+                };
+                error!(code, "RENAMES from field '{}' not found", from_field)
             })?;
             let thru_i = thru_i_opt.ok_or_else(|| {
-                error!(
-                    ErrorCode::CBKS602_RENAME_UNKNOWN_THRU,
-                    "RENAMES thru field '{}' not found", thru_field
-                )
+                let code = if is_qualified_qname(thru_field) {
+                    ErrorCode::CBKS608_RENAME_QUALIFIED_NAME_NOT_FOUND
+                } else {
+                    ErrorCode::CBKS602_RENAME_UNKNOWN_THRU
+                };
+                error!(code, "RENAMES thru field '{}' not found", thru_field)
             })?;
 
             if from_i > thru_i {

--- a/crates/copybook-core/tests/error_code_coverage_tests.rs
+++ b/crates/copybook-core/tests/error_code_coverage_tests.rs
@@ -6,7 +6,7 @@
 //! - CBKS611_RENAME_PARTIAL_OCCURS: Partial array span in RENAMES (R5 flag)
 //! - CBKA001_BASELINE_ERROR: Performance baseline I/O error (audit feature)
 //!
-//! Note: CBKS603, CBKS608 are defined but never emitted by production code.
+//! Note: CBKS603 is defined but not emitted by production code yet.
 //! CBKD302 is vestigial (E2/E3 are now complete). CBKC201 is an I/O error
 //! that requires failing writes to trigger.
 

--- a/crates/copybook-core/tests/renames_resolver_negative_tests.rs
+++ b/crates/copybook-core/tests/renames_resolver_negative_tests.rs
@@ -47,6 +47,25 @@ fn renames_unknown_thru_field() {
     assert!(err.to_string().contains("UNKNOWN-FIELD"));
 }
 
+/// Test CBKS608: a qualified RENAMES path must resolve to the requested scope.
+#[test]
+fn renames_qualified_name_not_found() {
+    let cb = "
+01 ROOT-REC.
+   05 FIELD-A PIC X(5).
+   05 FIELD-B PIC 9(3).
+   66 ALIAS RENAMES FIELD-A OF WRONG-REC THRU FIELD-B OF WRONG-REC.
+";
+    let result = parse_copybook(cb);
+    assert!(
+        result.is_err(),
+        "Should fail when a qualified path is wrong"
+    );
+    let err = result.unwrap_err();
+    assert_eq!(err.code, ErrorCode::CBKS608_RENAME_QUALIFIED_NAME_NOT_FOUND);
+    assert!(err.to_string().contains("WRONG-REC"));
+}
+
 /// Test CBKS604: RENAMES reversed range (from comes after thru)
 #[test]
 fn renames_reversed_range() {
@@ -170,7 +189,7 @@ fn renames_thru_is_occurs() {
 
 /// Test R4: RENAMES range crosses REDEFINES (flag disabled)
 ///
-/// Note: With RenamesR4R6 disabled, any REDEFINES in the RENAMES span
+/// Note: With `RenamesR4R6` disabled, any REDEFINES in the RENAMES span
 /// is rejected with CBKS609, regardless of offset contiguity.
 #[test]
 fn renames_not_contiguous_gap() {

--- a/docs/evidence/stable-errors.toml
+++ b/docs/evidence/stable-errors.toml
@@ -98,7 +98,8 @@ direct_test = "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbks607_rename_cros
 [[errors]]
 code = "CBKS608_RENAME_QUALIFIED_NAME_NOT_FOUND"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "crates/copybook-core/tests/renames_resolver_negative_tests.rs::renames_qualified_name_not_found"
 [[errors]]
 code = "CBKS609_RENAME_OVER_REDEFINES"
 stability_class = "stable"


### PR DESCRIPTION
## What this does

A qualified RENAMES reference such as `FIELD-A OF WRONG-REC` could resolve by its head identifier alone, silently selecting `FIELD-A` from the wrong scope. That makes copybook input appear valid while violating the qualified-name contract.

**Fix:** match qualified names against the requested field-path suffix, preserve unqualified RENAMES lookup, and emit `CBKS608_RENAME_QUALIFIED_NAME_NOT_FOUND` when a qualified path does not resolve. Valid qualified RENAMES paths remain supported.

## Verification

| Check | Result |
| --- | --- |
| RENAMES comprehensive suite | 33 passed |
| RENAMES negative suite | 12 passed, 1 existing ignored |
| RENAMES positive suite | 6 passed |
| focused core Clippy and changed test-target Clippy | clean |
| stable-error verifier | 65 codes, 52 direct, 13 pending |
| formatting and diff checks | clean |
| package-wide core test-target Clippy | pre-existing `items_after_statements` errors in `golden_fixtures_ac4_sibling_after_odo_fail.rs`, outside this diff |

## Review map

- `crates/copybook-core/src/layout.rs`: qualified-path matching and CBKS608 selection for sibling and nested RENAMES resolution.
- `crates/copybook-core/tests/renames_resolver_negative_tests.rs`: wrong-qualifier regression and existing unknown-name contracts.
- `docs/evidence/stable-errors.toml`: promotes CBKS608 to direct evidence at the exact regression test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RENAMES field lookup for qualified names containing `OF`, including case-insensitive matching and nested field paths.
  * Added clearer errors when qualified RENAMES targets or scopes cannot be found.
  * Continued excluding non-storage fields from RENAMES resolution.

* **Tests**
  * Added coverage for invalid qualified scopes and verified the expected error details.

* **Documentation**
  * Updated error-code coverage and evidence records for qualified RENAMES failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->