### PR TITLE
fix(codec): reject zoned decimal overflow

### DIFF
--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -297,6 +297,7 @@ fn process_fields_recursive(
                     json_obj,
                     options,
                     scratch_buffers,
+                    record_index,
                     encoding_acc,
                 )?;
             }
@@ -385,6 +386,7 @@ fn process_fields_recursive_with_scratch(
                     json_obj,
                     options,
                     scratch,
+                    record_index,
                     encoding_acc,
                 )?;
             }
@@ -417,6 +419,7 @@ fn process_scalar_field_standard(
     json_obj: &mut serde_json::Map<String, Value>,
     options: &DecodeOptions,
     scratch_buffers: &mut Option<crate::memory::ScratchBuffers>,
+    record_index: u64,
     encoding_acc: &mut Vec<(String, ZonedEncodingFormat)>,
 ) -> Result<()> {
     // Special handling for RENAMES fields - they use resolved metadata, not field offset/len
@@ -485,7 +488,8 @@ fn process_scalar_field_standard(
     }
 
     let field_data = &data[field_start..field_end];
-    let value = decode_scalar_field_value_standard(field, field_data, options, scratch_buffers)?;
+    let value = decode_scalar_field_value_standard(field, field_data, options, scratch_buffers)
+        .map_err(|error| add_zoned_overflow_context(error, field, record_index))?;
 
     // Collect zoned encoding metadata when preservation is enabled
     if options.preserve_zoned_encoding {
@@ -514,6 +518,7 @@ fn process_scalar_field_with_scratch(
     json_obj: &mut serde_json::Map<String, Value>,
     options: &DecodeOptions,
     scratch: &mut crate::memory::ScratchBuffers,
+    record_index: u64,
     encoding_acc: &mut Vec<(String, ZonedEncodingFormat)>,
 ) -> Result<()> {
     // Special handling for RENAMES fields - they use resolved metadata, not field offset/len
@@ -589,7 +594,8 @@ fn process_scalar_field_with_scratch(
     }
 
     let field_data = &data[field_start..field_end];
-    let value = decode_scalar_field_value_with_scratch(field, field_data, options, scratch)?;
+    let value = decode_scalar_field_value_with_scratch(field, field_data, options, scratch)
+        .map_err(|error| add_zoned_overflow_context(error, field, record_index))?;
 
     // Collect zoned encoding metadata when preservation is enabled
     if options.preserve_zoned_encoding {
@@ -606,6 +612,22 @@ fn process_scalar_field_with_scratch(
     }
 
     Ok(())
+}
+
+#[inline]
+fn add_zoned_overflow_context(
+    error: Error,
+    field: &copybook_core::Field,
+    record_index: u64,
+) -> Error {
+    if error.code == ErrorCode::CBKD410_ZONED_OVERFLOW {
+        error
+            .with_record(record_index)
+            .with_field(field.path.clone())
+            .with_offset(u64::from(field.offset))
+    } else {
+        error
+    }
 }
 
 /// Process an array field (with OCCURS clause)
@@ -713,7 +735,8 @@ fn process_array_field(
                     element_data,
                     options,
                     scratch_buffers,
-                )?;
+                )
+                .map_err(|error| add_zoned_overflow_context(error, field, record_index))?;
                 if options.preserve_zoned_encoding {
                     collect_zoned_encoding_info(field, element_data, options, encoding_acc);
                 }
@@ -835,7 +858,8 @@ fn process_array_field_with_scratch(
             FieldKind::Condition { values } => condition_value(values, "CONDITION_ARRAY"),
             _ => {
                 let val =
-                    decode_scalar_field_value_with_scratch(field, element_data, options, scratch)?;
+                    decode_scalar_field_value_with_scratch(field, element_data, options, scratch)
+                        .map_err(|error| add_zoned_overflow_context(error, field, record_index))?;
                 if options.preserve_zoned_encoding {
                     collect_zoned_encoding_info(field, element_data, options, encoding_acc);
                 }

--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -654,8 +654,14 @@ fn process_array_field(
         } => {
             // Find the counter field and get its value
             let scratch = scratch_buffers.get_or_insert_with(crate::memory::ScratchBuffers::new);
-            let counter_value =
-                find_and_read_counter_field(counter_path, all_fields, data, options, scratch)?;
+            let counter_value = find_and_read_counter_field(
+                counter_path,
+                all_fields,
+                data,
+                options,
+                scratch,
+                record_index,
+            )?;
 
             let counter_field = find_field_by_path(all_fields, counter_path)?;
             let validation_context = crate::odo_redefines::OdoValidationContext {
@@ -775,8 +781,14 @@ fn process_array_field_with_scratch(
             counter_path,
         } => {
             // Find the counter field and get its value
-            let counter_value =
-                find_and_read_counter_field(counter_path, all_fields, data, options, scratch)?;
+            let counter_value = find_and_read_counter_field(
+                counter_path,
+                all_fields,
+                data,
+                options,
+                scratch,
+                record_index,
+            )?;
 
             let counter_field = find_field_by_path(all_fields, counter_path)?;
             let validation_context = crate::odo_redefines::OdoValidationContext {
@@ -881,6 +893,7 @@ fn find_and_read_counter_field(
     data: &[u8],
     options: &DecodeOptions,
     scratch: &mut crate::memory::ScratchBuffers,
+    record_index: u64,
 ) -> Result<u32> {
     // Find the counter field by path
     let counter_field = find_field_by_path(all_fields, counter_path)?;
@@ -924,7 +937,8 @@ fn find_and_read_counter_field(
                     options.codepage,
                     counter_field.blank_when_zero,
                     scratch,
-                )?;
+                )
+                .map_err(|error| add_zoned_overflow_context(error, counter_field, record_index))?;
                 decimal_str.parse::<u32>().map_err(|_| {
                     Error::new(
                         ErrorCode::CBKS121_COUNTER_NOT_FOUND,

--- a/crates/copybook-codec/src/numeric.rs
+++ b/crates/copybook-codec/src/numeric.rs
@@ -173,8 +173,8 @@ const EBCDIC_DIGIT_ZONE: u8 = 0xF; // EBCDIC '0'..'9' => 0xF0..0xF9
 /// Applies the codec default: ASCII uses `ZeroSignPolicy::Positive`; EBCDIC zeros normalize via `ZeroSignPolicy::Preferred`.
 ///
 /// # Errors
-/// Returns an error if the zoned decimal data is invalid or contains bad sign zones.
-/// All errors include proper context information (`record_index`, `field_path`, `byte_offset`).
+/// * `CBKD410_ZONED_OVERFLOW` - if the decoded magnitude exceeds `i64` capacity
+/// * `CBKD411_ZONED_BAD_SIGN` - if the zoned digits, zones, or sign are invalid
 ///
 /// # Examples
 ///
@@ -320,7 +320,7 @@ pub fn decode_zoned_decimal(
                 }
             }
 
-            value = value.saturating_mul(10).saturating_add(i64::from(digit));
+            value = zoned_append_digit(value, digit, i)?;
         } else {
             let zone = (byte >> 4) & 0x0F;
             let digit = byte & 0x0F;
@@ -345,13 +345,29 @@ pub fn decode_zoned_decimal(
                 ));
             }
 
-            value = value.saturating_mul(10).saturating_add(i64::from(digit));
+            value = zoned_append_digit(value, digit, i)?;
         }
     }
 
     let mut decimal = SmallDecimal::new(value, scale, is_negative);
     decimal.normalize(); // Normalize -0 → 0 (NORMATIVE)
     Ok(decimal)
+}
+
+/// Append one logical digit to a zoned-decimal magnitude without data loss.
+#[inline]
+fn zoned_append_digit(value: i64, digit: u8, position: usize) -> Result<i64> {
+    value
+        .checked_mul(10)
+        .and_then(|scaled| scaled.checked_add(i64::from(digit)))
+        .ok_or_else(|| {
+            Error::new(
+                ErrorCode::CBKD410_ZONED_OVERFLOW,
+                format!(
+                    "Zoned decimal magnitude exceeds i64 capacity while appending digit {digit} at position {position}"
+                ),
+            )
+        })
 }
 
 /// Decode a zoned decimal field with SIGN SEPARATE clause
@@ -745,8 +761,11 @@ fn build_scaled_digit_string(abs_str: &str, scale: i16) -> String {
 /// Mirrors [`decode_zoned_decimal`], defaulting to preferred-zero handling for EBCDIC unless a preserved format dictates otherwise.
 ///
 /// # Errors
-/// Returns an error if the zoned decimal data is invalid or contains bad sign zones.
-/// All errors include proper context information (`record_index`, `field_path`, `byte_offset`).
+/// * `CBKD410_ZONED_OVERFLOW` - if the decoded magnitude exceeds `i64` capacity
+/// * `CBKD411_ZONED_BAD_SIGN` - if the zoned digits, zones, or sign are invalid
+/// * `CBKD413_ZONED_INVALID_ENCODING` - if preserved encoding zones are invalid
+/// * `CBKD414_ZONED_MIXED_ENCODING` - if preserved encoding mixes formats
+/// * `CBKD415_ZONED_ENCODING_AMBIGUOUS` - if preserved encoding cannot be detected
 ///
 /// # Examples
 ///
@@ -876,7 +895,8 @@ pub fn decode_zoned_decimal_with_encoding(
 /// A tuple of (`accumulated_value`, `is_negative`)
 ///
 /// # Errors
-/// Returns an error if an invalid digit or zone nibble is encountered.
+/// Returns `CBKD410_ZONED_OVERFLOW` if the magnitude exceeds `i64` capacity,
+/// or a typed zoned-format error if a digit, zone, or sign is invalid.
 #[inline]
 fn zoned_decode_digits_with_encoding(
     data: &[u8],
@@ -932,7 +952,7 @@ fn zoned_decode_digits_with_encoding(
                 }
             }
 
-            value = value.saturating_mul(10).saturating_add(i64::from(digit));
+            value = zoned_append_digit(value, digit, index)?;
         } else {
             let digit = byte & 0x0F;
             if digit > 9 {
@@ -979,7 +999,7 @@ fn zoned_decode_digits_with_encoding(
                 }
             }
 
-            value = value.saturating_mul(10).saturating_add(i64::from(digit));
+            value = zoned_append_digit(value, digit, index)?;
         }
     }
 
@@ -2223,11 +2243,8 @@ fn zoned_validate_non_final_byte(
 /// Accumulated integer value from non-final digits
 ///
 /// # Errors
+/// * `CBKD410_ZONED_OVERFLOW` - Magnitude exceeds `i64` capacity
 /// * `CBKD411_ZONED_BAD_SIGN` - Invalid zone or digit nibble encountered
-///
-/// # Performance
-/// Uses saturating arithmetic to prevent overflow panics while accumulating
-/// the numeric value.
 #[inline]
 fn zoned_process_non_final_digits(
     data: &[u8],
@@ -2240,7 +2257,7 @@ fn zoned_process_non_final_digits(
     for (index, &byte) in data.iter().enumerate() {
         let digit = zoned_validate_non_final_byte(byte, index, expected_zone, codepage)?;
         scratch.digit_buffer.push(digit);
-        value = value.saturating_mul(10).saturating_add(i64::from(digit));
+        value = zoned_append_digit(value, digit, index)?;
     }
 
     Ok(value)
@@ -2342,7 +2359,8 @@ fn zoned_ensure_unsigned(
 /// `preserve_zoned_encoding` captured an explicit format at decode.
 ///
 /// # Errors
-/// Returns an error if zone nibbles or the last-byte overpunch are invalid.
+/// * `CBKD410_ZONED_OVERFLOW` - if the decoded magnitude exceeds `i64` capacity
+/// * `CBKD411_ZONED_BAD_SIGN` - if the zone nibbles or last-byte sign are invalid
 ///
 /// # Performance
 /// This function avoids allocations by reusing scratch buffers across decode operations.
@@ -2434,9 +2452,7 @@ pub fn decode_zoned_decimal_with_scratch(
         zoned_process_non_final_digits(non_final, expected_zone, codepage, scratch)?;
     let (last_digit, negative) = zoned_decode_last_byte(last_byte, codepage)?;
     scratch.digit_buffer.push(last_digit);
-    let value = partial_value
-        .saturating_mul(10)
-        .saturating_add(i64::from(last_digit));
+    let value = zoned_append_digit(partial_value, last_digit, non_final.len())?;
     let is_negative = if signed {
         negative
     } else {
@@ -3140,6 +3156,7 @@ fn format_integer_with_leading_zeros_to_buffer(value: i64, width: u32, buffer: &
 /// preferred-zero handling for EBCDIC data.
 ///
 /// # Errors
+/// * `CBKD410_ZONED_OVERFLOW` - if the decoded magnitude exceeds `i64` capacity
 /// * `CBKD411_ZONED_BAD_SIGN` - if the zone nibbles or sign are invalid
 ///
 /// # See Also

--- a/crates/copybook-codec/src/numeric.rs
+++ b/crates/copybook-codec/src/numeric.rs
@@ -2452,12 +2452,12 @@ pub fn decode_zoned_decimal_with_scratch(
         zoned_process_non_final_digits(non_final, expected_zone, codepage, scratch)?;
     let (last_digit, negative) = zoned_decode_last_byte(last_byte, codepage)?;
     scratch.digit_buffer.push(last_digit);
-    let value = zoned_append_digit(partial_value, last_digit, non_final.len())?;
     let is_negative = if signed {
         negative
     } else {
         zoned_ensure_unsigned(last_byte, expected_zone, codepage, negative)?
     };
+    let value = zoned_append_digit(partial_value, last_digit, non_final.len())?;
     let mut decimal = SmallDecimal::new(value, scale, is_negative);
     decimal.normalize();
 

--- a/crates/copybook-codec/tests/zoned_overflow.rs
+++ b/crates/copybook-codec/tests/zoned_overflow.rs
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Regression coverage for checked zoned-decimal magnitude accumulation.
+
+use anyhow::{Result, bail, ensure};
+use copybook_codec::numeric::{
+    decode_zoned_decimal, decode_zoned_decimal_to_string_with_scratch,
+    decode_zoned_decimal_with_encoding, decode_zoned_decimal_with_scratch,
+};
+use copybook_codec::runtime::ScratchBuffers;
+use copybook_codec::{
+    Codepage, DecodeOptions, JsonNumberMode, RecordFormat, decode_record,
+    decode_record_with_scratch,
+};
+use copybook_core::{Error, ErrorCode, parse_copybook};
+
+const I64_MAX_DIGITS: &[u8] = b"9223372036854775807";
+const I64_OVERFLOW_DIGITS: &[u8] = b"9223372036854775808";
+
+fn require_error<T>(result: copybook_core::Result<T>) -> Result<Error> {
+    match result {
+        Ok(_) => bail!("expected zoned-decimal overflow"),
+        Err(error) => Ok(error),
+    }
+}
+
+fn ensure_overflow(error: &Error) -> Result<()> {
+    ensure!(
+        error.code == ErrorCode::CBKD410_ZONED_OVERFLOW,
+        "expected CBKD410_ZONED_OVERFLOW, got {}",
+        error.code
+    );
+    Ok(())
+}
+
+fn ebcdic_unsigned(ascii_digits: &[u8]) -> Vec<u8> {
+    ascii_digits
+        .iter()
+        .map(|byte| 0xF0 + (byte - b'0'))
+        .collect()
+}
+
+#[test]
+fn basic_decode_accepts_i64_max_and_rejects_next_magnitude() -> Result<()> {
+    let maximum = decode_zoned_decimal(I64_MAX_DIGITS, 19, 0, false, Codepage::ASCII, false)?;
+    ensure!(maximum.to_string() == "9223372036854775807");
+
+    let overflow = require_error(decode_zoned_decimal(
+        I64_OVERFLOW_DIGITS,
+        19,
+        0,
+        false,
+        Codepage::ASCII,
+        false,
+    ))?;
+    ensure_overflow(&overflow)
+}
+
+#[test]
+fn encoding_preserving_decode_checks_overflow_with_preservation_on_and_off() -> Result<()> {
+    for preserve_encoding in [false, true] {
+        let (maximum, encoding) = decode_zoned_decimal_with_encoding(
+            I64_MAX_DIGITS,
+            19,
+            0,
+            false,
+            Codepage::ASCII,
+            false,
+            preserve_encoding,
+        )?;
+        ensure!(maximum.to_string() == "9223372036854775807");
+        ensure!(encoding.is_some() == preserve_encoding);
+
+        let overflow = require_error(decode_zoned_decimal_with_encoding(
+            I64_OVERFLOW_DIGITS,
+            19,
+            0,
+            false,
+            Codepage::ASCII,
+            false,
+            preserve_encoding,
+        ))?;
+        ensure_overflow(&overflow)?;
+    }
+    Ok(())
+}
+
+#[test]
+fn scratch_and_string_paths_propagate_checked_overflow() -> Result<()> {
+    let mut scratch = ScratchBuffers::new();
+    let maximum = decode_zoned_decimal_with_scratch(
+        I64_MAX_DIGITS,
+        19,
+        2,
+        false,
+        Codepage::ASCII,
+        false,
+        &mut scratch,
+    )?;
+    ensure!(maximum.to_string() == "92233720368547758.07");
+
+    let overflow = require_error(decode_zoned_decimal_with_scratch(
+        I64_OVERFLOW_DIGITS,
+        19,
+        0,
+        false,
+        Codepage::ASCII,
+        false,
+        &mut scratch,
+    ))?;
+    ensure_overflow(&overflow)?;
+
+    let string_overflow = require_error(decode_zoned_decimal_to_string_with_scratch(
+        I64_OVERFLOW_DIGITS,
+        19,
+        0,
+        false,
+        Codepage::ASCII,
+        false,
+        &mut scratch,
+    ))?;
+    ensure_overflow(&string_overflow)
+}
+
+#[test]
+fn sign_and_codepage_do_not_change_magnitude_capacity() -> Result<()> {
+    let mut ascii_positive_max = I64_MAX_DIGITS.to_vec();
+    ascii_positive_max[18] = b'G';
+    let mut ascii_negative_max = I64_MAX_DIGITS.to_vec();
+    ascii_negative_max[18] = b'P';
+    let mut ascii_negative_overflow = I64_OVERFLOW_DIGITS.to_vec();
+    ascii_negative_overflow[18] = b'Q';
+
+    for (data, expected) in [
+        (ascii_positive_max.as_slice(), "9223372036854775807"),
+        (ascii_negative_max.as_slice(), "-9223372036854775807"),
+    ] {
+        let decoded = decode_zoned_decimal(data, 19, 0, true, Codepage::ASCII, false)?;
+        ensure!(decoded.to_string() == expected);
+    }
+    ensure_overflow(&require_error(decode_zoned_decimal(
+        &ascii_negative_overflow,
+        19,
+        0,
+        true,
+        Codepage::ASCII,
+        false,
+    ))?)?;
+
+    let ebcdic_max = ebcdic_unsigned(I64_MAX_DIGITS);
+    let ebcdic_overflow = ebcdic_unsigned(I64_OVERFLOW_DIGITS);
+    let decoded = decode_zoned_decimal(&ebcdic_max, 19, 0, false, Codepage::CP037, false)?;
+    ensure!(decoded.to_string() == "9223372036854775807");
+    ensure_overflow(&require_error(decode_zoned_decimal(
+        &ebcdic_overflow,
+        19,
+        0,
+        false,
+        Codepage::CP037,
+        false,
+    ))?)?;
+
+    let mut ebcdic_negative_max = ebcdic_max;
+    ebcdic_negative_max[18] = 0xD7;
+    let mut ebcdic_negative_overflow = ebcdic_overflow;
+    ebcdic_negative_overflow[18] = 0xD8;
+    let decoded = decode_zoned_decimal(&ebcdic_negative_max, 19, 0, true, Codepage::CP037, false)?;
+    ensure!(decoded.to_string() == "-9223372036854775807");
+    ensure_overflow(&require_error(decode_zoned_decimal(
+        &ebcdic_negative_overflow,
+        19,
+        0,
+        true,
+        Codepage::CP037,
+        false,
+    ))?)?;
+    Ok(())
+}
+
+#[test]
+fn leading_zero_width_may_exceed_nineteen_when_magnitude_fits() -> Result<()> {
+    let decoded = decode_zoned_decimal(
+        b"09223372036854775807",
+        20,
+        0,
+        false,
+        Codepage::ASCII,
+        false,
+    )?;
+    ensure!(decoded.to_string() == "9223372036854775807");
+    Ok(())
+}
+
+#[test]
+fn decode_record_pic_9_19_preserves_typed_field_context() -> Result<()> {
+    let schema = parse_copybook("01 REC. 05 AMOUNT PIC 9(19).")?;
+    let options = DecodeOptions::new()
+        .with_format(RecordFormat::Fixed)
+        .with_codepage(Codepage::ASCII)
+        .with_json_number_mode(JsonNumberMode::Lossless);
+
+    let standard = require_error(decode_record(&schema, I64_OVERFLOW_DIGITS, &options))?;
+    ensure_overflow(&standard)?;
+    let standard_context = standard
+        .context
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("standard decode omitted overflow context"))?;
+    ensure!(standard_context.record_index == Some(0));
+    ensure!(standard_context.field_path.as_deref() == Some("REC.AMOUNT"));
+    ensure!(standard_context.byte_offset == Some(0));
+
+    let mut scratch = ScratchBuffers::new();
+    let scratch_error = require_error(decode_record_with_scratch(
+        &schema,
+        I64_OVERFLOW_DIGITS,
+        &options,
+        &mut scratch,
+    ))?;
+    ensure_overflow(&scratch_error)?;
+    let scratch_context = scratch_error
+        .context
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("scratch decode omitted overflow context"))?;
+    ensure!(scratch_context.record_index == Some(0));
+    ensure!(scratch_context.field_path.as_deref() == Some("REC.AMOUNT"));
+    ensure!(scratch_context.byte_offset == Some(0));
+    Ok(())
+}

--- a/crates/copybook-codec/tests/zoned_overflow.rs
+++ b/crates/copybook-codec/tests/zoned_overflow.rs
@@ -32,6 +32,15 @@ fn ensure_overflow(error: &Error) -> Result<()> {
     Ok(())
 }
 
+fn ensure_bad_sign(error: &Error) -> Result<()> {
+    ensure!(
+        error.code == ErrorCode::CBKD411_ZONED_BAD_SIGN,
+        "expected CBKD411_ZONED_BAD_SIGN, got {}",
+        error.code
+    );
+    Ok(())
+}
+
 fn ebcdic_unsigned(ascii_digits: &[u8]) -> Vec<u8> {
     ascii_digits
         .iter()
@@ -223,5 +232,71 @@ fn decode_record_pic_9_19_preserves_typed_field_context() -> Result<()> {
     ensure!(scratch_context.record_index == Some(0));
     ensure!(scratch_context.field_path.as_deref() == Some("REC.AMOUNT"));
     ensure!(scratch_context.byte_offset == Some(0));
+    Ok(())
+}
+
+#[test]
+fn unsigned_bad_sign_precedes_last_digit_overflow_across_decode_paths() -> Result<()> {
+    let mut bad_sign_and_overflow = I64_OVERFLOW_DIGITS.to_vec();
+    bad_sign_and_overflow[18] = b'Q';
+
+    ensure_bad_sign(&require_error(decode_zoned_decimal(
+        &bad_sign_and_overflow,
+        19,
+        0,
+        false,
+        Codepage::ASCII,
+        false,
+    ))?)?;
+
+    ensure_bad_sign(&require_error(decode_zoned_decimal_with_encoding(
+        &bad_sign_and_overflow,
+        19,
+        0,
+        false,
+        Codepage::ASCII,
+        false,
+        false,
+    ))?)?;
+
+    let mut scratch = ScratchBuffers::new();
+    ensure_bad_sign(&require_error(decode_zoned_decimal_with_scratch(
+        &bad_sign_and_overflow,
+        19,
+        0,
+        false,
+        Codepage::ASCII,
+        false,
+        &mut scratch,
+    ))?)?;
+    ensure_bad_sign(&require_error(
+        decode_zoned_decimal_to_string_with_scratch(
+            &bad_sign_and_overflow,
+            19,
+            0,
+            false,
+            Codepage::ASCII,
+            false,
+            &mut scratch,
+        ),
+    )?)?;
+
+    let schema = parse_copybook("01 REC. 05 AMOUNT PIC 9(19).")?;
+    let options = DecodeOptions::new()
+        .with_format(RecordFormat::Fixed)
+        .with_codepage(Codepage::ASCII)
+        .with_json_number_mode(JsonNumberMode::Lossless);
+    ensure_bad_sign(&require_error(decode_record(
+        &schema,
+        &bad_sign_and_overflow,
+        &options,
+    ))?)?;
+    ensure_bad_sign(&require_error(decode_record_with_scratch(
+        &schema,
+        &bad_sign_and_overflow,
+        &options,
+        &mut scratch,
+    ))?)?;
+
     Ok(())
 }

--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -10,7 +10,7 @@
 # content-addressed, so squash merges cannot invalidate it.
 schema_version = 1
 scope = "fixed-rdw-pipeline"
-content_digest = "5652932f8ab184d0b06c413c40566fb7792f198d651494df59d896f91e96e5b7"
+content_digest = "9a7b5e9c4346ab2236888ab67d580a3703b439a6ac00ba9493c825f443a090b8"
 
 [[scenarios]]
 id = "format.fixed.basic"


### PR DESCRIPTION
<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
# Pull Request

## Summary

Rejects zoned-decimal magnitudes that exceed `i64` capacity instead of silently saturating to `i64::MAX`. One checked digit-append invariant now serves the basic, encoding-preserving, scratch-backed, and string-wrapper decode paths, while high-level scalar, array, and ODO-counter decoding add field/record/offset context to `CBKD410_ZONED_OVERFLOW`. Unsigned final-byte sign validation retains `CBKD411_ZONED_BAD_SIGN` precedence when the same byte would also overflow.

## Type of Change

- [ ] Feature (new functionality)
- [x] Bugfix (fixes an issue)
- [ ] Refactor (code improvement without behavior change)
- [ ] Performance (optimization)
- [x] Documentation (README, docs/, code comments)
- [x] Tests (test additions or improvements)
- [ ] CI/CD (workflow or tooling changes)
- [ ] Chore (dependencies, formatting, etc.)

## COBOL/Mainframe Context

- **COBOL features affected**: DISPLAY/zoned decimal (`PIC 9`, `PIC S9`)
- **Data processing impact**: numeric decoding and validation
- **Mainframe compatibility**: ASCII and EBCDIC zoned data retain sign/scale semantics; out-of-range magnitudes now fail explicitly

## Workspace Crates Affected

- [ ] copybook-core (parsing, schema, AST)
- [x] copybook-codec (encoding, decoding, character conversion)
- [ ] copybook-codec-memory (shared memory primitives for codec hot paths)
- [ ] copybook-cli (CLI commands and options)
- [ ] copybook-gen (test fixture generation)
- [ ] copybook-bench (performance benchmarks)
- [ ] copybook-contracts (feature flag contracts)
- [ ] copybook-support-matrix (COBOL support contract data)
- [ ] copybook-governance-contracts (contracts + support matrix facade)
- [ ] copybook-governance-grid (support-to-flag mapping)
- [ ] copybook-governance-runtime (runtime governance state evaluation)
- [ ] copybook-governance (governance compatibility facade)
- [ ] copybook-bdd (BDD smoke/exploratory runners)

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (public error rustdocs, obsolete saturation wording, and governed record-pipeline digest)
- [ ] CHANGELOG.md updated (not required for this focused correctness fix)
- [x] `rtk cargo fmt -p copybook-codec -- --check` passes
- [ ] Broad test-target Clippy passes (blocked by unrelated existing test lint debt; scoped library and new target pass)
- [ ] Full crate test command passes (blocked by existing `CARGO_BIN_EXE_copybook` harness requirement)
- [ ] `bash scripts/ci/governance-bdd-smoke.sh` passes (not applicable)
- [x] Follows conventional commit format
- [ ] MSRV compliance verified (no dependency or toolchain change)
- [ ] Golden fixtures updated (not applicable)

## Testing Instructions

```text
rtk cargo test -p copybook-codec --test zoned_overflow
# PASS: 7 tests

rtk cargo test -p copybook-codec --lib
# PASS: 219 tests

rtk cargo test -p copybook-codec --test zoned_encoding_format_tests
# PASS: 16 tests

rtk cargo test -p copybook-codec --test scratch_decode_integration
# PASS: 4 tests

rtk cargo fmt -p copybook-codec -- --check
# PASS

rtk cargo clippy -p copybook-codec --lib -- -D warnings -W clippy::pedantic
# PASS

rtk cargo clippy -p copybook-codec --test zoned_overflow -- -D warnings -W clippy::pedantic
# PASS

rtk cargo test -p copybook-codec
# FAIL after passing library and early integration suites: existing
# binary_roundtrip_fidelity_tests::test_cli_roundtrip_cmp_validation expects
# CARGO_BIN_EXE_copybook, which is unset for this package-only invocation.

rtk cargo clippy -p copybook-codec --tests -- -D warnings -W clippy::pedantic
# FAIL on existing unrelated lint debt in float/edited-PIC/streaming tests.

rtk cargo run -p xtask -- docs sync-record-pipeline
# PASS: final digest 9a7b5e9c4346ab2236888ab67d580a3703b439a6ac00ba9493c825f443a090b8

rtk cargo run -p xtask -- docs verify-record-pipeline
# PASS: 11 scenarios at the final digest

rtk cargo run -p xtask -- docs verify-all
# FAIL at unrelated pre-existing stable-error-registry handling of
# CBKW005_PARQUET_WRITE, which is present on origin/main in the enum,
# stable-surface contract, stable-errors ledger, and ERROR_CODES reference.
```

## Performance Impact

- [x] No material performance impact expected; valid digits use checked integer operations in the existing accumulation loop
- [ ] Performance improvement
- [ ] Performance regression acceptable
- [ ] Performance tested with baseline comparison

## Infrastructure/Tooling Changes

None.

**Adversarial Testing**:
- [x] Tested with malformed/out-of-range input and exact typed error
- [x] Verified boundary cases: `i64::MAX`, next magnitude, positive/negative overpunch, combined invalid-sign-plus-overflow precedence, ASCII/EBCDIC, preservation on/off, scratch/string wrappers, scale, and leading-zero width
- [x] Manual calculation verification for numeric boundaries
- [ ] Drift detection validated (not applicable)

## Breaking Changes

- [x] No supported-contract breaking change; silent data loss now becomes a typed error
- [ ] Breaking changes with migration path

## Enterprise Validation

- [ ] Performance targets rebenchmarked (no performance claim)
- [ ] Tested with real-world mainframe data
- [x] Existing `CBKD410_ZONED_OVERFLOW` taxonomy reused and asserted
- [x] Compatible in-range ASCII/EBCDIC, sign, scale, and preservation behavior covered

## Related Issues

Closes #764

Parent: #658. Related evidence coordinator: #574.

## Additional Notes

`rtk 0.45.0` became available during remediation and all remediation proof used it. Initial-head proof used direct commands while the wrapper was unavailable.

Claim boundary: this PR fixes zoned-decimal magnitude accumulation only. It does not add arbitrary precision, change COMP-3, redesign schemas/error taxonomy, or address the separate negative-scale formatting multiplication in `decimal.rs`.