### PR TITLE
fix(codec): classify ambiguous zoned encoding

### DIFF
--- a/crates/copybook-codec/src/numeric.rs
+++ b/crates/copybook-codec/src/numeric.rs
@@ -835,14 +835,22 @@ pub fn decode_zoned_decimal_with_encoding(
         None
     };
 
-    // Check for mixed encoding error
+    // Reject mixed encoding and data with no determinable zoned encoding
     if let Some(ref info) = encoding_info
-        && info.has_mixed_encoding
+        && info.detected_format == ZonedEncodingFormat::Auto
     {
-        return Err(Error::new(
-            ErrorCode::CBKD414_ZONED_MIXED_ENCODING,
-            "Mixed ASCII/EBCDIC encoding detected within zoned decimal field",
-        ));
+        let (code, message) = if info.has_mixed_encoding {
+            (
+                ErrorCode::CBKD414_ZONED_MIXED_ENCODING,
+                "Mixed ASCII/EBCDIC encoding detected within zoned decimal field",
+            )
+        } else {
+            (
+                ErrorCode::CBKD415_ZONED_ENCODING_AMBIGUOUS,
+                "Unable to determine ASCII or EBCDIC encoding for zoned decimal field",
+            )
+        };
+        return Err(Error::new(code, message));
     }
 
     let (value, is_negative) =

--- a/crates/copybook-codec/src/numeric/decimal.rs
+++ b/crates/copybook-codec/src/numeric/decimal.rs
@@ -42,18 +42,18 @@ impl EncodingAnalysisStats {
     /// Determine the overall format and mixed encoding status from collected statistics
     ///
     /// # Logic
-    /// - If invalid zones exist: Auto format with mixed encoding flag
+    /// - If invalid zones exist without both known formats: Auto format without a mixed flag
     /// - If both ASCII and EBCDIC zones exist: Auto format with mixed encoding flag
     /// - If only ASCII zones: ASCII format, no mixing
     /// - If only EBCDIC zones: EBCDIC format, no mixing
     /// - If no valid zones: Auto format, no mixing (empty or all invalid)
     fn determine_overall_format(&self) -> (ZonedEncodingFormat, bool) {
-        if self.invalid_count > 0 {
-            // Invalid zones detected - cannot determine format reliably
-            (ZonedEncodingFormat::Auto, true)
-        } else if self.ascii_count > 0 && self.ebcdic_count > 0 {
+        if self.ascii_count > 0 && self.ebcdic_count > 0 {
             // Mixed ASCII and EBCDIC zones within the same field
             (ZonedEncodingFormat::Auto, true)
+        } else if self.invalid_count > 0 {
+            // No unambiguous format can be determined from the invalid zones
+            (ZonedEncodingFormat::Auto, false)
         } else if self.ascii_count > 0 {
             // Consistent ASCII encoding throughout the field
             (ZonedEncodingFormat::Ascii, false)

--- a/crates/copybook-codec/tests/zoned_encoding_ambiguity_error_codes.rs
+++ b/crates/copybook-codec/tests/zoned_encoding_ambiguity_error_codes.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use copybook_codec::numeric::decode_zoned_decimal_with_encoding;
+use copybook_codec::{Codepage, ZonedEncodingFormat};
+use copybook_core::ErrorCode;
+
+#[test]
+fn cbkd415_zoned_encoding_ambiguous_is_emitted_for_undetectable_data() {
+    let error = decode_zoned_decimal_with_encoding(
+        &[0x00, 0x01, 0x02],
+        3,
+        0,
+        false,
+        Codepage::CP037,
+        false,
+        true,
+    )
+    .expect_err("undetectable zoned bytes should be rejected");
+
+    assert_eq!(error.code, ErrorCode::CBKD415_ZONED_ENCODING_AMBIGUOUS);
+
+    let info = copybook_codec::ZonedEncodingInfo::detect_from_data(&[0x00, 0x01, 0x02])
+        .expect("encoding analysis should complete");
+    assert_eq!(info.detected_format, ZonedEncodingFormat::Auto);
+    assert!(!info.has_mixed_encoding);
+}

--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -4,7 +4,7 @@
 # the complete stable-error registry requested by issue #576.
 schema_version = 1
 scope = "fixed-rdw-pipeline"
-verified_against = "0999c48ef64960a02eee14559a1ff6ece4b56897"
+verified_against = "0999aa223b165e49954d7345e71053b218eb6cb4"
 
 [[scenarios]]
 id = "format.fixed.basic"

--- a/docs/evidence/stable-errors.toml
+++ b/docs/evidence/stable-errors.toml
@@ -214,7 +214,8 @@ direct_test = "crates/copybook-core/tests/zoned_encoding_error_codes_tests.rs::t
 [[errors]]
 code = "CBKD415_ZONED_ENCODING_AMBIGUOUS"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "crates/copybook-codec/tests/zoned_encoding_ambiguity_error_codes.rs::cbkd415_zoned_encoding_ambiguous_is_emitted_for_undetectable_data"
 [[errors]]
 code = "CBKD421_EDITED_PIC_INVALID_FORMAT"
 stability_class = "stable"


### PR DESCRIPTION
## What this does

Zoned-decimal decoding now distinguishes a field containing both ASCII and EBCDIC zones from a field whose bytes do not identify either encoding. The latter returns the stable `CBKD415_ZONED_ENCODING_AMBIGUOUS` error instead of being misclassified as mixed encoding (`CBKD414`).

**Fix:** preserve the existing mixed-encoding rejection, classify undetectable zone patterns as ambiguity, and add direct evidence for the public numeric decoder. Normal ASCII, EBCDIC, blank-when-zero, and mixed-encoding paths remain covered by their existing contracts.

## Verification

| Check | Result |
| --- | --- |
| `cbkd415_zoned_encoding_ambiguous_is_emitted_for_undetectable_data` | passes; asserts `CBKD415` and `Auto` detection without mixed encoding |
| zoned encoding format suite | 16 passed, including mixed encoding behavior |
| stable-error registry | passes; 65 codes, 56 direct, 9 pending |
| fixed/RDW evidence registry | passes at source commit `0999aa223b165e49954d7345e71053b218eb6cb4` |
| targeted codec Clippy, `cargo fmt --all`, `git diff --check` | clean |

## Review map

- `crates/copybook-codec/src/numeric/decimal.rs::EncodingAnalysisStats::determine_overall_format`: keeps mixed-format detection separate from invalid or undetectable zones.
- `crates/copybook-codec/src/numeric.rs::decode_zoned_decimal_with_encoding`: maps mixed data to `CBKD414` and undetectable data to `CBKD415`.
- `crates/copybook-codec/tests/zoned_encoding_ambiguity_error_codes.rs`: proves the public ambiguity error and detection classification.
- `docs/evidence/stable-errors.toml`: records direct CBKD415 evidence; fixed/RDW source truth is anchored to the implementation commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved zoned-decimal encoding detection for data containing mixed ASCII and EBCDIC values.
  * Added a distinct error when the encoding cannot be determined, improving diagnostic clarity.
  * Invalid zone values no longer incorrectly trigger mixed-encoding errors unless both encodings are detected.

* **Tests**
  * Added coverage for ambiguous zoned-decimal encoding scenarios.

* **Documentation**
  * Updated evidence records to reflect verified support for the ambiguous-encoding error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->