### PR TITLE
fix(core): normalize nested renames qualifiers

### DIFF
--- a/crates/copybook-core/src/layout.rs
+++ b/crates/copybook-core/src/layout.rs
@@ -715,6 +715,16 @@ fn is_qualified_qname(q: &str) -> bool {
     qname_parts(q).len() > 1
 }
 
+fn qnames_equivalent(left: &str, right: &str) -> bool {
+    let left_parts = qname_parts(left);
+    let right_parts = qname_parts(right);
+    left_parts.len() == right_parts.len()
+        && left_parts
+            .iter()
+            .zip(right_parts.iter())
+            .all(|(left, right)| left.eq_ignore_ascii_case(right))
+}
+
 fn find_sibling_index_by_qname(siblings: &[crate::schema::Field], qname: &str) -> Option<usize> {
     siblings
         .iter()
@@ -849,8 +859,9 @@ fn resolve_renames_aliases(
             let thru_i_opt = find_sibling_index_by_qname(fields, thru_field);
 
             // Check if this is a nested single-group RENAMES (R3 case)
-            let is_nested_single_group =
-                from_i_opt.is_none() && thru_i_opt.is_none() && from_field == thru_field;
+            let is_nested_single_group = from_i_opt.is_none()
+                && thru_i_opt.is_none()
+                && qnames_equivalent(from_field, thru_field);
 
             if is_nested_single_group {
                 // R3: Nested group RENAMES - find target anywhere in subtree

--- a/crates/copybook-core/tests/renames_resolver_positive_tests.rs
+++ b/crates/copybook-core/tests/renames_resolver_positive_tests.rs
@@ -190,3 +190,36 @@ fn renames_r3_nested_group() {
     assert!(rr.members.iter().any(|p| p.contains("START-DATE")));
     assert!(rr.members.iter().any(|p| p.contains("END-DATE")));
 }
+
+#[test]
+fn renames_r3_nested_qualified_name_is_case_insensitive() {
+    let cb = "
+01 POLICY-RECORD.
+   05 POLICY-INFO.
+      10 POLICY-DATES.
+         15 START-DATE PIC X(8).
+         15 END-DATE PIC X(8).
+   66 POLICY-PERIOD RENAMES policy-dates OF policy-info OF policy-record THRU POLICY-DATES OF POLICY-INFO OF POLICY-RECORD.
+";
+    let schema = parse_copybook(cb).expect("parse ok");
+    let alias = schema.fields[0]
+        .children
+        .iter()
+        .find(|field| field.name == "POLICY-PERIOD")
+        .expect("POLICY-PERIOD alias");
+    let resolved = alias.resolved_renames.as_ref().expect("resolved renames");
+
+    assert_eq!(resolved.members.len(), 2);
+    assert!(
+        resolved
+            .members
+            .iter()
+            .any(|path| path.ends_with("START-DATE"))
+    );
+    assert!(
+        resolved
+            .members
+            .iter()
+            .any(|path| path.ends_with("END-DATE"))
+    );
+}


### PR DESCRIPTION
## What this does

Nested RENAMES detection already resolves qualifier paths case-insensitively, but its single-target check compared the raw `FROM` and `THRU` strings case-sensitively. Mixed-case equivalent qualified names therefore skipped the nested lookup.

**Fix:** compare normalized qualified-name parts case-insensitively before the existing nested resolution path. This preserves the prior resolver behavior and closes the actionable review finding from PR #739.

## Verification

| Check | Result |
| --- | --- |
| mixed-case nested qualified RENAMES regression | 1 passed |
| existing nested RENAMES regression | 1 passed |
| core library Clippy, pedantic | clean |
| changed positive test target Clippy, pedantic | clean |
| formatting and diff checks | clean |

## Review map

- `crates/copybook-core/src/layout.rs`: normalized qualifier equivalence selects the nested single-group resolver for case variants.
- `crates/copybook-core/tests/renames_resolver_positive_tests.rs`: mixed-case qualified nested RENAMES proof plus the existing behavior anchor.
