### PR TITLE
docs(error): retire stale CBKD302 guidance

### DIFF
--- a/crates/copybook-codec/tests/edited_pic_codec_rejection.rs
+++ b/crates/copybook-codec/tests/edited_pic_codec_rejection.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-//! Phase E1: Codec rejection tests for edited PIC
+//! Legacy taxonomy coverage for the retired CBKD302 edited-PIC boundary.
 //!
-//! Tests that edited PIC fields properly reject during decode/encode operations
-//! with CBKD302_EDITED_PIC_NOT_IMPLEMENTED error code.
+//! Edited PIC decode and encode are implemented in the current codec. These
+//! checks retain compatibility coverage for the historical error identifier;
+//! they do not claim that current runtime paths emit CBKD302.
 
 use copybook_core::{ErrorCode, parse_copybook};
 

--- a/crates/copybook-error/src/lib.rs
+++ b/crates/copybook-error/src/lib.rs
@@ -189,7 +189,7 @@ pub enum ErrorCode {
     CBKD101_INVALID_FIELD_TYPE,
     /// CBKD301: Record data too short for field requirements
     CBKD301_RECORD_TOO_SHORT,
-    /// CBKD302: Edited PIC field encountered during decode (Phase E1: not implemented)
+    /// CBKD302: Legacy edited PIC identifier retained for compatibility; not emitted by current paths.
     CBKD302_EDITED_PIC_NOT_IMPLEMENTED,
     /// CBKD401: Invalid packed decimal nibble value
     CBKD401_COMP3_INVALID_NIBBLE,

--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -4,7 +4,7 @@
 # the complete stable-error registry requested by issue #576.
 schema_version = 1
 scope = "fixed-rdw-pipeline"
-verified_against = "6748868a205b12e475edf1f6eb2ca07257575238"
+verified_against = "0735ad09e09b1c791d7167a62fac2ebd791315cf"
 
 [[scenarios]]
 id = "format.fixed.basic"

--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -4,7 +4,7 @@
 # the complete stable-error registry requested by issue #576.
 schema_version = 1
 scope = "fixed-rdw-pipeline"
-verified_against = "a38b090123bc44af3be621988478279718293c98"
+verified_against = "6748868a205b12e475edf1f6eb2ca07257575238"
 
 [[scenarios]]
 id = "format.fixed.basic"

--- a/docs/internal/features/e3_edited_pic_encode_contract.md
+++ b/docs/internal/features/e3_edited_pic_encode_contract.md
@@ -325,7 +325,7 @@ The following patterns are explicitly NOT supported in v0.5.0 and should return 
 
 | Code | Description | Severity | Usage |
 |------|-------------|----------|-------|
-| `CBKD302_EDITED_PIC_NOT_IMPLEMENTED` | Encode not implemented (E3) | Error | Temporary error during implementation |
+| `CBKD302_EDITED_PIC_NOT_IMPLEMENTED` | Legacy identifier retained for compatibility; no current encode or decode path emits it | Not emitted | Historical Phase E1/E3 implementation boundary |
 | `CBKD421_EDITED_PIC_INVALID_FORMAT` | Input doesn't match pattern | Error | When input value cannot be encoded to the pattern |
 | `CBKD422_EDITED_PIC_SIGN_MISMATCH` | Sign editing symbol mismatch | Error | When sign handling fails |
 | `CBKD423_EDITED_PIC_BLANK_WHEN_ZERO` | Field is blank (warning) | Warning | When decoding blank fields (E2 only) |

--- a/docs/reference/ERROR_CODES.md
+++ b/docs/reference/ERROR_CODES.md
@@ -413,10 +413,10 @@ Record 15 too short: expected 120 bytes, got 85 bytes
 ```
 
 #### CBKD302_EDITED_PIC_NOT_IMPLEMENTED
-**Description**: Edited PIC field encountered during decode when edited PIC decoding is not available (Phase E1)
-**Severity**: Error
-**Context**: Field path, PIC clause
-**Resolution**: Upgrade to a version with Phase E2 edited PIC decode support, or remove edited PIC fields from the decode path
+**Description**: Legacy taxonomy identifier retained for compatibility; current edited PIC decode is implemented in Phase E2 and does not emit CBKD302
+**Severity**: Legacy, not emitted by current decode paths
+**Context**: Historical Phase E1 edited PIC decode boundary
+**Resolution**: Use the current edited PIC diagnostics: CBKD421 for invalid format, CBKD422 for sign mismatch, and CBKD423 for blank-when-zero warnings
 
 #### CBKD401_COMP3_INVALID_NIBBLE
 **Description**: Invalid nibble in packed decimal field


### PR DESCRIPTION
## What this does

`CBKD302_EDITED_PIC_NOT_IMPLEMENTED` describes a retired Phase E1 boundary, but current edited-PIC decode and encode are implemented and use CBKD421, CBKD422, CBKD423, or CBKP051 for active diagnostics. The stale reference made the operator-facing error catalog contradict the supported v0.6.0 direction.

**Change:** retain CBKD302 in the public taxonomy for compatibility, mark it as legacy and not emitted by current paths, align the E3 contract and compatibility test wording, and refresh the fixed/RDW source-truth anchor. The stable registry intentionally keeps CBKD302 pending because no current runtime trigger should exist.

## Verification

| Check | Result |
| --- | --- |
| edited-PIC compatibility test | 3 passed; confirms the legacy identifier remains defined while edited PIC parses successfully |
| stable-error registry | passes; 65 codes, 57 direct, 8 pending |
| fixed/RDW evidence registry | passes at source commit `0735ad09e09b1c791d7167a62fac2ebd791315cf` |
| `cargo fmt --all -- --check`, `git diff --check` | clean |
| `docs verify-all` | source registries passed; test-status subcheck requires a JUnit receipt not generated by this focused lane |

## Review map

- `docs/reference/ERROR_CODES.md`: replaces the obsolete “upgrade for Phase E2” guidance with current diagnostics and legacy status.
- `docs/internal/features/e3_edited_pic_encode_contract.md`: records CBKD302 as not emitted by current encode/decode paths.
- `crates/copybook-error/src/lib.rs`, `crates/copybook-codec/tests/edited_pic_codec_rejection.rs`: preserve compatibility while removing the implication of active rejection.
- `docs/evidence/fixed-rdw-pipeline.toml`: anchors source-truth evidence to the exact changed test/documentation commit.
