### PR TITLE
feat(xtask): content-addressed anchoring for fixed/RDW evidence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4777,6 +4777,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_plain",
+ "sha2",
  "tempfile",
  "toml",
 ]

--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -2,11 +2,13 @@
 # Current-main evidence coordinator for issue #572.
 # This registry covers the fixed/RDW pipeline plane. It is intentionally not
 # the complete stable-error registry requested by issue #576.
-# Anchor rule (#753): verified_against must name a commit already on main,
-# never a PR-branch commit; squash merges drop branch commits from history.
+# Anchor rule (#753): content_digest is a SHA-256 over the gated source paths
+# (excluding Cargo.toml/Cargo.lock manifests). Any PR that changes those paths
+# must refresh it via `cargo run -p xtask -- docs sync-record-pipeline`. The
+# digest is content-addressed, so squash merges cannot invalidate it.
 schema_version = 1
 scope = "fixed-rdw-pipeline"
-verified_against = "7e218aa4b36dd2d542f1eea0a6d2ef1872d63b23"
+content_digest = "022184dc9946cfc16e021210215421e75711327a9a37fc334b72d53e04470e7d"
 
 [[scenarios]]
 id = "format.fixed.basic"

--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -2,13 +2,15 @@
 # Current-main evidence coordinator for issue #572.
 # This registry covers the fixed/RDW pipeline plane. It is intentionally not
 # the complete stable-error registry requested by issue #576.
-# Anchor rule (#753): content_digest is a SHA-256 over the gated source paths
-# (excluding Cargo.toml/Cargo.lock manifests). Any PR that changes those paths
-# must refresh it via `cargo run -p xtask -- docs sync-record-pipeline`. The
-# digest is content-addressed, so squash merges cannot invalidate it.
+# Anchor rule (#753): content_digest is a SHA-256 over the canonical staged Git
+# blobs and modes in the gated source paths, including behavior-affecting
+# manifests. Untracked files are excluded and unstaged gated changes are
+# rejected. Stage intended gated changes, then refresh via
+# `cargo run -p xtask -- docs sync-record-pipeline`. The digest is
+# content-addressed, so squash merges cannot invalidate it.
 schema_version = 1
 scope = "fixed-rdw-pipeline"
-content_digest = "022184dc9946cfc16e021210215421e75711327a9a37fc334b72d53e04470e7d"
+content_digest = "5652932f8ab184d0b06c413c40566fb7792f198d651494df59d896f91e96e5b7"
 
 [[scenarios]]
 id = "format.fixed.basic"

--- a/tools/xtask/Cargo.toml
+++ b/tools/xtask/Cargo.toml
@@ -32,6 +32,7 @@ copybook-core = { workspace = true }
 copybook-bench = { workspace = true }
 num_cpus = { workspace = true }
 toml.workspace = true
+sha2.workspace = true
 
 [lints]
 workspace = true

--- a/tools/xtask/src/docs_verify.rs
+++ b/tools/xtask/src/docs_verify.rs
@@ -68,6 +68,45 @@ pub(crate) fn verify_record_pipeline_command() -> Result<()> {
     verify_record_pipeline_evidence()
 }
 
+pub(crate) fn sync_record_pipeline_command() -> Result<()> {
+    let root = workspace_root();
+    let registry_path = root.join(RECORD_PIPELINE_EVIDENCE_PATH);
+    let source = fs::read_to_string(&registry_path).with_context(|| {
+        format!(
+            "loading fixed/RDW evidence registry {}",
+            registry_path.display()
+        )
+    })?;
+    let digest = compute_record_pipeline_digest(&root)?;
+
+    let mut updated = String::new();
+    let mut digest_written = false;
+    for line in source.lines() {
+        if line.starts_with("content_digest") {
+            updated.push_str(&format!("content_digest = \"{digest}\""));
+            digest_written = true;
+        } else if line.starts_with("verified_against") {
+            // Legacy commit anchor (#753): dropped on sync; the content
+            // digest is topology-independent and survives squash merges.
+        } else {
+            updated.push_str(line);
+            if line.starts_with("scope =") && !digest_written {
+                updated.push_str(&format!("\ncontent_digest = \"{digest}\""));
+                digest_written = true;
+            }
+        }
+        updated.push('\n');
+    }
+    fs::write(&registry_path, updated).with_context(|| {
+        format!(
+            "writing fixed/RDW evidence registry {}",
+            registry_path.display()
+        )
+    })?;
+    println!("fixed/RDW evidence content digest synced: {digest}");
+    Ok(())
+}
+
 pub(crate) fn verify_stable_error_registry_command() -> Result<()> {
     verify_stable_error_registry()
 }
@@ -252,7 +291,10 @@ struct ContractErrorInventory {
 struct RecordPipelineEvidence {
     schema_version: u32,
     scope: String,
-    verified_against: String,
+    #[serde(default)]
+    verified_against: Option<String>,
+    #[serde(default)]
+    content_digest: Option<String>,
     scenarios: Vec<RecordPipelineScenario>,
 }
 
@@ -295,29 +337,29 @@ fn verify_record_pipeline_evidence() -> Result<()> {
         bail!("fixed/RDW evidence registry contains no scenarios");
     }
 
-    let sha = registry.verified_against.trim();
-    if sha.len() != 40 || !sha.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-        bail!("verified_against must be a 40-character commit SHA, found `{sha}`");
-    }
-
-    let commit_check = Command::new("git")
-        .current_dir(&root)
-        .args(["cat-file", "-e", &format!("{sha}^{{commit}}")])
-        .output()
-        .context("checking fixed/RDW evidence registry commit")?;
-    match commit_check.status.code() {
-        Some(0) => verify_record_pipeline_commit_ancestry(&root, sha)?,
-        Some(1) if is_shallow_repository(&root)? => {
-            println!(
-                "fixed/RDW evidence commit `{sha}` unavailable in shallow checkout; ancestry and drift checks skipped"
-            );
+    let anchor_description = match registry.content_digest.as_deref().map(str::trim) {
+        Some(digest) if !digest.is_empty() => {
+            verify_record_pipeline_content_digest(&root, digest)?;
+            format!("content digest {digest}")
         }
-        Some(1) => bail!("fixed/RDW evidence registry commit `{sha}` is not available"),
-        other => bail!(
-            "git cat-file failed while checking fixed/RDW evidence registry commit (exit {other:?}): {}",
-            String::from_utf8_lossy(&commit_check.stderr).trim()
-        ),
-    }
+        _ => {
+            let sha = registry
+                .verified_against
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "fixed/RDW evidence registry must set content_digest or verified_against"
+                    )
+                })?;
+            println!(
+                "warning: verified_against commit anchoring is deprecated (#753); run `cargo run -p xtask -- docs sync-record-pipeline` to migrate to content_digest"
+            );
+            verify_record_pipeline_commit_anchor(&root, sha)?;
+            format!("commit {sha}")
+        }
+    };
 
     let error_code_source = fs::read_to_string(root.join("crates/copybook-error/src/lib.rs"))
         .context("loading crates/copybook-error/src/lib.rs")?;
@@ -327,9 +369,114 @@ fn verify_record_pipeline_evidence() -> Result<()> {
     println!(
         "fixed/RDW evidence registry verified: {} scenarios at {}",
         registry.scenarios.len(),
-        sha
+        anchor_description
     );
     Ok(())
+}
+
+/// Files excluded from the record-pipeline content digest: dependency
+/// manifest churn is not record-pipeline behavior (#753).
+const RECORD_PIPELINE_DIGEST_EXCLUDED_BASENAMES: [&str; 2] = ["Cargo.toml", "Cargo.lock"];
+
+fn verify_record_pipeline_content_digest(root: &Path, expected: &str) -> Result<()> {
+    if expected.len() != 64 || !expected.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        bail!("content_digest must be a 64-character SHA-256 hex string, found `{expected}`");
+    }
+    let actual = compute_record_pipeline_digest(root)?;
+    if actual != expected {
+        bail!(
+            "fixed/RDW evidence content digest mismatch: registry records `{expected}`, workspace computes `{actual}`; run `cargo run -p xtask -- docs sync-record-pipeline` and commit the update"
+        );
+    }
+    Ok(())
+}
+
+fn compute_record_pipeline_digest(root: &Path) -> Result<String> {
+    use sha2::Digest as _;
+
+    let mut files = Vec::new();
+    for rel in RECORD_PIPELINE_SOURCE_PATHS {
+        collect_record_pipeline_digest_files(&root.join(rel), rel, &mut files)?;
+    }
+    files.sort();
+
+    let mut state = sha2::Sha256::new();
+    for rel in &files {
+        state.update(rel.as_bytes());
+        state.update([0]);
+        let bytes = fs::read(root.join(rel))
+            .with_context(|| format!("reading record-pipeline digest input `{rel}`"))?;
+        state.update(&bytes);
+        state.update([0]);
+    }
+    let digest = state.finalize();
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{byte:02x}");
+    }
+    Ok(hex)
+}
+
+fn collect_record_pipeline_digest_files(
+    dir: &Path,
+    rel_prefix: &str,
+    out: &mut Vec<String>,
+) -> Result<()> {
+    if !dir.is_dir() {
+        bail!(
+            "record-pipeline digest input path `{}` is missing",
+            dir.display()
+        );
+    }
+    for entry in fs::read_dir(dir)
+        .with_context(|| format!("listing record-pipeline digest path `{}`", dir.display()))?
+    {
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some(name_str) = name.to_str() else {
+            continue;
+        };
+        if name_str == ".git" || name_str == "target" {
+            continue;
+        }
+        let entry_path = entry.path();
+        let rel = format!("{rel_prefix}/{name_str}");
+        if entry_path.is_dir() {
+            collect_record_pipeline_digest_files(&entry_path, &rel, out)?;
+        } else if entry_path.is_file()
+            && !RECORD_PIPELINE_DIGEST_EXCLUDED_BASENAMES.contains(&name_str)
+        {
+            out.push(rel);
+        }
+    }
+    Ok(())
+}
+
+fn verify_record_pipeline_commit_anchor(root: &Path, sha: &str) -> Result<()> {
+    if sha.len() != 40 || !sha.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        bail!("verified_against must be a 40-character commit SHA, found `{sha}`");
+    }
+
+    let commit_check = Command::new("git")
+        .current_dir(root)
+        .args(["cat-file", "-e", &format!("{sha}^{{commit}}")])
+        .output()
+        .context("checking fixed/RDW evidence registry commit")?;
+    match commit_check.status.code() {
+        Some(0) => verify_record_pipeline_commit_ancestry(root, sha),
+        Some(1) if is_shallow_repository(root)? => {
+            println!(
+                "fixed/RDW evidence commit `{sha}` unavailable in shallow checkout; ancestry and drift checks skipped"
+            );
+            Ok(())
+        }
+        Some(1) => bail!("fixed/RDW evidence registry commit `{sha}` is not available"),
+        other => bail!(
+            "git cat-file failed while checking fixed/RDW evidence registry commit (exit {other:?}): {}",
+            String::from_utf8_lossy(&commit_check.stderr).trim()
+        ),
+    }
 }
 
 fn verify_record_pipeline_commit_ancestry(root: &Path, sha: &str) -> Result<()> {
@@ -2547,6 +2694,64 @@ mod tests {
     )]
     fn ok() -> Result<()> {
         Ok(())
+    }
+
+    fn scaffold_record_pipeline_paths(root: &Path) {
+        for rel in RECORD_PIPELINE_SOURCE_PATHS {
+            std::fs::create_dir_all(root.join(rel).join("src")).unwrap();
+            std::fs::write(root.join(rel).join("src/code.rs"), b"fn code() {}\n").unwrap();
+            std::fs::write(root.join(rel).join("Cargo.toml"), b"[package]\n").unwrap();
+        }
+    }
+
+    #[test]
+    fn record_pipeline_digest_is_deterministic() {
+        let temp = tempfile::tempdir().unwrap();
+        scaffold_record_pipeline_paths(temp.path());
+
+        let first = compute_record_pipeline_digest(temp.path()).unwrap();
+        let second = compute_record_pipeline_digest(temp.path()).unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 64);
+    }
+
+    #[test]
+    fn record_pipeline_digest_ignores_manifest_churn() {
+        let temp = tempfile::tempdir().unwrap();
+        scaffold_record_pipeline_paths(temp.path());
+        let before = compute_record_pipeline_digest(temp.path()).unwrap();
+
+        std::fs::write(
+            temp.path().join("crates/copybook-cli/Cargo.toml"),
+            b"[package]\n# dependency bump\n",
+        )
+        .unwrap();
+
+        let after = compute_record_pipeline_digest(temp.path()).unwrap();
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn record_pipeline_digest_detects_source_change() {
+        let temp = tempfile::tempdir().unwrap();
+        scaffold_record_pipeline_paths(temp.path());
+        let before = compute_record_pipeline_digest(temp.path()).unwrap();
+
+        std::fs::write(
+            temp.path().join("crates/copybook-codec/src/code.rs"),
+            b"fn code() { changed(); }\n",
+        )
+        .unwrap();
+
+        let after = compute_record_pipeline_digest(temp.path()).unwrap();
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn record_pipeline_digest_missing_path_errors() {
+        let temp = tempfile::tempdir().unwrap();
+        assert!(compute_record_pipeline_digest(temp.path()).is_err());
     }
 
     #[test]

--- a/tools/xtask/src/docs_verify.rs
+++ b/tools/xtask/src/docs_verify.rs
@@ -8,8 +8,9 @@ use serde_json::Value;
 use std::{
     collections::{BTreeMap, BTreeSet},
     env, fs,
+    io::{BufRead, BufReader, Read, Write},
     path::{Path, PathBuf},
-    process::Command,
+    process::{Command, Stdio},
 };
 
 use super::{verify, verify_support_matrix};
@@ -78,27 +79,7 @@ pub(crate) fn sync_record_pipeline_command() -> Result<()> {
         )
     })?;
     let digest = compute_record_pipeline_digest(&root)?;
-
-    let mut updated = String::new();
-    let mut digest_written = false;
-    for line in source.lines() {
-        if line.starts_with("content_digest") {
-            use std::fmt::Write as _;
-            let _ = write!(updated, "content_digest = \"{digest}\"");
-            digest_written = true;
-        } else if line.starts_with("verified_against") {
-            // Legacy commit anchor (#753): dropped on sync; the content
-            // digest is topology-independent and survives squash merges.
-        } else {
-            updated.push_str(line);
-            if line.starts_with("scope =") && !digest_written {
-                use std::fmt::Write as _;
-                let _ = write!(updated, "\ncontent_digest = \"{digest}\"");
-                digest_written = true;
-            }
-        }
-        updated.push('\n');
-    }
+    let updated = update_record_pipeline_registry(&source, &digest)?;
     fs::write(&registry_path, updated).with_context(|| {
         format!(
             "writing fixed/RDW evidence registry {}",
@@ -107,6 +88,67 @@ pub(crate) fn sync_record_pipeline_command() -> Result<()> {
     })?;
     println!("fixed/RDW evidence content digest synced: {digest}");
     Ok(())
+}
+
+fn update_record_pipeline_registry(source: &str, digest: &str) -> Result<String> {
+    let registry: RecordPipelineEvidence =
+        toml::from_str(source).context("parsing fixed/RDW evidence registry before sync")?;
+    if registry.schema_version != 1 {
+        bail!(
+            "unsupported fixed/RDW evidence registry schema version {}",
+            registry.schema_version
+        );
+    }
+    if registry.scope != "fixed-rdw-pipeline" {
+        bail!(
+            "unexpected fixed/RDW evidence registry scope `{}`",
+            registry.scope
+        );
+    }
+    if registry.scenarios.is_empty() {
+        bail!("fixed/RDW evidence registry contains no scenarios");
+    }
+
+    let has_digest = registry
+        .content_digest
+        .as_deref()
+        .is_some_and(|value| !value.trim().is_empty());
+    let mut updated = String::with_capacity(source.len() + digest.len());
+    let mut digest_written = false;
+    let mut in_top_level = true;
+    for line in source.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with('[') {
+            in_top_level = false;
+        }
+        let key = in_top_level
+            .then(|| trimmed.split_once('=').map(|(key, _)| key.trim()))
+            .flatten();
+        match key {
+            Some("content_digest") => {
+                use std::fmt::Write as _;
+                let indentation = &line[..line.len() - trimmed.len()];
+                let _ = write!(updated, "{indentation}content_digest = \"{digest}\"");
+                digest_written = true;
+            }
+            Some("verified_against") => {
+                // Legacy commit anchor (#753): dropped on sync; the content
+                // digest is topology-independent and survives squash merges.
+            }
+            Some("scope") if !has_digest && !digest_written => {
+                use std::fmt::Write as _;
+                updated.push_str(line);
+                let _ = write!(updated, "\ncontent_digest = \"{digest}\"");
+                digest_written = true;
+            }
+            _ => updated.push_str(line),
+        }
+        updated.push('\n');
+    }
+    if !digest_written {
+        bail!("fixed/RDW evidence registry sync could not locate top-level scope");
+    }
+    Ok(updated)
 }
 
 pub(crate) fn verify_stable_error_registry_command() -> Result<()> {
@@ -339,28 +381,32 @@ fn verify_record_pipeline_evidence() -> Result<()> {
         bail!("fixed/RDW evidence registry contains no scenarios");
     }
 
-    let anchor_description = match registry.content_digest.as_deref().map(str::trim) {
-        Some(digest) if !digest.is_empty() => {
+    let content_digest = registry
+        .content_digest
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let verified_against = registry
+        .verified_against
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    validate_record_pipeline_anchor_selection(content_digest, verified_against)?;
+    let anchor_description = match (content_digest, verified_against) {
+        (Some(digest), None) => {
             verify_record_pipeline_content_digest(&root, digest)?;
             format!("content digest {digest}")
         }
-        _ => {
-            let sha = registry
-                .verified_against
-                .as_deref()
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "fixed/RDW evidence registry must set content_digest or verified_against"
-                    )
-                })?;
+        (None, Some(sha)) => {
             println!(
                 "warning: verified_against commit anchoring is deprecated (#753); run `cargo run -p xtask -- docs sync-record-pipeline` to migrate to content_digest"
             );
             verify_record_pipeline_commit_anchor(&root, sha)?;
             format!("commit {sha}")
         }
+        (Some(_), Some(_)) | (None, None) => bail!(
+            "fixed/RDW evidence registry must set exactly one of content_digest or verified_against"
+        ),
     };
 
     let error_code_source = fs::read_to_string(root.join("crates/copybook-error/src/lib.rs"))
@@ -376,9 +422,17 @@ fn verify_record_pipeline_evidence() -> Result<()> {
     Ok(())
 }
 
-/// Files excluded from the record-pipeline content digest: dependency
-/// manifest churn is not record-pipeline behavior (#753).
-const RECORD_PIPELINE_DIGEST_EXCLUDED_BASENAMES: [&str; 2] = ["Cargo.toml", "Cargo.lock"];
+fn validate_record_pipeline_anchor_selection(
+    content_digest: Option<&str>,
+    verified_against: Option<&str>,
+) -> Result<()> {
+    if content_digest.is_some() == verified_against.is_some() {
+        bail!(
+            "fixed/RDW evidence registry must set exactly one of content_digest or verified_against"
+        );
+    }
+    Ok(())
+}
 
 fn verify_record_pipeline_content_digest(root: &Path, expected: &str) -> Result<()> {
     if expected.len() != 64 || !expected.bytes().all(|byte| byte.is_ascii_hexdigit()) {
@@ -396,20 +450,69 @@ fn verify_record_pipeline_content_digest(root: &Path, expected: &str) -> Result<
 fn compute_record_pipeline_digest(root: &Path) -> Result<String> {
     use sha2::Digest as _;
 
-    let mut files = Vec::new();
-    for rel in RECORD_PIPELINE_SOURCE_PATHS {
-        collect_record_pipeline_digest_files(&root.join(rel), rel, &mut files)?;
-    }
-    files.sort();
+    verify_record_pipeline_index_is_current(root)?;
+    let files = tracked_record_pipeline_digest_files(root)?;
 
     let mut state = sha2::Sha256::new();
-    for rel in &files {
-        state.update(rel.as_bytes());
-        state.update([0]);
-        let bytes = fs::read(root.join(rel))
-            .with_context(|| format!("reading record-pipeline digest input `{rel}`"))?;
-        state.update(&bytes);
-        state.update([0]);
+    let mut child = Command::new("git")
+        .current_dir(root)
+        .args(["cat-file", "--batch"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .context("starting git cat-file for record-pipeline digest inputs")?;
+    {
+        let mut stdin = child
+            .stdin
+            .take()
+            .context("opening git cat-file stdin for record-pipeline digest inputs")?;
+        for file in &files {
+            writeln!(stdin, "{}", file.object_id)
+                .context("requesting record-pipeline digest blob from git")?;
+        }
+    }
+    let stdout = child
+        .stdout
+        .take()
+        .context("opening git cat-file stdout for record-pipeline digest inputs")?;
+    let mut reader = BufReader::new(stdout);
+    for file in &files {
+        let mut header = String::new();
+        reader
+            .read_line(&mut header)
+            .with_context(|| format!("reading git blob header for `{}`", file.path))?;
+        let mut fields = header.split_whitespace();
+        let returned_id = fields.next().unwrap_or_default();
+        let object_type = fields.next().unwrap_or_default();
+        let size = fields
+            .next()
+            .with_context(|| format!("git returned an incomplete blob header for `{}`", file.path))?
+            .parse::<usize>()
+            .with_context(|| format!("git returned an invalid blob size for `{}`", file.path))?;
+        if returned_id != file.object_id || object_type != "blob" {
+            bail!("git returned an invalid blob header for `{}`", file.path);
+        }
+        let mut bytes = vec![0_u8; size];
+        reader
+            .read_exact(&mut bytes)
+            .with_context(|| format!("reading canonical git blob for `{}`", file.path))?;
+        let mut terminator = [0_u8; 1];
+        reader
+            .read_exact(&mut terminator)
+            .with_context(|| format!("reading git blob terminator for `{}`", file.path))?;
+        if terminator != [b'\n'] {
+            bail!(
+                "git returned an invalid blob terminator for `{}`",
+                file.path
+            );
+        }
+        update_record_pipeline_digest(&mut state, &file.path, &file.mode, &bytes)?;
+    }
+    let status = child
+        .wait()
+        .context("waiting for git cat-file record-pipeline digest inputs")?;
+    if !status.success() {
+        bail!("git cat-file failed while reading record-pipeline digest inputs");
     }
     let digest = state.finalize();
     let mut hex = String::with_capacity(digest.len() * 2);
@@ -420,38 +523,108 @@ fn compute_record_pipeline_digest(root: &Path) -> Result<String> {
     Ok(hex)
 }
 
-fn collect_record_pipeline_digest_files(
-    dir: &Path,
-    rel_prefix: &str,
-    out: &mut Vec<String>,
-) -> Result<()> {
-    if !dir.is_dir() {
+#[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct RecordPipelineDigestFile {
+    path: String,
+    mode: String,
+    object_id: String,
+}
+
+fn verify_record_pipeline_index_is_current(root: &Path) -> Result<()> {
+    let output = Command::new("git")
+        .current_dir(root)
+        .args(["diff", "--quiet", "--"])
+        .args(RECORD_PIPELINE_SOURCE_PATHS)
+        .output()
+        .context("checking record-pipeline digest inputs for unstaged changes")?;
+    match output.status.code() {
+        Some(0) => Ok(()),
+        Some(1) => bail!(
+            "record-pipeline digest inputs contain unstaged changes; stage the intended gated files before synchronizing or verifying the digest"
+        ),
+        other => bail!(
+            "git diff failed while checking record-pipeline digest inputs (exit {other:?}): {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ),
+    }
+}
+
+fn tracked_record_pipeline_digest_files(root: &Path) -> Result<Vec<RecordPipelineDigestFile>> {
+    let output = Command::new("git")
+        .current_dir(root)
+        .args(["ls-files", "--stage", "-z", "--"])
+        .args(RECORD_PIPELINE_SOURCE_PATHS)
+        .output()
+        .context("listing tracked record-pipeline digest inputs")?;
+    if !output.status.success() {
         bail!(
-            "record-pipeline digest input path `{}` is missing",
-            dir.display()
+            "git ls-files failed while listing record-pipeline digest inputs: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
         );
     }
-    for entry in fs::read_dir(dir)
-        .with_context(|| format!("listing record-pipeline digest path `{}`", dir.display()))?
-    {
-        let entry = entry?;
-        let name = entry.file_name();
-        let Some(name_str) = name.to_str() else {
-            continue;
-        };
-        if name_str == ".git" || name_str == "target" {
-            continue;
-        }
-        let entry_path = entry.path();
-        let rel = format!("{rel_prefix}/{name_str}");
-        if entry_path.is_dir() {
-            collect_record_pipeline_digest_files(&entry_path, &rel, out)?;
-        } else if entry_path.is_file()
-            && !RECORD_PIPELINE_DIGEST_EXCLUDED_BASENAMES.contains(&name_str)
-        {
-            out.push(rel);
-        }
+
+    let mut files = parse_tracked_record_pipeline_paths(&output.stdout)?;
+    files.sort();
+    if files.is_empty() {
+        bail!("record-pipeline digest has no tracked input files");
     }
+    Ok(files)
+}
+
+fn parse_tracked_record_pipeline_paths(output: &[u8]) -> Result<Vec<RecordPipelineDigestFile>> {
+    output
+        .split(|byte| *byte == 0)
+        .filter(|raw| !raw.is_empty())
+        .map(|raw| {
+            let entry = String::from_utf8(raw.to_vec())
+                .context("record-pipeline digest input path is not valid UTF-8")?;
+            let (metadata, path) = entry
+                .split_once('\t')
+                .context("git returned an invalid record-pipeline index entry")?;
+            let mut fields = metadata.split_whitespace();
+            let mode = fields
+                .next()
+                .context("git omitted a record-pipeline index mode")?;
+            let object_id = fields
+                .next()
+                .context("git omitted a record-pipeline blob id")?;
+            let stage = fields
+                .next()
+                .context("git omitted a record-pipeline index stage")?;
+            if stage != "0" {
+                bail!("record-pipeline digest input `{path}` has unresolved index stage {stage}");
+            }
+            if mode == "120000" {
+                bail!("record-pipeline digest input `{path}` is a symbolic link");
+            }
+            if !matches!(mode, "100644" | "100755") {
+                bail!("record-pipeline digest input `{path}` has unsupported git mode {mode}");
+            }
+            Ok(RecordPipelineDigestFile {
+                path: path.to_string(),
+                mode: mode.to_string(),
+                object_id: object_id.to_string(),
+            })
+        })
+        .collect()
+}
+
+fn update_record_pipeline_digest(
+    state: &mut sha2::Sha256,
+    rel: &str,
+    mode: &str,
+    bytes: &[u8],
+) -> Result<()> {
+    use sha2::Digest as _;
+
+    let path_len = u64::try_from(rel.len()).context("record-pipeline digest path is too large")?;
+    let body_len =
+        u64::try_from(bytes.len()).context("record-pipeline digest file is too large")?;
+    state.update(path_len.to_be_bytes());
+    state.update(rel.as_bytes());
+    state.update(mode.as_bytes());
+    state.update(body_len.to_be_bytes());
+    state.update(bytes);
     Ok(())
 }
 
@@ -2704,6 +2877,31 @@ mod tests {
             std::fs::write(root.join(rel).join("src/code.rs"), b"fn code() {}\n").unwrap();
             std::fs::write(root.join(rel).join("Cargo.toml"), b"[package]\n").unwrap();
         }
+        let status = Command::new("git")
+            .current_dir(root)
+            .args(["init", "--quiet"])
+            .status()
+            .unwrap();
+        assert!(status.success());
+        let status = Command::new("git")
+            .current_dir(root)
+            .args(["config", "core.autocrlf", "false"])
+            .status()
+            .unwrap();
+        assert!(status.success());
+        let status = Command::new("git")
+            .current_dir(root)
+            .args(["add", "--"])
+            .args(RECORD_PIPELINE_SOURCE_PATHS)
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
+
+    fn record_pipeline_registry(top_level: &str) -> String {
+        format!(
+            "schema_version = 1\nscope = \"fixed-rdw-pipeline\"\n{top_level}\n\n[[scenarios]]\nid = \"format.fixed.basic\"\nrecord_formats = [\"fixed\"]\napi_tests = [\"crates/copybook-codec/tests/test.rs::works\"]\ncli_tests = []\nerror_codes = []\ncli_commands = []\nknown_limitation = \"none\"\n"
+        )
     }
 
     #[test]
@@ -2719,14 +2917,42 @@ mod tests {
     }
 
     #[test]
-    fn record_pipeline_digest_ignores_manifest_churn() {
+    fn record_pipeline_digest_detects_behavior_affecting_manifest_change() {
         let temp = tempfile::tempdir().unwrap();
         scaffold_record_pipeline_paths(temp.path());
         let before = compute_record_pipeline_digest(temp.path()).unwrap();
 
         std::fs::write(
             temp.path().join("crates/copybook-cli/Cargo.toml"),
-            b"[package]\n# dependency bump\n",
+            b"[package]\n[features]\ndefault = [\"different-runtime\"]\n",
+        )
+        .unwrap();
+        let status = Command::new("git")
+            .current_dir(temp.path())
+            .args(["add", "--", "crates/copybook-cli/Cargo.toml"])
+            .status()
+            .unwrap();
+        assert!(status.success());
+
+        let after = compute_record_pipeline_digest(temp.path()).unwrap();
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn record_pipeline_digest_ignores_untracked_and_ignored_files() {
+        let temp = tempfile::tempdir().unwrap();
+        scaffold_record_pipeline_paths(temp.path());
+        let before = compute_record_pipeline_digest(temp.path()).unwrap();
+
+        std::fs::write(
+            temp.path().join("crates/copybook-codec/review-proof.tmp"),
+            b"local review artifact\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(temp.path().join("crates/copybook-codec/target")).unwrap();
+        std::fs::write(
+            temp.path().join("crates/copybook-codec/target/output.bin"),
+            b"ignored build artifact\n",
         )
         .unwrap();
 
@@ -2745,6 +2971,12 @@ mod tests {
             b"fn code() { changed(); }\n",
         )
         .unwrap();
+        let status = Command::new("git")
+            .current_dir(temp.path())
+            .args(["add", "--", "crates/copybook-codec/src/code.rs"])
+            .status()
+            .unwrap();
+        assert!(status.success());
 
         let after = compute_record_pipeline_digest(temp.path()).unwrap();
         assert_ne!(before, after);
@@ -2754,6 +2986,97 @@ mod tests {
     fn record_pipeline_digest_missing_path_errors() {
         let temp = tempfile::tempdir().unwrap();
         assert!(compute_record_pipeline_digest(temp.path()).is_err());
+    }
+
+    #[test]
+    fn record_pipeline_digest_rejects_non_utf8_git_path() {
+        let error = parse_tracked_record_pipeline_paths(
+            b"100644 0123456789012345678901234567890123456789 0\tcrates/copybook-codec/bad-\xff\0",
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("not valid UTF-8"));
+    }
+
+    #[test]
+    fn record_pipeline_digest_rejects_tracked_symlink_mode() {
+        let error = parse_tracked_record_pipeline_paths(
+            b"120000 0123456789012345678901234567890123456789 0\tcrates/copybook-codec/src/linked.rs\0",
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("symbolic link"));
+    }
+
+    #[test]
+    fn record_pipeline_digest_rejects_unstaged_gated_change() {
+        let temp = tempfile::tempdir().unwrap();
+        scaffold_record_pipeline_paths(temp.path());
+        std::fs::write(
+            temp.path().join("crates/copybook-codec/src/code.rs"),
+            b"fn unstaged() {}\n",
+        )
+        .unwrap();
+
+        let error = compute_record_pipeline_digest(temp.path()).unwrap_err();
+        assert!(error.to_string().contains("unstaged changes"));
+    }
+
+    #[test]
+    fn record_pipeline_digest_length_framing_is_unambiguous() {
+        use sha2::Digest as _;
+
+        let path_a = "crates/copybook-codec/a";
+        let path_b = "crates/copybook-codec/b";
+        let mut one_file = sha2::Sha256::new();
+        update_record_pipeline_digest(
+            &mut one_file,
+            path_a,
+            "100644",
+            format!("\0{path_b}\0").as_bytes(),
+        )
+        .unwrap();
+
+        let mut two_files = sha2::Sha256::new();
+        update_record_pipeline_digest(&mut two_files, path_a, "100644", b"").unwrap();
+        update_record_pipeline_digest(&mut two_files, path_b, "100644", b"").unwrap();
+
+        assert_ne!(one_file.finalize(), two_files.finalize());
+    }
+
+    #[test]
+    fn record_pipeline_registry_sync_updates_only_exact_top_level_keys() {
+        let source = record_pipeline_registry(
+            "  content_digest = \"old\"\ncontent_digest_extra = \"preserve\"\nverified_against_extra = \"preserve\"\nverified_against = \"legacy\"",
+        );
+        let updated = update_record_pipeline_registry(&source, &"d".repeat(64)).unwrap();
+
+        assert!(updated.contains(&format!("  content_digest = \"{}\"", "d".repeat(64))));
+        assert_eq!(updated.matches("content_digest =").count(), 1);
+        assert!(updated.contains("content_digest_extra = \"preserve\""));
+        assert!(updated.contains("verified_against_extra = \"preserve\""));
+        assert!(!updated.contains("verified_against = \"legacy\""));
+
+        let legacy = record_pipeline_registry("verified_against = \"legacy\"");
+        let migrated = update_record_pipeline_registry(&legacy, &"e".repeat(64)).unwrap();
+        assert_eq!(migrated.matches("content_digest =").count(), 1);
+        assert!(!migrated.contains("verified_against = \"legacy\""));
+    }
+
+    #[test]
+    fn record_pipeline_registry_sync_rejects_malformed_or_incomplete_input() {
+        let malformed = "schema_version = 1\nscope = \"fixed-rdw-pipeline\"\nnot valid\n";
+        assert!(update_record_pipeline_registry(malformed, &"d".repeat(64)).is_err());
+
+        let missing_scope =
+            record_pipeline_registry("").replace("scope = \"fixed-rdw-pipeline\"\n", "");
+        assert!(update_record_pipeline_registry(&missing_scope, &"d".repeat(64)).is_err());
+    }
+
+    #[test]
+    fn record_pipeline_registry_rejects_conflicting_or_missing_anchor() {
+        assert!(validate_record_pipeline_anchor_selection(Some("digest"), Some("commit")).is_err());
+        assert!(validate_record_pipeline_anchor_selection(None, None).is_err());
+        assert!(validate_record_pipeline_anchor_selection(Some("digest"), None).is_ok());
+        assert!(validate_record_pipeline_anchor_selection(None, Some("commit")).is_ok());
     }
 
     #[test]

--- a/tools/xtask/src/docs_verify.rs
+++ b/tools/xtask/src/docs_verify.rs
@@ -83,7 +83,8 @@ pub(crate) fn sync_record_pipeline_command() -> Result<()> {
     let mut digest_written = false;
     for line in source.lines() {
         if line.starts_with("content_digest") {
-            updated.push_str(&format!("content_digest = \"{digest}\""));
+            use std::fmt::Write as _;
+            let _ = write!(updated, "content_digest = \"{digest}\"");
             digest_written = true;
         } else if line.starts_with("verified_against") {
             // Legacy commit anchor (#753): dropped on sync; the content
@@ -91,7 +92,8 @@ pub(crate) fn sync_record_pipeline_command() -> Result<()> {
         } else {
             updated.push_str(line);
             if line.starts_with("scope =") && !digest_written {
-                updated.push_str(&format!("\ncontent_digest = \"{digest}\""));
+                use std::fmt::Write as _;
+                let _ = write!(updated, "\ncontent_digest = \"{digest}\"");
                 digest_written = true;
             }
         }

--- a/tools/xtask/src/docs_verify.rs
+++ b/tools/xtask/src/docs_verify.rs
@@ -500,7 +500,7 @@ fn compute_record_pipeline_digest(root: &Path) -> Result<String> {
         reader
             .read_exact(&mut terminator)
             .with_context(|| format!("reading git blob terminator for `{}`", file.path))?;
-        if terminator != [b'\n'] {
+        if terminator != *b"\n" {
             bail!(
                 "git returned an invalid blob terminator for `{}`",
                 file.path

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -24,6 +24,7 @@ fn main() -> Result<()> {
         ["docs", "verify-tests"] => verify(),
         ["docs", "verify-all"] => docs_verify::run(),
         ["docs", "verify-record-pipeline"] => docs_verify::verify_record_pipeline_command(),
+        ["docs", "sync-record-pipeline"] => docs_verify::sync_record_pipeline_command(),
         ["docs", "verify-stable-errors"] => docs_verify::verify_stable_error_registry_command(),
         ["docs", "verify-support-matrix"] => verify_support_matrix(),
         ["docs", "freeze", "contracts"] => docs_verify::run_freeze_contract_checks(),
@@ -89,6 +90,7 @@ fn usage() {
          docs verify-tests                   Verify test status is in sync\n\
          docs verify-all                     Verify all source-of-truth documentation invariants\n\
          docs verify-record-pipeline         Verify fixed/RDW evidence registry anchors\n\
+         docs sync-record-pipeline           Refresh the fixed/RDW evidence content digest\n\
          docs verify-stable-errors            Verify stable error taxonomy registry\n\
          docs freeze contracts               Verify freeze-sensitive contracts (strict, API surface contract guard)\n\
          docs contracts generate             Regenerate stable contract manifest baseline\n\


### PR DESCRIPTION
Implements #753.

## Problem

The fixed/RDW evidence registry used branch commit anchors that became unreachable after squash merges. The first content-digest implementation removed that topology dependency, but review found five integrity gaps: behavior-changing manifests were excluded, local untracked files were included, digest framing was ambiguous for arbitrary bytes, symlinks/non-UTF-8 paths were not rejected, and the sync rewrite could corrupt or incompletely validate TOML.

## Fix

- Compute the digest from stage-0 regular files reported by Git for the six gated paths.
- Hash canonical staged Git blobs and executable modes, including Cargo.toml; reject unstaged gated changes so working-tree CRLF or dirty bytes cannot change the result.
- Exclude untracked/ignored files by construction; reject symlink modes, non-UTF-8 paths, unsupported modes, and unresolved index stages.
- Frame every path and body with fixed-width lengths before SHA-256 hashing.
- Parse and validate the full registry before a minimal formatting-preserving edit of exact top-level anchor keys.
- Require exactly one anchor: content_digest or the deprecated verified_against, never both.
- Keep legacy commit-only registries readable so in-flight migrations remain possible.

## Proof

- cargo test -p xtask record_pipeline -- --nocapture: 17 focused tests passed.
- cargo test -p xtask: 139 tests passed plus doctests.
- cargo clippy -p xtask --all-targets -- -D warnings -W clippy::pedantic: passed.
- cargo fmt -p xtask -- --check: passed.
- cargo run -p xtask -- docs sync-record-pipeline: idempotent at digest 5652932f8ab184d0b06c413c40566fb7792f198d651494df59d896f91e96e5b7.
- cargo run -p xtask -- docs verify-record-pipeline: 11 scenarios verified at that digest.
- git diff --check: passed.
- cargo run -p xtask -- docs verify-all: fails outside this PR's seam because the stable-error registry verifier reports unknown CBKW005_PARQUET_WRITE; this lane does not change that registry or taxonomy.

## Claim boundary

This makes the fixed/RDW evidence anchor reproducible across squash merges and clean checkouts while detecting tracked behavior inputs. It does not claim the unrelated full stable-error registry gate is locally green.

Closes #753