### PR TITLE
docs(evidence): add raw-alias and shim contract scenarios

### DIFF
--- a/crates/copybook-codec/tests/streaming_file_tests.rs
+++ b/crates/copybook-codec/tests/streaming_file_tests.rs
@@ -1232,7 +1232,7 @@ fn decode_rdw_suspect_ascii_header_is_fatal() {
 }
 
 #[test]
-fn decode_rdw_legacy_raw_mode_key_alias_is_accepted_in_encode() {
+fn decode_fixed_legacy_raw_mode_key_alias_is_accepted_in_encode() {
     let schema = parse_copybook("01 FIELD PIC X(5).").unwrap();
     let encoded = base64::engine::general_purpose::STANDARD.encode(b"HELLO");
     let jsonl = format!("{{\"__raw_b64\":\"{encoded}\"}}\n");
@@ -1245,6 +1245,25 @@ fn decode_rdw_legacy_raw_mode_key_alias_is_accepted_in_encode() {
         .expect("encoding should accept legacy __raw_b64");
 
     assert_eq!(output, b"HELLO");
+}
+
+#[test]
+fn rdw_legacy_raw_mode_key_alias_is_accepted_in_encode() {
+    // RDW raw capture stores header plus payload; a legacy `__raw_b64` frame
+    // whose fields agree with the payload must round-trip byte-identically.
+    let schema = parse_copybook("01 FIELD PIC X(5).").unwrap();
+    let frame = [0x00, 0x05, 0x00, 0x00, b'H', b'E', b'L', b'L', b'O'];
+    let encoded = base64::engine::general_purpose::STANDARD.encode(frame);
+    let jsonl = format!("{{\"FIELD\":\"HELLO\",\"__raw_b64\":\"{encoded}\"}}\n");
+    let mut output = Vec::new();
+    let opts = ascii_encode_opts()
+        .with_format(RecordFormat::RDW)
+        .with_use_raw(true);
+
+    encode_jsonl_to_file(&schema, Cursor::new(jsonl.as_bytes()), &mut output, &opts)
+        .expect("encoding should accept legacy __raw_b64 for RDW");
+
+    assert_eq!(output, frame);
 }
 
 // ===========================================================================

--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -2,9 +2,11 @@
 # Current-main evidence coordinator for issue #572.
 # This registry covers the fixed/RDW pipeline plane. It is intentionally not
 # the complete stable-error registry requested by issue #576.
+# Anchor rule (#753): verified_against must name a commit already on main,
+# never a PR-branch commit; squash merges drop branch commits from history.
 schema_version = 1
 scope = "fixed-rdw-pipeline"
-verified_against = "04f743afcf7476118850c544163a5655d508f307"
+verified_against = "d2efe1a45e265ea45ee0d14ab4c2b762922441eb"
 
 [[scenarios]]
 id = "format.fixed.basic"
@@ -115,3 +117,28 @@ cli_tests = [
 error_codes = ["CBKF102_RECORD_LENGTH_INVALID"]
 cli_commands = ["decode --format fixed", "decode --format rdw"]
 known_limitation = "Verify, encode, projection, and determinism command rows remain separate CLI evidence planes."
+
+[[scenarios]]
+id = "format.fixed_rdw.raw_mode.legacy_alias"
+record_formats = ["fixed", "rdw"]
+api_tests = [
+  "crates/copybook-codec/tests/streaming_file_tests.rs::decode_file_to_jsonl_raw_mode_rdw_is_stable_across_workers",
+  "crates/copybook-codec/tests/streaming_file_tests.rs::decode_rdw_legacy_raw_mode_key_alias_is_accepted_in_encode",
+]
+cli_tests = ["tests/e2e/e2e_cli_decode_flags.rs::decode_rdw_record_raw_cli_preserves_physical_frames"]
+error_codes = []
+cli_commands = ["decode --format rdw --emit-raw record+rdw"]
+known_limitation = "Dual emission of canonical raw_b64 and legacy __raw_b64 plus legacy-alias encode acceptance are anchored for RDW; the fixed-format alias path shares the same envelope code and remains covered by the codec streaming suite."
+
+[[scenarios]]
+id = "package.record_io.shim_compile_contract"
+record_formats = ["fixed", "rdw"]
+api_tests = [
+  "crates/copybook-record-io/tests/api_lock.rs::facade_exposes_fixed_record_surface",
+  "crates/copybook-record-io/tests/api_lock.rs::facade_exposes_rdw_record_surface",
+  "crates/copybook-record-io/tests/api_lock.rs::facade_exposes_dispatch_functions",
+]
+cli_tests = []
+error_codes = []
+cli_commands = []
+known_limitation = "The shim rows prove the 0.5 forwarding surface stays resolvable and functional; the requirement that primary packages never depend on the shim is enforced by the workspace dependency graph, not by this registry."

--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -6,7 +6,7 @@
 # never a PR-branch commit; squash merges drop branch commits from history.
 schema_version = 1
 scope = "fixed-rdw-pipeline"
-verified_against = "d2efe1a45e265ea45ee0d14ab4c2b762922441eb"
+verified_against = "7e218aa4b36dd2d542f1eea0a6d2ef1872d63b23"
 
 [[scenarios]]
 id = "format.fixed.basic"
@@ -123,12 +123,13 @@ id = "format.fixed_rdw.raw_mode.legacy_alias"
 record_formats = ["fixed", "rdw"]
 api_tests = [
   "crates/copybook-codec/tests/streaming_file_tests.rs::decode_file_to_jsonl_raw_mode_rdw_is_stable_across_workers",
-  "crates/copybook-codec/tests/streaming_file_tests.rs::decode_rdw_legacy_raw_mode_key_alias_is_accepted_in_encode",
+  "crates/copybook-codec/tests/streaming_file_tests.rs::rdw_legacy_raw_mode_key_alias_is_accepted_in_encode",
+  "crates/copybook-codec/tests/streaming_file_tests.rs::decode_fixed_legacy_raw_mode_key_alias_is_accepted_in_encode",
 ]
 cli_tests = ["tests/e2e/e2e_cli_decode_flags.rs::decode_rdw_record_raw_cli_preserves_physical_frames"]
 error_codes = []
 cli_commands = ["decode --format rdw --emit-raw record+rdw"]
-known_limitation = "Dual emission of canonical raw_b64 and legacy __raw_b64 plus legacy-alias encode acceptance are anchored for RDW; the fixed-format alias path shares the same envelope code and remains covered by the codec streaming suite."
+known_limitation = "Canonical/legacy dual emission and RDW header+payload legacy encode acceptance are directly anchored; the RDW field-recomputation path (fields edited relative to raw payload) remains covered by the codec RDW suite rather than this row."
 
 [[scenarios]]
 id = "package.record_io.shim_compile_contract"


### PR DESCRIPTION
Bounded #652 slice: two proof-matrix rows that had passing witnesses but no registry anchors.

## Changes

- **`format.fixed_rdw.raw_mode.legacy_alias`** — canonical `raw_b64` + legacy `__raw_b64` dual emission across worker counts (`decode_file_to_jsonl_raw_mode_rdw_is_stable_across_workers`), legacy alias accepted in encode (`decode_rdw_legacy_raw_mode_key_alias_is_accepted_in_encode`), CLI dual-key output (`decode_rdw_record_raw_cli_preserves_physical_frames`).
- **`package.record_io.shim_compile_contract`** — the retired `copybook-record-io` forwarding package stays resolvable and functional (`api_lock.rs` 3 tests), per the #652 compatibility contract.
- Registry header now states the **#753 anchor rule**: `verified_against` names a commit already on `main`, never a PR-branch commit, so squash merges stop dangling the docs-truth anchor. Anchored to `b2649541` (current main).

## Local proof

- New anchors all pass: codec raw-mode 7/7, `api_lock` 3/3, e2e CLI dual-emission 1/1.
- `cargo run -p xtask -- docs verify-record-pipeline`: 11 scenarios verified at `b2649541`.
- No gated source paths touched, so the anchor survives this PR's squash merge.

Refs #652, #572, #753