### PR TITLE
fix(xtask): parse stable errors across line endings

### DIFF
--- a/tools/xtask/src/docs_verify.rs
+++ b/tools/xtask/src/docs_verify.rs
@@ -1505,14 +1505,14 @@ fn parse_error_code_variants(source: &str) -> Result<Vec<String>> {
     let variant_re =
         Regex::new(r"^([A-Z][A-Z0-9_]*)[ \t]*(?:=[ \t]*[^,]+)?[ \t]*,[ \t]*(?://.*)?$")?;
     let variant_candidate_re = Regex::new(r"^[A-Z][A-Z0-9_]*\b")?;
-    let closing_re = Regex::new(r"^}[ \t]*[;,]?$")?;
+    let closing_re = Regex::new(r"^}$")?;
     let mut lexical_state = RustLineState::default();
     let mut variants = BTreeSet::new();
     let mut found_end = false;
     for line in source[start..].lines() {
         let code = rust_code_on_line(line, &mut lexical_state);
         let line = code.trim();
-        if lexical_state.is_code() && closing_re.is_match(line) {
+        if closing_re.is_match(line) {
             found_end = true;
             break;
         }
@@ -1537,12 +1537,6 @@ struct RustLineState {
     quoted: Option<char>,
     raw_string_hashes: Option<usize>,
     escaped: bool,
-}
-
-impl RustLineState {
-    fn is_code(&self) -> bool {
-        self.block_comment_depth == 0 && self.quoted.is_none() && self.raw_string_hashes.is_none()
-    }
 }
 
 fn rust_code_on_line(line: &str, state: &mut RustLineState) -> String {
@@ -3316,20 +3310,29 @@ mod tests {
 
     #[test]
     fn parse_error_code_variants_ignores_braces_outside_enum_syntax() {
-        let lf = r##"pub enum ErrorCode {
+        let lf = r###"pub enum ErrorCode {
     /// A doc comment containing } and { braces.
     #[doc = "an attribute string containing } and {"]
+    #[doc = "an ordinary string with an escaped quote: \"
+       }
+       and more content"]
     #[doc = r#"a raw attribute string containing
        " and a delimiter-looking line:
        }
        {"#]
+    #[parser_fixture = br##"a byte raw string containing
+       " and }# without the two-hash terminator,
+       }
+       plus more content"##]
     CBK001_FIRST,
     /* A block comment starts with {
+       /* nested } and { block comment */
        } and neither brace is an enum delimiter. */
     CBK002_FINAL, // trailing } comment
-} // actual enum terminator
+} /* actual enum terminator with a multiline trailing comment
+*/
 CBK999_OUTSIDE,
-"##;
+"###;
         let crlf = lf.replace('\n', "\r\n");
         let expected = vec!["CBK001_FIRST".to_string(), "CBK002_FINAL".to_string()];
 
@@ -3347,6 +3350,12 @@ CBK999_OUTSIDE,
         assert!(parse_error_code_variants("pub enum Other { CBK001_VALUE, }").is_err());
         assert!(parse_error_code_variants("pub enum ErrorCode {\n").is_err());
         assert!(parse_error_code_variants("pub enum ErrorCode {\n}\n").is_err());
+        assert!(
+            parse_error_code_variants("pub enum ErrorCode {\n    CBK001_VALID,\n};\n").is_err()
+        );
+        assert!(
+            parse_error_code_variants("pub enum ErrorCode {\n    CBK001_VALID,\n},\n").is_err()
+        );
         assert!(
             parse_error_code_variants(
                 "pub enum ErrorCode {\n    CBK001_VALID,\n    CBK002_MISSING_COMMA\n}\n"

--- a/tools/xtask/src/docs_verify.rs
+++ b/tools/xtask/src/docs_verify.rs
@@ -1502,40 +1502,89 @@ fn parse_error_code_variants(source: &str) -> Result<Vec<String>> {
         .ok_or_else(|| anyhow::anyhow!("could not find ErrorCode enum"))?
         .end();
 
-    let mut depth = 1i32;
-    let mut end = None;
-    for (offset, ch) in source[start..].char_indices() {
-        match ch {
-            '{' => depth += 1,
-            '}' => {
-                depth -= 1;
-                if depth == 0 {
-                    end = Some(start + offset);
-                    break;
-                }
-            }
-            _ => {}
-        }
-    }
-    let end = end.ok_or_else(|| anyhow::anyhow!("could not parse ErrorCode enum body"))?;
-
-    let remainder = &source[start..end];
     let variant_re =
         Regex::new(r"^([A-Z][A-Z0-9_]*)[ \t]*(?:=[ \t]*[^,]+)?[ \t]*,[ \t]*(?://.*)?$")?;
     let variant_candidate_re = Regex::new(r"^[A-Z][A-Z0-9_]*\b")?;
+    let closing_re = Regex::new(r"^}[ \t]*[;,]?$")?;
+    let mut lexical_state = RustLineState::default();
     let mut variants = BTreeSet::new();
-    for line in remainder.lines() {
-        let line = line.trim();
+    let mut found_end = false;
+    for line in source[start..].lines() {
+        let code = rust_code_on_line(line, &mut lexical_state);
+        let line = code.trim();
+        if lexical_state.is_code() && closing_re.is_match(line) {
+            found_end = true;
+            break;
+        }
         if let Some(capture) = variant_re.captures(line) {
             variants.insert(capture[1].to_string());
         } else if variant_candidate_re.is_match(line) {
             bail!("malformed ErrorCode variant line `{line}`");
         }
     }
+    if !found_end {
+        bail!("could not parse ErrorCode enum body");
+    }
     if variants.is_empty() {
         bail!("no ErrorCode variants parsed");
     }
     Ok(variants.into_iter().collect())
+}
+
+#[derive(Default)]
+struct RustLineState {
+    block_comment_depth: usize,
+    quoted: Option<char>,
+    escaped: bool,
+}
+
+impl RustLineState {
+    fn is_code(&self) -> bool {
+        self.block_comment_depth == 0 && self.quoted.is_none()
+    }
+}
+
+fn rust_code_on_line(line: &str, state: &mut RustLineState) -> String {
+    let mut code = String::with_capacity(line.len());
+    let mut chars = line.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if let Some(quote) = state.quoted {
+            if state.escaped {
+                state.escaped = false;
+            } else if ch == '\\' {
+                state.escaped = true;
+            } else if ch == quote {
+                state.quoted = None;
+            }
+            continue;
+        }
+        if state.block_comment_depth > 0 {
+            if ch == '/' && chars.peek() == Some(&'*') {
+                let _ = chars.next();
+                state.block_comment_depth += 1;
+            } else if ch == '*' && chars.peek() == Some(&'/') {
+                let _ = chars.next();
+                state.block_comment_depth -= 1;
+            }
+            continue;
+        }
+        if ch == '/' && chars.peek() == Some(&'/') {
+            break;
+        }
+        if ch == '/' && chars.peek() == Some(&'*') {
+            let _ = chars.next();
+            state.block_comment_depth = 1;
+            continue;
+        }
+        if matches!(ch, '\'' | '"') {
+            state.quoted = Some(ch);
+            state.escaped = false;
+            continue;
+        }
+        code.push(ch);
+    }
+    state.escaped = false;
+    code
 }
 
 fn parse_jsonl_schema_inventory(source: &str) -> Result<(Vec<String>, Vec<String>, Vec<String>)> {
@@ -3224,6 +3273,30 @@ mod tests {
     #[test]
     fn parse_error_code_variants_is_line_ending_invariant_for_final_member() {
         let lf = "pub enum ErrorCode {\n    CBK001_FIRST,\n    CBK002_FINAL,\n}\n";
+        let crlf = lf.replace('\n', "\r\n");
+        let expected = vec!["CBK001_FIRST".to_string(), "CBK002_FINAL".to_string()];
+
+        assert_eq!(parse_error_code_variants(lf).unwrap(), expected);
+        assert_eq!(parse_error_code_variants(&crlf).unwrap(), expected);
+        assert_eq!(parse_error_code_variant_count(lf).unwrap(), expected.len());
+        assert_eq!(
+            parse_error_code_variant_count(&crlf).unwrap(),
+            expected.len()
+        );
+    }
+
+    #[test]
+    fn parse_error_code_variants_ignores_braces_outside_enum_syntax() {
+        let lf = r#"pub enum ErrorCode {
+    /// A doc comment containing } and { braces.
+    #[doc = "an attribute string containing } and {"]
+    CBK001_FIRST,
+    /* A block comment starts with {
+       } and neither brace is an enum delimiter. */
+    CBK002_FINAL, // trailing } comment
+} // actual enum terminator
+CBK999_OUTSIDE,
+"#;
         let crlf = lf.replace('\n', "\r\n");
         let expected = vec!["CBK001_FIRST".to_string(), "CBK002_FINAL".to_string()];
 

--- a/tools/xtask/src/docs_verify.rs
+++ b/tools/xtask/src/docs_verify.rs
@@ -1503,29 +1503,34 @@ fn parse_error_code_variants(source: &str) -> Result<Vec<String>> {
         .end();
 
     let mut depth = 1i32;
-    let mut end = source.len();
+    let mut end = None;
     for (offset, ch) in source[start..].char_indices() {
         match ch {
             '{' => depth += 1,
             '}' => {
                 depth -= 1;
                 if depth == 0 {
-                    end = start + offset;
+                    end = Some(start + offset);
                     break;
                 }
             }
             _ => {}
         }
     }
-    if end <= start {
-        bail!("could not parse ErrorCode enum body");
-    }
+    let end = end.ok_or_else(|| anyhow::anyhow!("could not parse ErrorCode enum body"))?;
 
     let remainder = &source[start..end];
-    let variant_re = Regex::new(r"(?m)^\s*([A-Z][A-Z0-9_]*)\s*(?:=\s*[^,]+)?\s*,(?:\s*//.*)?$")?;
+    let variant_re =
+        Regex::new(r"^([A-Z][A-Z0-9_]*)[ \t]*(?:=[ \t]*[^,]+)?[ \t]*,[ \t]*(?://.*)?$")?;
+    let variant_candidate_re = Regex::new(r"^[A-Z][A-Z0-9_]*\b")?;
     let mut variants = BTreeSet::new();
-    for capture in variant_re.captures_iter(remainder) {
-        variants.insert(capture[1].to_string());
+    for line in remainder.lines() {
+        let line = line.trim();
+        if let Some(capture) = variant_re.captures(line) {
+            variants.insert(capture[1].to_string());
+        } else if variant_candidate_re.is_match(line) {
+            bail!("malformed ErrorCode variant line `{line}`");
+        }
     }
     if variants.is_empty() {
         bail!("no ErrorCode variants parsed");
@@ -2738,29 +2743,7 @@ fn parse_cli_command_variants(source: &str) -> Result<Vec<String>> {
 }
 
 fn parse_error_code_variant_count(source: &str) -> Result<usize> {
-    let start_re = Regex::new(r"(?m)^pub enum ErrorCode \{")?;
-    let start = start_re
-        .find(source)
-        .ok_or_else(|| anyhow::anyhow!("could not find ErrorCode enum"))?
-        .end();
-
-    let variant_re = Regex::new(r"(?m)^[A-Z][A-Z0-9_]+\s*(?:=\s*[^,]+)?\s*,(?:\s*//.*)?$")?;
-    let mut count = 0usize;
-    for line in source[start..].lines() {
-        let line = line.trim();
-        if line.trim() == "}" {
-            break;
-        }
-        if variant_re.is_match(line) {
-            count += 1;
-        }
-    }
-
-    if count == 0 {
-        bail!("no ErrorCode variants found");
-    }
-
-    Ok(count)
+    Ok(parse_error_code_variants(source)?.len())
 }
 
 fn parse_error_index_count(source: &str) -> Result<usize> {
@@ -3227,7 +3210,43 @@ mod tests {
     CBK003_FLAG, // plain variant
 }"#;
 
+        assert_eq!(
+            parse_error_code_variants(source).unwrap(),
+            vec![
+                "CBK001_ORDINAL".to_string(),
+                "CBK002_COMMENTS".to_string(),
+                "CBK003_FLAG".to_string(),
+            ]
+        );
         assert_eq!(parse_error_code_variant_count(source).unwrap(), 3);
+    }
+
+    #[test]
+    fn parse_error_code_variants_is_line_ending_invariant_for_final_member() {
+        let lf = "pub enum ErrorCode {\n    CBK001_FIRST,\n    CBK002_FINAL,\n}\n";
+        let crlf = lf.replace('\n', "\r\n");
+        let expected = vec!["CBK001_FIRST".to_string(), "CBK002_FINAL".to_string()];
+
+        assert_eq!(parse_error_code_variants(lf).unwrap(), expected);
+        assert_eq!(parse_error_code_variants(&crlf).unwrap(), expected);
+        assert_eq!(parse_error_code_variant_count(lf).unwrap(), expected.len());
+        assert_eq!(
+            parse_error_code_variant_count(&crlf).unwrap(),
+            expected.len()
+        );
+    }
+
+    #[test]
+    fn parse_error_code_variants_rejects_missing_or_empty_enum() {
+        assert!(parse_error_code_variants("pub enum Other { CBK001_VALUE, }").is_err());
+        assert!(parse_error_code_variants("pub enum ErrorCode {\n").is_err());
+        assert!(parse_error_code_variants("pub enum ErrorCode {\n}\n").is_err());
+        assert!(
+            parse_error_code_variants(
+                "pub enum ErrorCode {\n    CBK001_VALID,\n    CBK002_MISSING_COMMA\n}\n"
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/tools/xtask/src/docs_verify.rs
+++ b/tools/xtask/src/docs_verify.rs
@@ -1535,12 +1535,13 @@ fn parse_error_code_variants(source: &str) -> Result<Vec<String>> {
 struct RustLineState {
     block_comment_depth: usize,
     quoted: Option<char>,
+    raw_string_hashes: Option<usize>,
     escaped: bool,
 }
 
 impl RustLineState {
     fn is_code(&self) -> bool {
-        self.block_comment_depth == 0 && self.quoted.is_none()
+        self.block_comment_depth == 0 && self.quoted.is_none() && self.raw_string_hashes.is_none()
     }
 }
 
@@ -1548,6 +1549,19 @@ fn rust_code_on_line(line: &str, state: &mut RustLineState) -> String {
     let mut code = String::with_capacity(line.len());
     let mut chars = line.chars().peekable();
     while let Some(ch) = chars.next() {
+        if let Some(hash_count) = state.raw_string_hashes {
+            if ch == '"' {
+                let mut lookahead = chars.clone();
+                let closes = (0..hash_count).all(|_| lookahead.next() == Some('#'));
+                if closes {
+                    for _ in 0..hash_count {
+                        let _ = chars.next();
+                    }
+                    state.raw_string_hashes = None;
+                }
+            }
+            continue;
+        }
         if let Some(quote) = state.quoted {
             if state.escaped {
                 state.escaped = false;
@@ -1575,6 +1589,21 @@ fn rust_code_on_line(line: &str, state: &mut RustLineState) -> String {
             let _ = chars.next();
             state.block_comment_depth = 1;
             continue;
+        }
+        if ch == 'r' {
+            let mut lookahead = chars.clone();
+            let mut hash_count = 0usize;
+            while lookahead.peek() == Some(&'#') {
+                let _ = lookahead.next();
+                hash_count += 1;
+            }
+            if lookahead.next() == Some('"') {
+                for _ in 0..=hash_count {
+                    let _ = chars.next();
+                }
+                state.raw_string_hashes = Some(hash_count);
+                continue;
+            }
         }
         if matches!(ch, '\'' | '"') {
             state.quoted = Some(ch);
@@ -3287,16 +3316,20 @@ mod tests {
 
     #[test]
     fn parse_error_code_variants_ignores_braces_outside_enum_syntax() {
-        let lf = r#"pub enum ErrorCode {
+        let lf = r##"pub enum ErrorCode {
     /// A doc comment containing } and { braces.
     #[doc = "an attribute string containing } and {"]
+    #[doc = r#"a raw attribute string containing
+       " and a delimiter-looking line:
+       }
+       {"#]
     CBK001_FIRST,
     /* A block comment starts with {
        } and neither brace is an enum delimiter. */
     CBK002_FINAL, // trailing } comment
 } // actual enum terminator
 CBK999_OUTSIDE,
-"#;
+"##;
         let crlf = lf.replace('\n', "\r\n");
         let expected = vec!["CBK001_FIRST".to_string(), "CBK002_FINAL".to_string()];
 

--- a/tools/xtask/src/docs_verify.rs
+++ b/tools/xtask/src/docs_verify.rs
@@ -1505,16 +1505,18 @@ fn parse_error_code_variants(source: &str) -> Result<Vec<String>> {
     let variant_re =
         Regex::new(r"^([A-Z][A-Z0-9_]*)[ \t]*(?:=[ \t]*[^,]+)?[ \t]*,[ \t]*(?://.*)?$")?;
     let variant_candidate_re = Regex::new(r"^[A-Z][A-Z0-9_]*\b")?;
-    let closing_re = Regex::new(r"^}$")?;
     let mut lexical_state = RustLineState::default();
     let mut variants = BTreeSet::new();
     let mut found_end = false;
     for line in source[start..].lines() {
         let code = rust_code_on_line(line, &mut lexical_state);
         let line = code.trim();
-        if closing_re.is_match(line) {
-            found_end = true;
-            break;
+        if line.starts_with('}') {
+            if line == "}" {
+                found_end = true;
+                break;
+            }
+            bail!("malformed ErrorCode enum terminator `{line}`");
         }
         if let Some(capture) = variant_re.captures(line) {
             variants.insert(capture[1].to_string());
@@ -3351,10 +3353,16 @@ CBK999_OUTSIDE,
         assert!(parse_error_code_variants("pub enum ErrorCode {\n").is_err());
         assert!(parse_error_code_variants("pub enum ErrorCode {\n}\n").is_err());
         assert!(
-            parse_error_code_variants("pub enum ErrorCode {\n    CBK001_VALID,\n};\n").is_err()
+            parse_error_code_variants(
+                "pub enum ErrorCode {\n    CBK001_VALID,\n};\nimpl Outside {\n}\nCBK999_OUTSIDE,\n"
+            )
+            .is_err()
         );
         assert!(
-            parse_error_code_variants("pub enum ErrorCode {\n    CBK001_VALID,\n},\n").is_err()
+            parse_error_code_variants(
+                "pub enum ErrorCode {\n    CBK001_VALID,\n},\n}\nCBK999_OUTSIDE,\n"
+            )
+            .is_err()
         );
         assert!(
             parse_error_code_variants(


### PR DESCRIPTION
## Summary

- make stable `ErrorCode` inventory parsing invariant across LF and CRLF
- use one comment/string-aware, line-oriented parser for registry membership and count verification
- ignore braces in docs, line/block comments, attributes, and quoted strings
- reject missing, unclosed, empty, and malformed variant input

Closes #766.

## Why this seam

On Windows, the prior multiline regex let `\s*` consume CRLF and the following doc-comment line. The final `CBKW005_PARQUET_WRITE` variant had no following doc comment and disappeared from the parsed inventory (64 parsed versus 65 canonical), while Linux LF CI passed. A follow-up review also identified that raw brace counting could mistake comment or string content for the enum boundary.

## Proof

- PASS: `rtk cargo test -p xtask` — 142 tests
- PASS: `rtk cargo run -p xtask -- docs verify-stable-errors` — 65 codes (57 direct, 8 pending)
- PASS: `rtk cargo fmt -p xtask -- --check`
- PASS: `rtk cargo clippy -p xtask --tests -- -D warnings -W clippy::pedantic`
- PARTIAL: `rtk cargo run -p xtask -- docs verify-all` passed stable-error registry and fixed/RDW evidence, then stopped at the existing local prerequisite: no nextest `junit.xml`; `cargo-nextest` is not installed in this environment. Hosted docs-truth generates JUnit before verification.

## Claim boundary

This changes only xtask source parsing and its fixtures. It does not change the error taxonomy, stability classifications, stable-error registry, generated contracts, or runtime error behavior.

## Non-goals

- taxonomy or registry edits
- broad Rust syntax parsing infrastructure
- changes to unrelated docs-truth checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of error-code definitions to correctly ignore comments and quoted or raw string content.
  * Prevented invalid or incomplete enum syntax from being accepted.
  * Added support for consistent parsing across LF and CRLF line endings.

* **Tests**
  * Expanded coverage for discriminants, nested comments, braces, malformed definitions, missing commas, empty enums, and trailing content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->