### PR TITLE
fix(core): classify invalid PIC clauses

### DIFF
--- a/crates/copybook-codec/tests/panic_elimination_numeric_hotspot.rs
+++ b/crates/copybook-codec/tests/panic_elimination_numeric_hotspot.rs
@@ -526,7 +526,9 @@ mod zoned_overpunch_hotspot_safety {
                 assert!(
                     matches!(
                         error.code,
-                        ErrorCode::CBKP001_SYNTAX | ErrorCode::CBKP011_UNSUPPORTED_CLAUSE
+                        ErrorCode::CBKP001_SYNTAX
+                            | ErrorCode::CBKP011_UNSUPPORTED_CLAUSE
+                            | ErrorCode::CBKP101_INVALID_PIC
                     ),
                     "Edge case schema error should use CBKP* code, got {:?}",
                     error.code

--- a/crates/copybook-core/src/parser.rs
+++ b/crates/copybook-core/src/parser.rs
@@ -830,7 +830,12 @@ impl Parser {
         }
 
         let pic_str = pic_parts.join("");
-        let pic = PicClause::parse(&pic_str)?;
+        let pic = PicClause::parse(&pic_str).map_err(|mut err| {
+            if err.code == ErrorCode::CBKP001_SYNTAX {
+                err.code = ErrorCode::CBKP101_INVALID_PIC;
+            }
+            err
+        })?;
 
         field.kind = match pic.kind {
             crate::pic::PicKind::Alphanumeric => FieldKind::Alphanum {

--- a/crates/copybook-core/tests/panic_elimination_hotspot_units.rs
+++ b/crates/copybook-core/tests/panic_elimination_hotspot_units.rs
@@ -72,7 +72,9 @@ mod hotspot_parser_safety {
                 assert!(
                     matches!(
                         error.code,
-                        ErrorCode::CBKP001_SYNTAX | ErrorCode::CBKP011_UNSUPPORTED_CLAUSE
+                        ErrorCode::CBKP001_SYNTAX
+                            | ErrorCode::CBKP011_UNSUPPORTED_CLAUSE
+                            | ErrorCode::CBKP101_INVALID_PIC
                     ),
                     "Token bounds error should use CBKP* code, got {:?}",
                     error.code
@@ -407,6 +409,7 @@ mod hotspot_pic_safety {
                             ErrorCode::CBKP001_SYNTAX
                                 | ErrorCode::CBKP011_UNSUPPORTED_CLAUSE
                                 | ErrorCode::CBKP051_UNSUPPORTED_EDITED_PIC
+                                | ErrorCode::CBKP101_INVALID_PIC
                         ),
                         "PIC parsing error should use CBKP* code for '{}', got {:?}",
                         invalid_pic,
@@ -436,7 +439,9 @@ mod hotspot_pic_safety {
                 assert!(
                     matches!(
                         error.code,
-                        ErrorCode::CBKP001_SYNTAX | ErrorCode::CBKP011_UNSUPPORTED_CLAUSE
+                        ErrorCode::CBKP001_SYNTAX
+                            | ErrorCode::CBKP011_UNSUPPORTED_CLAUSE
+                            | ErrorCode::CBKP101_INVALID_PIC
                     ),
                     "Numeric PIC validation error should use CBKP* code for '{}', got {:?}",
                     invalid_pic,
@@ -465,7 +470,9 @@ mod hotspot_pic_safety {
                 assert!(
                     matches!(
                         error.code,
-                        ErrorCode::CBKP001_SYNTAX | ErrorCode::CBKP011_UNSUPPORTED_CLAUSE
+                        ErrorCode::CBKP001_SYNTAX
+                            | ErrorCode::CBKP011_UNSUPPORTED_CLAUSE
+                            | ErrorCode::CBKP101_INVALID_PIC
                     ),
                     "COMP usage validation error should use CBKP* code for '{}', got {:?}",
                     invalid_comp,
@@ -507,6 +514,7 @@ mod hotspot_pic_safety {
                             ErrorCode::CBKP001_SYNTAX
                                 | ErrorCode::CBKP011_UNSUPPORTED_CLAUSE
                                 | ErrorCode::CBKP051_UNSUPPORTED_EDITED_PIC
+                                | ErrorCode::CBKP101_INVALID_PIC
                         ),
                         "Complex PIC error should use CBKP* code for '{}', got {:?}",
                         complex_pic,

--- a/crates/copybook-core/tests/panic_elimination_tests.rs
+++ b/crates/copybook-core/tests/panic_elimination_tests.rs
@@ -96,7 +96,9 @@ mod panic_elimination_parser_tests {
                 assert!(
                     matches!(
                         error.code,
-                        ErrorCode::CBKP001_SYNTAX | ErrorCode::CBKP011_UNSUPPORTED_CLAUSE
+                        ErrorCode::CBKP001_SYNTAX
+                            | ErrorCode::CBKP011_UNSUPPORTED_CLAUSE
+                            | ErrorCode::CBKP101_INVALID_PIC
                     ),
                     "Position bounds error should use CBKP* error code, got {:?}",
                     error.code
@@ -417,7 +419,9 @@ mod panic_elimination_pic_tests {
                 assert!(
                     matches!(
                         error.code,
-                        ErrorCode::CBKP001_SYNTAX | ErrorCode::CBKP051_UNSUPPORTED_EDITED_PIC
+                        ErrorCode::CBKP001_SYNTAX
+                            | ErrorCode::CBKP051_UNSUPPORTED_EDITED_PIC
+                            | ErrorCode::CBKP101_INVALID_PIC
                     ),
                     "PIC digit parsing error should use CBKP* error code, got {:?}",
                     error.code
@@ -442,7 +446,9 @@ mod panic_elimination_pic_tests {
                 assert!(
                     matches!(
                         error.code,
-                        ErrorCode::CBKP001_SYNTAX | ErrorCode::CBKP051_UNSUPPORTED_EDITED_PIC
+                        ErrorCode::CBKP001_SYNTAX
+                            | ErrorCode::CBKP051_UNSUPPORTED_EDITED_PIC
+                            | ErrorCode::CBKP101_INVALID_PIC
                     ),
                     "PIC parentheses parsing error should use CBKP* error code, got {:?}",
                     error.code
@@ -472,7 +478,9 @@ mod panic_elimination_pic_tests {
                     assert!(
                         matches!(
                             error.code,
-                            ErrorCode::CBKP001_SYNTAX | ErrorCode::CBKP051_UNSUPPORTED_EDITED_PIC
+                            ErrorCode::CBKP001_SYNTAX
+                                | ErrorCode::CBKP051_UNSUPPORTED_EDITED_PIC
+                                | ErrorCode::CBKP101_INVALID_PIC
                         ),
                         "PIC size validation error should use CBKP* error code for '{}', got {:?}",
                         pic_copybook,
@@ -504,7 +512,9 @@ mod panic_elimination_pic_tests {
                     assert!(
                         matches!(
                             error.code,
-                            ErrorCode::CBKP001_SYNTAX | ErrorCode::CBKP011_UNSUPPORTED_CLAUSE
+                            ErrorCode::CBKP001_SYNTAX
+                                | ErrorCode::CBKP011_UNSUPPORTED_CLAUSE
+                                | ErrorCode::CBKP101_INVALID_PIC
                         ),
                         "PIC type validation error should use CBKP* error code for '{}', got {:?}",
                         pic_copybook,
@@ -815,6 +825,7 @@ mod panic_elimination_integration_tests {
                             | ErrorCode::CBKP021_ODO_NOT_TAIL
                             | ErrorCode::CBKS121_COUNTER_NOT_FOUND
                             | ErrorCode::CBKP051_UNSUPPORTED_EDITED_PIC
+                            | ErrorCode::CBKP101_INVALID_PIC
                     ),
                     "Comprehensive test error should use appropriate error code, got {:?}",
                     error.code

--- a/crates/copybook-core/tests/parser_edge_cases_deep.rs
+++ b/crates/copybook-core/tests/parser_edge_cases_deep.rs
@@ -58,6 +58,12 @@ fn test_newlines_only_returns_error() {
     assert_eq!(err.code(), ErrorCode::CBKP001_SYNTAX);
 }
 
+#[test]
+fn test_invalid_pic_uses_specific_error_code() {
+    let err = parse_copybook("01 REC.\n   05 FIELD PIC QQQ.").unwrap_err();
+    assert_eq!(err.code(), ErrorCode::CBKP101_INVALID_PIC);
+}
+
 // ===========================================================================
 // 2. Single-field copybook (minimal valid input)
 // ===========================================================================

--- a/crates/copybook-core/tests/parser_edge_cases_deep.rs
+++ b/crates/copybook-core/tests/parser_edge_cases_deep.rs
@@ -59,7 +59,7 @@ fn test_newlines_only_returns_error() {
 }
 
 #[test]
-fn test_invalid_pic_uses_specific_error_code() {
+fn parsing_invalid_pic_uses_specific_error_code() {
     let err = parse_copybook("01 REC.\n   05 FIELD PIC QQQ.").unwrap_err();
     assert_eq!(err.code(), ErrorCode::CBKP101_INVALID_PIC);
 }

--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -4,7 +4,7 @@
 # the complete stable-error registry requested by issue #576.
 schema_version = 1
 scope = "fixed-rdw-pipeline"
-verified_against = "63dbeb52b1348d46fb77ab32681394fc29382075"
+verified_against = "5d01669b7f43fd1b3c66bacc6c7e1cb00799b6c3"
 
 [[scenarios]]
 id = "format.fixed.basic"

--- a/docs/evidence/stable-errors.toml
+++ b/docs/evidence/stable-errors.toml
@@ -40,7 +40,8 @@ direct_test = "tests/e2e/e2e_cli_feature_flags.rs::disable_sign_separate_rejects
 [[errors]]
 code = "CBKP101_INVALID_PIC"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "crates/copybook-core/tests/parser_edge_cases_deep.rs::test_invalid_pic_uses_specific_error_code"
 [[errors]]
 code = "CBKS121_COUNTER_NOT_FOUND"
 stability_class = "stable"

--- a/docs/evidence/stable-errors.toml
+++ b/docs/evidence/stable-errors.toml
@@ -41,7 +41,7 @@ direct_test = "tests/e2e/e2e_cli_feature_flags.rs::disable_sign_separate_rejects
 code = "CBKP101_INVALID_PIC"
 stability_class = "stable"
 evidence_status = "direct"
-direct_test = "crates/copybook-core/tests/parser_edge_cases_deep.rs::test_invalid_pic_uses_specific_error_code"
+direct_test = "crates/copybook-core/tests/parser_edge_cases_deep.rs::parsing_invalid_pic_uses_specific_error_code"
 [[errors]]
 code = "CBKS121_COUNTER_NOT_FOUND"
 stability_class = "stable"

--- a/tests/e2e/e2e_cli_error_code_coverage.rs
+++ b/tests/e2e/e2e_cli_error_code_coverage.rs
@@ -120,9 +120,9 @@ fn cli_cbkp001_syntax_empty_inspect() {
     );
 }
 
-/// CBKP001: Invalid PIC character triggers syntax error.
+/// CBKP101: Invalid PIC character triggers the specific PIC parse error.
 #[test]
-fn cli_cbkp001_syntax_invalid_pic_char() {
+fn cli_cbkp101_invalid_pic_char() {
     let dir = write_temp_file(
         "bad_pic.cpy",
         b"       01  REC.\n           05  FLD   PIC Q(5).\n",
@@ -139,8 +139,8 @@ fn cli_cbkp001_syntax_invalid_pic_char() {
     let se = stderr_str(&output);
     assert_no_panic(&se);
     assert!(
-        se.contains("CBKP001_SYNTAX"),
-        "Expected CBKP001_SYNTAX for invalid PIC char: {se}"
+        se.contains("CBKP101_INVALID_PIC"),
+        "Expected CBKP101_INVALID_PIC for invalid PIC char: {se}"
     );
 }
 


### PR DESCRIPTION
## Summary

Closes no issue; this is the next bounded source-truth slice of #576.

Malformed PIC syntax now emits the specific `CBKP101_INVALID_PIC` parse code instead of the generic `CBKP001_SYNTAX`. Explicitly unsupported edited-PIC features continue to use `CBKP051_UNSUPPORTED_EDITED_PIC`.

Review map = reading order, not file inventory:

1. `crates/copybook-core/src/parser.rs` — remap only generic syntax errors returned by `PicClause::parse`; preserve existing specialized errors.
2. `crates/copybook-core/tests/parser_edge_cases_deep.rs` — exact library regression for an illegal PIC character.
3. `tests/e2e/e2e_cli_error_code_coverage.rs` — align CLI coverage with the specific stable code.
4. `docs/evidence/stable-errors.toml` — promote CBKP101 to direct evidence.

## Verification

| Check | Result |
| --- | --- |
| `cargo test -p copybook-core --test parser_edge_cases_deep --test parser_fixtures` | pass: 47 parser edge tests; parser fixtures target has 0 tests |
| `cargo test -p copybook-core --test parser_edge_cases_deep test_invalid_pic_uses_specific_error_code -- --exact` | pass |
| `cargo test -p copybook-e2e --test e2e_cli_error_code_coverage cli_cbkp101_invalid_pic_char -- --exact` with `CARGO_BIN_EXE_copybook` configured | pass |
| `cargo run -p xtask -- docs verify-stable-errors` | pass: 65 codes, 54 direct, 11 pending |
| `cargo clippy -p copybook-core --lib -- -D warnings -W clippy::pedantic` | pass |
| `cargo clippy -p copybook-core --test parser_edge_cases_deep -- -D warnings -W clippy::pedantic` | pass |
| `git diff --check` | pass |

The first unconfigured e2e invocation reported the existing `CARGO_BIN_EXE_copybook` harness-variable absence; after explicitly building `copybook-cli` and setting that variable, the focused CLI test passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid PIC clauses now report the specific `CBKP101_INVALID_PIC` error code instead of a generic syntax error.
  * Error details for other syntax issues remain unchanged.

* **Tests**
  * Added parser and CLI coverage for invalid PIC clause reporting.
  * Updated error-code evidence to reflect direct test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->