### PR TITLE
test(codec): prove CBKD412 zoned blank warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,6 +884,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/copybook-codec/Cargo.toml
+++ b/crates/copybook-codec/Cargo.toml
@@ -49,6 +49,7 @@ assert_cmd.workspace = true
 predicates.workspace = true
 copybook-options = { path = "../copybook-options" }
 copybook-determinism = { path = "../copybook-determinism" }
+tracing-subscriber.workspace = true
 
 [features]
 default = ["comp3_fast"]

--- a/crates/copybook-codec/tests/zoned_blank_when_zero_error_codes.rs
+++ b/crates/copybook-codec/tests/zoned_blank_when_zero_error_codes.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use copybook_codec::Codepage;
+use copybook_codec::numeric::decode_zoned_decimal;
+use std::io::{self, Write};
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone)]
+struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+impl Write for CaptureWriter {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn cbkd412_zoned_blank_is_zero_warning_is_emitted() {
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .with_writer({
+            let captured = Arc::clone(&captured);
+            move || CaptureWriter(Arc::clone(&captured))
+        })
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let value = decode_zoned_decimal(b"   ", 3, 0, false, Codepage::ASCII, true)
+        .expect("blank when zero should decode successfully");
+    assert_eq!(value.to_string(), "0");
+    drop(_guard);
+
+    let log = String::from_utf8(captured.lock().unwrap().clone()).unwrap();
+    assert!(log.contains("CBKD412_ZONED_BLANK_IS_ZERO"), "{log}");
+}

--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -4,7 +4,7 @@
 # the complete stable-error registry requested by issue #576.
 schema_version = 1
 scope = "fixed-rdw-pipeline"
-verified_against = "5d01669b7f43fd1b3c66bacc6c7e1cb00799b6c3"
+verified_against = "0999c48ef64960a02eee14559a1ff6ece4b56897"
 
 [[scenarios]]
 id = "format.fixed.basic"

--- a/docs/evidence/stable-errors.toml
+++ b/docs/evidence/stable-errors.toml
@@ -199,7 +199,8 @@ direct_test = "tests/e2e/e2e_cli_error_code_coverage.rs::cli_cbkd411_zoned_bad_s
 [[errors]]
 code = "CBKD412_ZONED_BLANK_IS_ZERO"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "crates/copybook-codec/tests/zoned_blank_when_zero_error_codes.rs::cbkd412_zoned_blank_is_zero_warning_is_emitted"
 [[errors]]
 code = "CBKD413_ZONED_INVALID_ENCODING"
 stability_class = "stable"


### PR DESCRIPTION
## What this does

The public zoned-decimal decoder now has executable direct evidence that `BLANK WHEN ZERO` emits the stable `CBKD412_ZONED_BLANK_IS_ZERO` warning while decoding an all-space field as zero. This closes the evidence gap without changing runtime behavior.

**Change:** capture the tracing warning at the numeric seam, assert the stable code and decoded value, and promote the registry entry from pending to direct. The fixed/RDW registry anchor is refreshed to the code commit.

## Verification

| Check | Result |
| --- | --- |
| `cbkd412_zoned_blank_is_zero_warning_is_emitted` | passes; asserts `CBKD412_ZONED_BLANK_IS_ZERO` and zero result |
| stable-error registry | passes; 65 codes, 55 direct, 10 pending |
| fixed/RDW evidence registry | passes at code commit `0999c48ef64960a02eee14559a1ff6ece4b56897` |
| `cargo fmt --all`, targeted Clippy | clean |

## Review map

- `crates/copybook-codec/src/numeric.rs::decode_zoned_decimal`: existing `BLANK WHEN ZERO` path emits the stable warning and returns zero.
- `crates/copybook-codec/tests/zoned_blank_when_zero_error_codes.rs`: captures the warning and asserts the code/value contract.
- `docs/evidence/stable-errors.toml`: records the focused test as direct evidence.
- `docs/evidence/fixed-rdw-pipeline.toml`: anchors the current-main pipeline evidence to the source commit.
