### PR TITLE
ci(dependabot): drop include scope so PR titles pass commit-lint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,8 +24,9 @@ updates:
           - "*"
         update-types: ["patch", "minor"]
     commit-message:
+      # No "include: scope": it produces "build(deps)(deps): ..." titles,
+      # which the commit-lint PR-title validator rejects.
       prefix: "build(deps)"
-      include: "scope"
 
   # GitHub Actions dependencies
   - package-ecosystem: "github-actions"
@@ -45,4 +46,3 @@ updates:
           - "*"
     commit-message:
       prefix: "build(deps)"
-      include: "scope"


### PR DESCRIPTION
## Problem

Every dependabot PR arrives titled `build(deps)(deps): ...` (prefix + `include: "scope"` appends a second scope). The commit-lint validator (`.github/workflows/commit-lint.yml`) accepts at most one scope, so **Validate PR Title fails on every dependabot PR** and someone has to retitle manually — observed on #699, #700, #750, #751 this week.

## Fix

Remove `include: "scope"` from both dependabot update configs. Future titles become `build(deps): bump ...`, matching the validator and the merged-history convention (e.g. #608, #588, #506).

## Proof

- The resulting title shape matches validator pattern `^(types)(\([a-z0-9-]+\))?: .+` — same shape as the retitled #750/#751, which now pass Validate PR Title.
- YAML structure unchanged otherwise; no workflow code touched.