### PR TITLE
docs(evidence): anchor fixed/RDW registry to merged main commit

### DIFF
--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -4,7 +4,7 @@
 # the complete stable-error registry requested by issue #576.
 schema_version = 1
 scope = "fixed-rdw-pipeline"
-verified_against = "2b384a87bf8114ae1126d210f0c51415a8516269"
+verified_against = "04f743afcf7476118850c544163a5655d508f307"
 
 [[scenarios]]
 id = "format.fixed.basic"


### PR DESCRIPTION
## Problem

`docs/evidence/fixed-rdw-pipeline.toml` anchored `verified_against` to `2b384a87`, a pre-squash commit on the PR #749 branch. The squash merge into main dropped that commit from history, so `verify_record_pipeline_commit_ancestry` (docs-truth gate) fails on main and on every PR based on main:

```
Error: record-pipeline-evidence failed: ... Not a valid object name 8505e9df...^{commit}
```

(the same failure mode invalidated the previous anchor `8505e9df` after PR #747 squashed — seen failing on dependabot PRs #750/#751.)

## Fix

Re-anchor to `04f743af`, the squash commit that merged PR #749 into main:

- ancestor of main HEAD ✓
- `git diff --quiet 04f743af..origin/main -- <6 gated source paths>` → no drift ✓
- `cargo run -p xtask -- docs verify-all` locally: `fixed/RDW evidence registry verified: 9 scenarios at 04f743af...` ✓ (the trailing junit.xml error is local-only; CI produces junit output before this step)

## Note

Squash merges will keep invalidating these anchors whenever an evidence PR merges. A durable fix (post-merge anchor refresh, or merge-commit strategy for evidence PRs) is worth a follow-up issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the evidence record to reference the latest verification baseline.
  * No changes to exported functionality or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->