### PR TITLE
fix(core): enforce RENAMES byte contiguity

### DIFF
--- a/crates/copybook-core/src/layout.rs
+++ b/crates/copybook-core/src/layout.rs
@@ -1026,10 +1026,31 @@ fn resolve_renames_aliases(
                 }
             }
 
-            // Note: We do NOT enforce strict byte-level contiguity (CBKS603).
-            // COBOL RENAMES requires fields to be in source order within the same group,
-            // but REDEFINES can create overlapping offsets which is valid.
-            // The key validations are: same group, no OCCURS, no cross-branch, from before thru.
+            // Validate byte-level contiguity for ranges. Positive gaps are invalid,
+            // while overlapping offsets remain valid for supported REDEFINES layouts.
+            // Level-88 conditions and level-66 aliases consume no storage and do not
+            // interrupt the range.
+            if !is_single_group_rename {
+                let mut previous_storage_field: Option<&Field> = None;
+                for current in &fields[from_i..=thru_i] {
+                    if current.level == 66 || current.level == 88 {
+                        continue;
+                    }
+                    if let Some(previous) = previous_storage_field {
+                        let previous_end = u64::from(previous.offset) + u64::from(previous.len);
+                        if u64::from(current.offset) > previous_end {
+                            return Err(error!(
+                                ErrorCode::CBKS603_RENAME_NOT_CONTIGUOUS,
+                                "RENAMES alias '{}' has a byte gap between '{}' and '{}'",
+                                field.name,
+                                previous.name,
+                                current.name
+                            ));
+                        }
+                    }
+                    previous_storage_field = Some(current);
+                }
+            }
 
             // Compute (offset, length) and members (storage-bearing only).
             let offset = fields[from_i].offset;

--- a/crates/copybook-core/tests/error_code_coverage_tests.rs
+++ b/crates/copybook-core/tests/error_code_coverage_tests.rs
@@ -6,7 +6,6 @@
 //! - CBKS611_RENAME_PARTIAL_OCCURS: Partial array span in RENAMES (R5 flag)
 //! - CBKA001_BASELINE_ERROR: Performance baseline I/O error (audit feature)
 //!
-//! Note: CBKS603 is defined but not emitted by production code yet.
 //! CBKD302 is vestigial (E2/E3 are now complete). CBKC201 is an I/O error
 //! that requires failing writes to trigger.
 

--- a/crates/copybook-core/tests/renames_resolver_negative_tests.rs
+++ b/crates/copybook-core/tests/renames_resolver_negative_tests.rs
@@ -209,12 +209,25 @@ fn renames_not_contiguous_gap() {
     assert_eq!(err.code, ErrorCode::CBKS609_RENAME_OVER_REDEFINES);
 }
 
-/// Test CBKS603: Non-contiguous range with actual gap
-///
-/// This creates a scenario where fields are not adjacent in sibling order
-/// but we try to RENAMES across them. Due to how the parser works, this
-/// is hard to construct without OCCURS or groups, which are caught by other
-/// validations. This test documents the contiguity check behavior.
+/// Test CBKS603: Non-contiguous range with an actual alignment gap.
+#[test]
+fn renames_not_contiguous_alignment_gap() {
+    let cb = "
+01 ROOT-REC.
+   05 FIELD-A PIC X(1).
+   05 FIELD-B PIC 9(3) COMP SYNCHRONIZED.
+   66 ALIAS RENAMES FIELD-A THRU FIELD-B.
+";
+    let result = parse_copybook(cb);
+    assert!(
+        result.is_err(),
+        "An alignment gap should reject the RENAMES range"
+    );
+    let err = result.unwrap_err();
+    assert_eq!(err.code, ErrorCode::CBKS603_RENAME_NOT_CONTIGUOUS);
+}
+
+/// Level-88 conditions consume no storage and do not interrupt contiguity.
 #[test]
 fn renames_contiguity_check_with_level88() {
     let cb = "

--- a/docs/evidence/stable-errors.toml
+++ b/docs/evidence/stable-errors.toml
@@ -74,7 +74,8 @@ direct_test = "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbks602_rename_unkn
 [[errors]]
 code = "CBKS603_RENAME_NOT_CONTIGUOUS"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "crates/copybook-core/tests/renames_resolver_negative_tests.rs::renames_not_contiguous_alignment_gap"
 [[errors]]
 code = "CBKS604_RENAME_REVERSED_RANGE"
 stability_class = "stable"

--- a/docs/reference/COBOL_SUPPORT_MATRIX.md
+++ b/docs/reference/COBOL_SUPPORT_MATRIX.md
@@ -515,7 +515,7 @@ pub enum FieldKind {
 - **CBKS605/606**: Cross-group boundaries (from/thru have storage-bearing children)
 - **CBKS607**: OCCURS boundary violation (array in RENAMES range)
 - **CBKS608**: Qualified name resolution failure
-- **CBKS603**: Defined but NOT enforced (REDEFINES overlaps valid; source-order only)
+- **CBKS603**: Byte gaps in RENAMES ranges are rejected; overlapping offsets remain governed by the applicable REDEFINES policy
 
 **Layout Impact:** Level-66 fields consume zero bytes, implementing COBOL non-storage semantics. Resolver computes `(offset, length)` and populates `resolved_renames.members` with storage-bearing child paths.
 

--- a/docs/reference/ERROR_CODES.md
+++ b/docs/reference/ERROR_CODES.md
@@ -189,7 +189,7 @@ Field CUSTOMER-NAM not found in record scope
 **Description**: RENAMES range is not contiguous (gap between `from` and `THRU` fields)
 **Severity**: Fatal
 **Context**: RENAMES alias name, `from`/`THRU` field offsets
-**Resolution**: Adjust the RENAMES range so it covers a contiguous byte range. Note: strict byte-level contiguity is not currently enforced by layout resolution; this code is reserved for that validation.
+**Resolution**: Adjust the RENAMES range so it covers a contiguous byte range. Positive alignment gaps are rejected; overlapping offsets remain valid only where the applicable REDEFINES policy permits them.
 
 #### CBKS604_RENAME_REVERSED_RANGE
 **Description**: RENAMES range is reversed (`from` field starts after the `THRU` field)


### PR DESCRIPTION
## Summary

Closes no issue; this is the next bounded slice of #576.

`CBKS603_RENAME_NOT_CONTIGUOUS` is now emitted when a RENAMES range crosses a positive byte gap introduced by field alignment. Level-88 conditions and level-66 aliases remain zero-storage and do not interrupt contiguity. Overlapping offsets remain permitted for the existing supported REDEFINES policy.

Review map = reading order, not file inventory:

1. `crates/copybook-core/src/layout.rs` — enforce the resolved-offset gap predicate after existing group and REDEFINES validation.
2. `crates/copybook-core/tests/renames_resolver_negative_tests.rs` — prove an actual SYNCHRONIZED alignment gap is rejected and level-88 remains valid.
3. `docs/evidence/stable-errors.toml` — promote CBKS603 from pending to direct evidence.
4. `docs/reference/ERROR_CODES.md` and `docs/reference/COBOL_SUPPORT_MATRIX.md` — align the public contract with enforcement.

## Verification

| Check | Result |
| --- | --- |
| `cargo test -p copybook-core --test renames_resolver_negative_tests --test renames_resolver_positive_tests --test renames_comprehensive` | pass: 53 passed, 1 ignored |
| `cargo run -p xtask -- docs verify-stable-errors` | pass: 65 codes, 53 direct, 12 pending |
| `cargo clippy -p copybook-core --lib -- -D warnings -W clippy::pedantic` | pass |
| `cargo clippy -p copybook-core --test renames_resolver_negative_tests -- -D warnings -W clippy::pedantic` | pass |
| `git diff --check` | pass |
