### PR TITLE
test(e2e): prove RDW ODO CLI decoding

### DIFF
--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -55,10 +55,10 @@ api_tests = [
   "crates/copybook-codec/tests/comprehensive_rdw_tests.rs::test_rdw_with_odo_variable_length",
   "crates/copybook-codec/tests/comprehensive_rdw_tests.rs::test_rdw_with_odo_variable_length_parallel",
 ]
-cli_tests = []
+cli_tests = ["tests/e2e/e2e_cli_decode_flags.rs::decode_rdw_odo_cli_accepts_variable_payloads"]
 error_codes = []
-cli_commands = []
-known_limitation = "The current coordinator anchors library sequential and parallel RDW+ODO behavior; CLI coverage is not claimed by this row."
+cli_commands = ["decode --format rdw --codepage ascii --emit-meta"]
+known_limitation = "The current anchors cover sequential and parallel library behavior plus sequential CLI decoding; CLI worker-count parity remains covered by the broader determinism matrix."
 
 [[scenarios]]
 id = "format.fixed_rdw.raw_mode"

--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -4,7 +4,7 @@
 # the complete stable-error registry requested by issue #576.
 schema_version = 1
 scope = "fixed-rdw-pipeline"
-verified_against = "0735ad09e09b1c791d7167a62fac2ebd791315cf"
+verified_against = "ab58e1ecbba8d85c334bfb3f05234acc8f992921"
 
 [[scenarios]]
 id = "format.fixed.basic"

--- a/tests/e2e/e2e_cli_decode_flags.rs
+++ b/tests/e2e/e2e_cli_decode_flags.rs
@@ -24,6 +24,12 @@ const SIMPLE_CPY: &str = "\
 
 const RDW_CPY: &str = "01 FIELD PIC X(5).\n";
 
+const RDW_ODO_CPY: &str = "\
+       01  REC.\n\
+           05  CNT    PIC 9(3).\n\
+           05  ITEMS  OCCURS 1 TO 5 DEPENDING ON CNT\n\
+                      PIC X(4).\n";
+
 /// Build ASCII record: 10 bytes name + 5 bytes amount = 15 bytes.
 fn make_ascii_record(name: &str, amount: &str) -> Vec<u8> {
     let mut rec = vec![b' '; 15];
@@ -236,6 +242,49 @@ fn decode_rdw_record_raw_cli_preserves_physical_frames() {
             .unwrap();
         assert_eq!(compatibility_raw, raw);
     }
+}
+
+#[test]
+fn decode_rdw_odo_cli_accepts_variable_payloads() {
+    let payloads = [b"002ABCDWXYZ".as_slice(), b"001EFGH".as_slice()];
+    let mut rdw_data = Vec::new();
+    for payload in payloads {
+        let length = u16::try_from(payload.len()).unwrap();
+        rdw_data.extend_from_slice(&length.to_be_bytes());
+        rdw_data.extend_from_slice(&[0, 0]);
+        rdw_data.extend_from_slice(payload);
+    }
+    let (dir, cpy, data) = setup(RDW_ODO_CPY, &rdw_data);
+    let out = dir.path().join("out.jsonl");
+
+    cmd()
+        .args([
+            "decode",
+            "--format",
+            "rdw",
+            "--codepage",
+            "ascii",
+            "--emit-meta",
+            "--output",
+        ])
+        .arg(&out)
+        .arg(&cpy)
+        .arg(&data)
+        .assert()
+        .success();
+
+    let lines: Vec<Value> = std::fs::read_to_string(&out)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(lines.len(), 2);
+    assert_eq!(lines[0]["CNT"], "002");
+    assert_eq!(lines[0]["ITEMS"], serde_json::json!(["ABCD", "WXYZ"]));
+    assert_eq!(lines[1]["CNT"], "001");
+    assert_eq!(lines[1]["ITEMS"], serde_json::json!(["EFGH"]));
+    assert_eq!(lines[0]["length"], 11);
+    assert_eq!(lines[1]["length"], 7);
 }
 
 #[test]


### PR DESCRIPTION
## What this does

Adds direct CLI evidence for variable-length RDW records driven by an ODO counter. The test exercises two records with different counts, asserts decoded item arrays, and verifies per-record physical payload lengths. The fixed/RDW coordinator now points to this witness.

## Verification

| Check | Result |
| --- | --- |
| `CARGO_BIN_EXE_copybook=target/debug/copybook cargo test -p copybook-e2e --test e2e_cli_decode_flags` | 9 passed |
| `cargo run --offline -p xtask -- docs verify-record-pipeline` | passed: 9 scenarios |
| `cargo fmt --all -- --check` | passed |
| `git diff --check` | passed |

`cargo test` without the repository e2e binary environment is not a valid proof for this crate; the supported binary-backed invocation above was used.

## Review map

1. `tests/e2e/e2e_cli_decode_flags.rs` — RDW+ODO CLI scenario and user-visible assertions.
2. `docs/evidence/fixed-rdw-pipeline.toml` — coordinator row and exact-head source anchor.

Refs #652 #572