### PR TITLE
test(codec): prove edited PIC blank warning

### DIFF
--- a/crates/copybook-codec/tests/edited_pic_blank_when_zero_error_codes.rs
+++ b/crates/copybook-codec/tests/edited_pic_blank_when_zero_error_codes.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use copybook_codec::edited_pic::{decode_edited_numeric, tokenize_edited_pic};
+use std::io::{self, Write};
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone)]
+struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+impl Write for CaptureWriter {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn cbkd423_edited_pic_blank_when_zero_warning_is_emitted() {
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .with_writer({
+            let captured = Arc::clone(&captured);
+            move || CaptureWriter(Arc::clone(&captured))
+        })
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let pattern = tokenize_edited_pic("ZZZ9").expect("edited PIC should tokenize");
+    let value = decode_edited_numeric("    ", &pattern, 0, true)
+        .expect("blank when zero should decode successfully");
+    assert_eq!(value.to_decimal_string(), "0");
+    drop(_guard);
+
+    let log = String::from_utf8(captured.lock().unwrap().clone()).unwrap();
+    assert!(log.contains("CBKD423_EDITED_PIC_BLANK_WHEN_ZERO"), "{log}");
+}

--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -4,7 +4,7 @@
 # the complete stable-error registry requested by issue #576.
 schema_version = 1
 scope = "fixed-rdw-pipeline"
-verified_against = "0999aa223b165e49954d7345e71053b218eb6cb4"
+verified_against = "a38b090123bc44af3be621988478279718293c98"
 
 [[scenarios]]
 id = "format.fixed.basic"

--- a/docs/evidence/stable-errors.toml
+++ b/docs/evidence/stable-errors.toml
@@ -229,7 +229,8 @@ direct_test = "tests/e2e/e2e_error_taxonomy_complete.rs::cbkd422_edited_pic_sign
 [[errors]]
 code = "CBKD423_EDITED_PIC_BLANK_WHEN_ZERO"
 stability_class = "stable"
-evidence_status = "pending"
+evidence_status = "direct"
+direct_test = "crates/copybook-codec/tests/edited_pic_blank_when_zero_error_codes.rs::cbkd423_edited_pic_blank_when_zero_warning_is_emitted"
 [[errors]]
 code = "CBKD431_FLOAT_NAN"
 stability_class = "reserved"


### PR DESCRIPTION
## What this does

The edited-PIC decoder already treats an all-blank `BLANK WHEN ZERO` field as zero and emits `CBKD423_EDITED_PIC_BLANK_WHEN_ZERO`, but the stable registry had no executable proof of the warning code. This PR closes that evidence gap without changing runtime behavior.

**Change:** capture the tracing warning at the public edited-PIC decoder seam, assert the stable code and decoded zero value, and promote CBKD423 from pending to direct evidence.

## Verification

| Check | Result |
| --- | --- |
| `cbkd423_edited_pic_blank_when_zero_warning_is_emitted` | passes; asserts `CBKD423_EDITED_PIC_BLANK_WHEN_ZERO` and zero result |
| edited-PIC comprehensive suite | 109 passed, including blank-when-zero behavior |
| stable-error registry | passes; 65 codes, 57 direct, 8 pending |
| fixed/RDW evidence registry | passes at code commit `a38b090123bc44af3be621988478279718293c98` |
| targeted codec Clippy, `cargo fmt --all`, `git diff --check` | clean |

## Review map

- `crates/copybook-codec/src/edited_pic.rs::decode_edited_numeric`: existing blank-when-zero path emits CBKD423 and returns zero.
- `crates/copybook-codec/tests/edited_pic_blank_when_zero_error_codes.rs`: captures the warning and asserts the value contract.
- `docs/evidence/stable-errors.toml`: records direct CBKD423 evidence.
- `docs/evidence/fixed-rdw-pipeline.toml`: anchors current-main pipeline evidence to the implementation commit.
