### PR TITLE
fix(codec): preserve variable RDW ODO lengths

### DIFF
--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -1802,10 +1802,15 @@ fn encode_fields_to_bytes(
     json: &Value,
     options: &EncodeOptions,
 ) -> Result<Vec<u8>> {
-    let record_length = schema.lrecl_fixed.unwrap_or_else(|| {
+    let maximum_record_length = schema.lrecl_fixed.unwrap_or_else(|| {
         // For variable length, estimate based on schema
         schema.fields.iter().map(|f| f.len).sum::<u32>()
     }) as usize;
+    let record_length = if options.format == RecordFormat::RDW {
+        rdw_record_length_for_json(schema, json).unwrap_or(maximum_record_length)
+    } else {
+        maximum_record_length
+    };
 
     let mut buffer = vec![0u8; record_length];
 
@@ -1825,6 +1830,24 @@ fn encode_fields_to_bytes(
     }
 
     Ok(buffer)
+}
+
+/// Return the payload length required by one JSON record for RDW encoding.
+///
+/// `Schema::lrecl_fixed` is the maximum allocation for a tail ODO layout. RDW
+/// records are variable-length, so retaining that allocation would silently
+/// add zero-filled occurrences during a decode → encode round-trip.
+fn rdw_record_length_for_json(schema: &Schema, json: &Value) -> Option<usize> {
+    let array_field = schema
+        .all_fields()
+        .into_iter()
+        .find(|field| matches!(field.occurs, Some(copybook_core::Occurs::ODO { .. })))?;
+    let array = json_lookup_array(json, &array_field.path)
+        .or_else(|| json_lookup_array(json, &array_field.name))?;
+    let count = u32::try_from(array.len()).ok()?;
+    let array_bytes = array_field.len.checked_mul(count)?;
+    let payload_length = array_field.offset.checked_add(array_bytes)?;
+    usize::try_from(payload_length).ok()
 }
 
 /// Recursively encode fields into the buffer

--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -1834,20 +1834,33 @@ fn encode_fields_to_bytes(
 
 /// Return the payload length required by one JSON record for RDW encoding.
 ///
-/// `Schema::lrecl_fixed` is the maximum allocation for a tail ODO layout. RDW
+/// `Schema::lrecl_fixed` is the maximum allocation for an ODO layout. RDW
 /// records are variable-length, so retaining that allocation would silently
-/// add zero-filled occurrences during a decode → encode round-trip.
+/// add zero-filled occurrences during a decode → encode round-trip. Preserve
+/// any fixed storage after a nested ODO group when calculating the length.
 fn rdw_record_length_for_json(schema: &Schema, json: &Value) -> Option<usize> {
     let array_field = schema
         .all_fields()
         .into_iter()
         .find(|field| matches!(field.occurs, Some(copybook_core::Occurs::ODO { .. })))?;
+    let Some(copybook_core::Occurs::ODO { max, .. }) = array_field.occurs else {
+        return None;
+    };
+    let field_offset = usize::try_from(array_field.offset).ok()?;
+    let field_length = usize::try_from(array_field.len).ok()?;
+    let maximum_array_end = array_field
+        .offset
+        .checked_add(array_field.len.checked_mul(max)?)?;
+    let maximum_array_end = usize::try_from(maximum_array_end).ok()?;
+    let schema_length = usize::try_from(schema.lrecl_fixed?).ok()?;
+    let trailing_length = schema_length.checked_sub(maximum_array_end)?;
     let array = json_lookup_array(json, &array_field.path)
         .or_else(|| json_lookup_array(json, &array_field.name))?;
-    let count = u32::try_from(array.len()).ok()?;
-    let array_bytes = array_field.len.checked_mul(count)?;
-    let payload_length = array_field.offset.checked_add(array_bytes)?;
-    usize::try_from(payload_length).ok()
+    let count = array.len();
+    let array_bytes = field_length.checked_mul(count)?;
+    field_offset
+        .checked_add(array_bytes)?
+        .checked_add(trailing_length)
 }
 
 /// Recursively encode fields into the buffer
@@ -3601,6 +3614,27 @@ mod tests {
         // The result should be a properly encoded binary record
         // For this basic test, just verify it's the expected length
         assert_eq!(result.len(), 8); // 3 digits for ID + 5 chars for NAME
+        Ok(())
+    }
+
+    #[test]
+    fn rdw_odo_length_preserves_storage_after_nested_group() -> Result<()> {
+        let copybook_text = r"
+            01 RECORD.
+               05 HEADER PIC X(1).
+               05 WRAP.
+                  10 CNT PIC 9(3).
+                  10 ITEMS OCCURS 1 TO 5 DEPENDING ON CNT PIC X(4).
+               05 TRAILER PIC X(2).
+        ";
+        let schema = parse_copybook(copybook_text)?;
+        let json = serde_json::json!({
+            "HEADER": "H",
+            "WRAP": {"CNT": "002", "ITEMS": ["ABCD", "WXYZ"]},
+            "TRAILER": "TT"
+        });
+
+        assert_eq!(rdw_record_length_for_json(&schema, &json), Some(14));
         Ok(())
     }
 

--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -55,10 +55,17 @@ api_tests = [
   "crates/copybook-codec/tests/comprehensive_rdw_tests.rs::test_rdw_with_odo_variable_length",
   "crates/copybook-codec/tests/comprehensive_rdw_tests.rs::test_rdw_with_odo_variable_length_parallel",
 ]
-cli_tests = ["tests/e2e/e2e_cli_decode_flags.rs::decode_rdw_odo_cli_accepts_variable_payloads"]
+cli_tests = [
+  "tests/e2e/e2e_cli_decode_flags.rs::decode_rdw_odo_cli_accepts_variable_payloads",
+  "tests/e2e/e2e_cli_subcommands_comprehensive.rs::rdw_odo_cli_round_trip_preserves_variable_frames",
+]
 error_codes = []
-cli_commands = ["decode --format rdw --codepage ascii --emit-meta"]
-known_limitation = "The current anchors cover sequential and parallel library behavior plus sequential CLI decoding; CLI worker-count parity remains covered by the broader determinism matrix."
+cli_commands = [
+  "decode --format rdw --codepage ascii --emit-meta",
+  "encode --format rdw --codepage ascii",
+  "verify --format rdw --codepage ascii",
+]
+known_limitation = "The current anchors cover sequential and parallel library behavior plus sequential CLI decode/encode/verify; CLI worker-count parity remains covered by the broader determinism matrix."
 
 [[scenarios]]
 id = "format.fixed_rdw.raw_mode"

--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -4,7 +4,7 @@
 # the complete stable-error registry requested by issue #576.
 schema_version = 1
 scope = "fixed-rdw-pipeline"
-verified_against = "63de7b5303390f46995829a1a316cd091da94692"
+verified_against = "4dc30c04471da6051fb8bb1313a2fd965a7cacca"
 
 [[scenarios]]
 id = "format.fixed.basic"

--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -4,7 +4,7 @@
 # the complete stable-error registry requested by issue #576.
 schema_version = 1
 scope = "fixed-rdw-pipeline"
-verified_against = "4dc30c04471da6051fb8bb1313a2fd965a7cacca"
+verified_against = "8505e9df540a6f67eb85991fd5e29d3e49b4f98e"
 
 [[scenarios]]
 id = "format.fixed.basic"

--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -4,7 +4,7 @@
 # the complete stable-error registry requested by issue #576.
 schema_version = 1
 scope = "fixed-rdw-pipeline"
-verified_against = "ab58e1ecbba8d85c334bfb3f05234acc8f992921"
+verified_against = "63de7b5303390f46995829a1a316cd091da94692"
 
 [[scenarios]]
 id = "format.fixed.basic"

--- a/tests/e2e/e2e_cli_subcommands_comprehensive.rs
+++ b/tests/e2e/e2e_cli_subcommands_comprehensive.rs
@@ -834,11 +834,11 @@ fn full_pipeline_round_trip_fidelity() {
 // =========================================================================
 
 #[test]
-fn rdw_odo_cli_round_trip_preserves_variable_frames() {
+fn rdw_odo_cli_round_trip_preserves_variable_frames() -> Result<(), Box<dyn std::error::Error>> {
     let payloads = [b"002ABCDWXYZ".as_slice(), b"001EFGH".as_slice()];
     let mut original = Vec::new();
     for payload in payloads {
-        let length = u16::try_from(payload.len()).unwrap();
+        let length = u16::try_from(payload.len())?;
         original.extend_from_slice(&length.to_be_bytes());
         original.extend_from_slice(&[0, 0]);
         original.extend_from_slice(payload);
@@ -875,7 +875,8 @@ fn rdw_odo_cli_round_trip_preserves_variable_frames() {
         .assert()
         .success();
 
-    assert_eq!(std::fs::read(&encoded).unwrap(), original);
+    assert_eq!(std::fs::read(&encoded)?, original);
+    Ok(())
 }
 
 // =========================================================================

--- a/tests/e2e/e2e_cli_subcommands_comprehensive.rs
+++ b/tests/e2e/e2e_cli_subcommands_comprehensive.rs
@@ -43,6 +43,13 @@ const COMP3_CPY: &str = "\
            05  PKD    PIC S9(5) COMP-3.
 ";
 
+const RDW_ODO_CPY: &str = "\
+       01  REC.
+           05  CNT    PIC 9(3).
+           05  ITEMS  OCCURS 1 TO 5 DEPENDING ON CNT
+                      PIC X(4).
+";
+
 #[allow(dead_code)]
 /// Copybook with ODO (Occurs Depending On).
 const ODO_CPY: &str = "\
@@ -823,7 +830,56 @@ fn full_pipeline_round_trip_fidelity() {
 }
 
 // =========================================================================
-// 32. DECODE: --emit-filler flag accepted
+// 32. RDW + ODO: CLI decode → encode preserves variable physical frames
+// =========================================================================
+
+#[test]
+fn rdw_odo_cli_round_trip_preserves_variable_frames() {
+    let payloads = [b"002ABCDWXYZ".as_slice(), b"001EFGH".as_slice()];
+    let mut original = Vec::new();
+    for payload in payloads {
+        let length = u16::try_from(payload.len()).unwrap();
+        original.extend_from_slice(&length.to_be_bytes());
+        original.extend_from_slice(&[0, 0]);
+        original.extend_from_slice(payload);
+    }
+    let dir = setup(RDW_ODO_CPY, &original);
+    let jsonl = p(&dir, "decoded.jsonl");
+    let encoded = p(&dir, "encoded.bin");
+
+    cmd()
+        .args(["decode"])
+        .arg(p(&dir, "schema.cpy"))
+        .arg(p(&dir, "data.bin"))
+        .arg("--output")
+        .arg(&jsonl)
+        .args(["--format", "rdw", "--codepage", "ascii"])
+        .assert()
+        .success();
+
+    cmd()
+        .args(["encode"])
+        .arg(p(&dir, "schema.cpy"))
+        .arg(&jsonl)
+        .arg("--output")
+        .arg(&encoded)
+        .args(["--format", "rdw", "--codepage", "ascii"])
+        .assert()
+        .success();
+
+    cmd()
+        .args(["verify"])
+        .arg(p(&dir, "schema.cpy"))
+        .arg(&encoded)
+        .args(["--format", "rdw", "--codepage", "ascii"])
+        .assert()
+        .success();
+
+    assert_eq!(std::fs::read(&encoded).unwrap(), original);
+}
+
+// =========================================================================
+// 33. DECODE: --emit-filler flag accepted
 // =========================================================================
 
 #[test]
@@ -843,7 +899,7 @@ fn decode_emit_filler_flag_accepted() {
 }
 
 // =========================================================================
-// 33. DECODE: --strict flag accepted
+// 34. DECODE: --strict flag accepted
 // =========================================================================
 
 #[test]


### PR DESCRIPTION
## What this does

Preserves variable RDW payload lengths when encoding JSON produced from tail-ODO records. Previously `encode` allocated the schema maximum for every RDW record, so a decode → encode round-trip silently added zero-filled occurrences. The encoder now derives the RDW payload length from the actual ODO array count; fixed-format encoding keeps its existing maximum allocation contract.

The PR also adds a CLI decode → encode → verify regression covering two frames with ODO counts 2 and 1, and records the scenario in the fixed/RDW evidence coordinator.

## Verification

| Check | Result |
| --- | --- |
| Binary-backed `rdw_odo_cli_round_trip_preserves_variable_frames` | passed |
| `e2e_cli_decode_flags` | 9/9 passed |
| `e2e_cli_subcommands_comprehensive` | 37/37 passed |
| `cargo clippy -p copybook-codec --lib -- -D warnings` | passed |
| `cargo fmt --all -- --check` | passed |
| `cargo run --offline -p xtask -- docs verify-record-pipeline` | passed: 9 scenarios |
| `git diff --check` | passed |

## Review map

1. `crates/copybook-codec/src/lib_api.rs` — variable RDW payload sizing for actual ODO counts.
2. `tests/e2e/e2e_cli_subcommands_comprehensive.rs` — user-facing decode/encode/verify byte-fidelity regression.
3. `docs/evidence/fixed-rdw-pipeline.toml` — coordinator row and exact source anchor.

Refs #652 #572

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Variable-length RDW records now use the actual JSON array size instead of reserving space for maximum occurrences.
  * Prevented unused bytes from being retained in encoded records.

* **Tests**
  * Added end-to-end CLI coverage for decoding, encoding, verification, and round-trip preservation of variable-length RDW records.
  * Expanded documented evidence for RDW/ODO workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->