### PR TITLE
fix(core): reject hostile PIC repetitions

### DIFF
--- a/crates/copybook-core/src/parser.rs
+++ b/crates/copybook-core/src/parser.rs
@@ -37,6 +37,20 @@ fn try_extract_data_name(token_pos: &TokenPos) -> Option<String> {
     }
 }
 
+fn require_pic_repetition_adjacency(
+    previous_end: Option<usize>,
+    token: &TokenPos,
+    part: &str,
+) -> Result<()> {
+    if previous_end == Some(token.span.start) {
+        return Ok(());
+    }
+    Err(Error::new(
+        ErrorCode::CBKP101_INVALID_PIC,
+        format!("PIC repetition {part} must be attached to the preceding token"),
+    ))
+}
+
 /// Parse a COBOL copybook text into a schema
 ///
 /// # Errors
@@ -750,23 +764,20 @@ impl Parser {
         while let Some(token) = self.current_token() {
             match &token.token {
                 Token::LeftParen => {
-                    if previous_pic_end.is_some_and(|end| end != token.span.start) {
-                        return Err(Error::new(
-                            ErrorCode::CBKP101_INVALID_PIC,
-                            "PIC repetition count must be attached to its symbol",
-                        ));
-                    }
+                    require_pic_repetition_adjacency(previous_pic_end, token, "opening `(`")?;
                     previous_pic_end = Some(token.span.end);
                     paren_depth += 1;
                     pic_parts.push("(".to_string());
                     self.advance();
                 }
                 Token::Number(n) if paren_depth > 0 => {
+                    require_pic_repetition_adjacency(previous_pic_end, token, "count digits")?;
                     previous_pic_end = Some(token.span.end);
                     pic_parts.push(n.to_string());
                     self.advance();
                 }
                 Token::RightParen if paren_depth > 0 => {
+                    require_pic_repetition_adjacency(previous_pic_end, token, "closing `)`")?;
                     previous_pic_end = Some(token.span.end);
                     paren_depth -= 1;
                     pic_parts.push(")".to_string());
@@ -779,9 +790,28 @@ impl Parser {
                     self.advance();
                 }
                 Token::EditedPic(ep) => {
+                    if pic_parts.last().is_some_and(|part| part.ends_with(')')) {
+                        require_pic_repetition_adjacency(
+                            previous_pic_end,
+                            token,
+                            "continued picture symbol",
+                        )?;
+                    }
                     previous_pic_end = Some(token.span.end);
                     // Continuation of edited PIC after comma/period
                     pic_parts.push(ep.clone());
+                    self.advance();
+                }
+                Token::PicClause(pic) if token.line == token_line => {
+                    if pic_parts.last().is_some_and(|part| part.ends_with(')')) {
+                        require_pic_repetition_adjacency(
+                            previous_pic_end,
+                            token,
+                            "continued PIC clause",
+                        )?;
+                    }
+                    previous_pic_end = Some(token.span.end);
+                    pic_parts.push(pic.clone());
                     self.advance();
                 }
                 Token::Period => {

--- a/crates/copybook-core/src/parser.rs
+++ b/crates/copybook-core/src/parser.rs
@@ -700,6 +700,7 @@ impl Parser {
 
         // Track the starting line for same-line checks
         let token_line = self.current_token().map_or(0, |t| t.line);
+        let mut previous_pic_end = self.current_token().map(|t| t.span.end);
 
         // First token should be a PIC clause or identifier
         match self.current_token() {
@@ -749,25 +750,36 @@ impl Parser {
         while let Some(token) = self.current_token() {
             match &token.token {
                 Token::LeftParen => {
+                    if previous_pic_end.is_some_and(|end| end != token.span.start) {
+                        return Err(Error::new(
+                            ErrorCode::CBKP101_INVALID_PIC,
+                            "PIC repetition count must be attached to its symbol",
+                        ));
+                    }
+                    previous_pic_end = Some(token.span.end);
                     paren_depth += 1;
                     pic_parts.push("(".to_string());
                     self.advance();
                 }
                 Token::Number(n) if paren_depth > 0 => {
+                    previous_pic_end = Some(token.span.end);
                     pic_parts.push(n.to_string());
                     self.advance();
                 }
                 Token::RightParen if paren_depth > 0 => {
+                    previous_pic_end = Some(token.span.end);
                     paren_depth -= 1;
                     pic_parts.push(")".to_string());
                     self.advance();
                 }
                 Token::Comma => {
+                    previous_pic_end = Some(token.span.end);
                     // Comma in edited PIC patterns like $ZZ,ZZZ.99
                     pic_parts.push(",".to_string());
                     self.advance();
                 }
                 Token::EditedPic(ep) => {
+                    previous_pic_end = Some(token.span.end);
                     // Continuation of edited PIC after comma/period
                     pic_parts.push(ep.clone());
                     self.advance();
@@ -794,6 +806,7 @@ impl Parser {
                                 | Token::Identifier(_)
                         );
                         if next.line == token_line && is_pic_continuation {
+                            previous_pic_end = Some(token.span.end);
                             pic_parts.push(".".to_string());
                             self.advance();
                             continue;
@@ -805,6 +818,7 @@ impl Parser {
                     // Number outside parens on same line (e.g., "ZZZ9" split as EditedPic + Number)
                     let t = token.clone();
                     if t.line == token_line {
+                        previous_pic_end = Some(token.span.end);
                         pic_parts.push(n.to_string());
                         self.advance();
                     } else {
@@ -812,6 +826,7 @@ impl Parser {
                     }
                 }
                 Token::Identifier(id) if id.starts_with('V') || id.starts_with('v') => {
+                    previous_pic_end = Some(token.span.end);
                     pic_parts.push(id.clone());
                     self.advance();
                 }
@@ -819,6 +834,7 @@ impl Parser {
                 Token::Identifier(id) => {
                     let id_upper = id.to_ascii_uppercase();
                     if id_upper == "CR" || id_upper == "DB" {
+                        previous_pic_end = Some(token.span.end);
                         pic_parts.push(id.clone());
                         self.advance();
                     } else {

--- a/crates/copybook-core/src/pic.rs
+++ b/crates/copybook-core/src/pic.rs
@@ -627,6 +627,8 @@ mod tests {
             "9((2))",
             "9 (2)",
             "X\t(2)",
+            "9( 2)",
+            "9(2 )",
             "9(2)(3)",
             "9V(2)",
             "S(2)9",
@@ -637,6 +639,8 @@ mod tests {
             "Z(65536)",
             "Z (2)",
             "*\t(2)",
+            "Z( 2)",
+            "Z(2 )",
             "Z(2)(3)",
             "ZV(2)",
             "Z)",
@@ -696,10 +700,70 @@ mod tests {
         for copybook in [
             "01 ROOT.\n   05 FIELD PIC 9 (2).",
             "01 ROOT.\n   05 FIELD PIC Z\t(2).",
+            "01 ROOT.\n   05 FIELD PIC 9( 2).",
+            "01 ROOT.\n   05 FIELD PIC 9(\t2).",
+            "01 ROOT.\n   05 FIELD PIC Z( 2).",
+            "01 ROOT.\n   05 FIELD PIC Z(\t2).",
+            "01 ROOT.\n   05 FIELD PIC 9(2 ).",
+            "01 ROOT.\n   05 FIELD PIC 9(2\t).",
+            "01 ROOT.\n   05 FIELD PIC Z(2 ).",
+            "01 ROOT.\n   05 FIELD PIC Z(2\t).",
         ] {
             let error = crate::parse_copybook(copybook).unwrap_err();
             assert_eq!(error.code, ErrorCode::CBKP101_INVALID_PIC, "{copybook}");
             assert!(error.message.contains("must be attached"), "{copybook}");
+        }
+
+        for copybook in [
+            "01 ROOT.\n   05 FIELD PIC 9(\n2).",
+            "01 ROOT.\n   05 FIELD PIC Z(2\n).",
+        ] {
+            let error = crate::parse_copybook(copybook).unwrap_err();
+            assert_eq!(error.code, ErrorCode::CBKP101_INVALID_PIC, "{copybook}");
+        }
+    }
+
+    #[test]
+    fn parser_preserves_immediate_repetitions_and_ordinary_pic_whitespace() {
+        assert_eq!(PicClause::parse("9(2)9(3)").unwrap().digits, 5);
+        assert_eq!(PicClause::parse("Z(2)Z(3)").unwrap().digits, 5);
+
+        let repeated = crate::parse_copybook("01 ROOT.\n   05 FIELD PIC 9(2)9(3).").unwrap();
+        let field = repeated.find_field("ROOT.FIELD").unwrap();
+        assert!(
+            matches!(
+                field.kind,
+                crate::schema::FieldKind::ZonedDecimal { digits: 5, .. }
+            ),
+            "{:?}",
+            field.kind
+        );
+
+        let edited = crate::parse_copybook("01 ROOT.\n   05 FIELD PIC Z(2)Z(3).").unwrap();
+        let field = edited.find_field("ROOT.FIELD").unwrap();
+        assert!(
+            matches!(
+                field.kind,
+                crate::schema::FieldKind::EditedNumeric { width: 5, .. }
+            ),
+            "{:?}",
+            field.kind
+        );
+
+        for copybook in [
+            "01 ROOT.\n   05 FIELD PIC 9(2) 9(3).",
+            "01 ROOT.\n   05 FIELD PIC Z(2)\tZ(3).",
+        ] {
+            let error = crate::parse_copybook(copybook).unwrap_err();
+            assert_eq!(error.code, ErrorCode::CBKP101_INVALID_PIC, "{copybook}");
+            assert!(error.message.contains("must be attached"), "{copybook}");
+        }
+
+        for copybook in [
+            "01 ROOT.\n   05 FIELD PIC 9 9.",
+            "01 ROOT.\n   05 FIELD PIC Z Z.",
+        ] {
+            assert!(crate::parse_copybook(copybook).is_ok(), "{copybook}");
         }
     }
 }

--- a/crates/copybook-core/src/pic.rs
+++ b/crates/copybook-core/src/pic.rs
@@ -25,6 +25,8 @@
 use crate::error::ErrorCode;
 use crate::{Error, Result};
 use std::fmt;
+use std::iter::Peekable;
+use std::str::Chars;
 
 /// Parsed PIC clause information
 ///
@@ -103,6 +105,7 @@ impl PicClause {
         let mut scale = 0i16;
         let mut kind = None;
         let mut found_v = false;
+        let mut repetition_eligible = false;
 
         // Check for leading S (signed)
         if chars.peek() == Some(&'S') || chars.peek() == Some(&'s') {
@@ -120,7 +123,8 @@ impl PicClause {
                         ));
                     }
                     kind = Some(PicKind::Alphanumeric);
-                    digits += 1;
+                    digits = checked_add_u16(digits, 1, pic_str, "PIC width")?;
+                    repetition_eligible = true;
                 }
                 '9' => {
                     if kind.is_some() && kind != Some(PicKind::NumericDisplay) {
@@ -130,10 +134,11 @@ impl PicClause {
                         ));
                     }
                     kind = Some(PicKind::NumericDisplay);
-                    digits += 1;
+                    digits = checked_add_u16(digits, 1, pic_str, "PIC width")?;
                     if found_v {
-                        scale += 1;
+                        scale = checked_add_i16(scale, 1, pic_str, "PIC scale")?;
                     }
+                    repetition_eligible = true;
                 }
                 'V' => {
                     if found_v {
@@ -149,51 +154,31 @@ impl PicClause {
                         ));
                     }
                     found_v = true;
+                    repetition_eligible = false;
                 }
                 '(' => {
-                    // Parse repetition count
-                    let mut count_str = String::new();
-                    while let Some(&ch) = chars.peek() {
-                        if ch == ')' {
-                            chars.next(); // consume ')'
-                            break;
-                        }
-                        if ch.is_ascii_digit() {
-                            if let Some(digit_char) = chars.next() {
-                                count_str.push(digit_char);
-                            } else {
-                                return Err(Error::new(
-                                    ErrorCode::CBKP001_SYNTAX,
-                                    format!("Unexpected end of digit sequence in PIC: {}", pic_str),
-                                ));
-                            }
-                        } else {
-                            return Err(Error::new(
-                                ErrorCode::CBKP001_SYNTAX,
-                                format!("Invalid repetition count: {}", pic_str),
-                            ));
-                        }
-                    }
-
-                    let count: u16 = count_str.parse().map_err(|_| {
-                        Error::new(
-                            ErrorCode::CBKP001_SYNTAX,
-                            format!("Invalid repetition count: {}", count_str),
-                        )
-                    })?;
-
-                    if count == 0 {
-                        return Err(Error::new(
-                            ErrorCode::CBKP001_SYNTAX,
-                            "Repetition count cannot be zero".to_string(),
+                    if !repetition_eligible {
+                        return Err(invalid_pic(
+                            pic_str,
+                            "repetition count must follow `X` or `9`",
                         ));
                     }
+                    let count = parse_repetition_count(&mut chars, pic_str)?;
 
                     // Subtract 1 because we already counted the character before '('
-                    digits = digits.saturating_sub(1) + count;
+                    let prefix = digits.checked_sub(1).ok_or_else(|| {
+                        invalid_pic(pic_str, "repetition count has no preceding PIC symbol")
+                    })?;
+                    digits = checked_add_u16(prefix, count, pic_str, "PIC width")?;
                     if found_v {
-                        scale = scale.saturating_sub(1) + count as i16;
+                        let count = i16::try_from(count)
+                            .map_err(|_| invalid_pic(pic_str, "PIC scale exceeds i16::MAX"))?;
+                        let prefix = scale.checked_sub(1).ok_or_else(|| {
+                            invalid_pic(pic_str, "repetition count has no fractional PIC symbol")
+                        })?;
+                        scale = checked_add_i16(prefix, count, pic_str, "PIC scale")?;
                     }
+                    repetition_eligible = false;
                 }
                 ' ' | '\t' => {
                     // Skip whitespace
@@ -320,11 +305,69 @@ fn is_edited_pic(pic_str: &str) -> bool {
         || pic_str.contains("db")
 }
 
+fn invalid_pic(pic_str: &str, reason: &str) -> Error {
+    Error::new(
+        ErrorCode::CBKP001_SYNTAX,
+        format!("Invalid PIC clause `{pic_str}`: {reason}"),
+    )
+}
+
+fn parse_repetition_count(chars: &mut Peekable<Chars<'_>>, pic_str: &str) -> Result<u16> {
+    let mut count_str = String::new();
+    let mut closed = false;
+    while let Some(&ch) = chars.peek() {
+        if ch == ')' {
+            let _ = chars.next();
+            closed = true;
+            break;
+        }
+        if !ch.is_ascii_digit() {
+            return Err(invalid_pic(
+                pic_str,
+                "repetition count must contain only digits",
+            ));
+        }
+        count_str.push(ch);
+        let _ = chars.next();
+    }
+
+    if !closed {
+        return Err(invalid_pic(
+            pic_str,
+            "repetition count is missing closing `)`",
+        ));
+    }
+    if count_str.is_empty() {
+        return Err(invalid_pic(pic_str, "repetition count cannot be empty"));
+    }
+
+    let count = count_str
+        .parse::<u16>()
+        .map_err(|_| invalid_pic(pic_str, "repetition count exceeds u16::MAX"))?;
+    if count == 0 {
+        return Err(invalid_pic(pic_str, "repetition count cannot be zero"));
+    }
+    Ok(count)
+}
+
+fn checked_add_u16(value: u16, increment: u16, pic_str: &str, name: &str) -> Result<u16> {
+    value
+        .checked_add(increment)
+        .ok_or_else(|| invalid_pic(pic_str, &format!("{name} exceeds u16::MAX")))
+}
+
+fn checked_add_i16(value: i16, increment: i16, pic_str: &str, name: &str) -> Result<i16> {
+    value
+        .checked_add(increment)
+        .ok_or_else(|| invalid_pic(pic_str, &format!("{name} exceeds i16::MAX")))
+}
+
 /// Compute display width from edited PIC string
 /// Example: "ZZ,ZZZ.99" → 8 (including comma and decimal point)
 fn compute_edited_pic_width(pic_str: &str) -> Result<u16> {
     let mut width = 0u16;
     let mut chars = pic_str.chars().peekable();
+    let mut repetition_eligible = false;
 
     while let Some(ch) = chars.next() {
         match ch.to_ascii_uppercase() {
@@ -333,43 +376,28 @@ fn compute_edited_pic_width(pic_str: &str) -> Result<u16> {
                 // Check for repetition count
                 if chars.peek() == Some(&'(') {
                     chars.next(); // consume '('
-                    let mut count_str = String::new();
-                    while let Some(&ch) = chars.peek() {
-                        if ch == ')' {
-                            chars.next(); // consume ')'
-                            break;
-                        } else if ch.is_ascii_digit() {
-                            count_str.push(ch);
-                            chars.next();
-                        } else {
-                            return Err(Error::new(
-                                ErrorCode::CBKP001_SYNTAX,
-                                format!("Invalid repetition count in edited PIC: {}", pic_str),
-                            ));
-                        }
-                    }
-                    let count: u16 = count_str.parse().map_err(|_| {
-                        Error::new(
-                            ErrorCode::CBKP001_SYNTAX,
-                            format!("Invalid repetition count: {}", count_str),
-                        )
-                    })?;
-                    width = width.saturating_add(count);
+                    let count = parse_repetition_count(&mut chars, pic_str)?;
+                    width = checked_add_u16(width, count, pic_str, "edited PIC width")?;
+                    repetition_eligible = false;
                 } else {
-                    width = width.saturating_add(1);
+                    width = checked_add_u16(width, 1, pic_str, "edited PIC width")?;
+                    repetition_eligible = true;
                 }
             }
             // Insertion characters (commas, slashes, etc.)
             ',' | '/' | '.' => {
-                width = width.saturating_add(1);
+                width = checked_add_u16(width, 1, pic_str, "edited PIC width")?;
+                repetition_eligible = false;
             }
             // Currency symbol
             '$' => {
-                width = width.saturating_add(1);
+                width = checked_add_u16(width, 1, pic_str, "edited PIC width")?;
+                repetition_eligible = false;
             }
             // Sign symbols
             '+' | '-' => {
-                width = width.saturating_add(1);
+                width = checked_add_u16(width, 1, pic_str, "edited PIC width")?;
+                repetition_eligible = false;
             }
             // CR/DB handling (2 characters)
             'C' | 'D' => {
@@ -378,20 +406,31 @@ fn compute_edited_pic_width(pic_str: &str) -> Result<u16> {
                         || (ch == 'D' && (next_ch == 'B' || next_ch == 'b')))
                 {
                     chars.next(); // consume second character
-                    width = width.saturating_add(2);
+                    width = checked_add_u16(width, 2, pic_str, "edited PIC width")?;
                 }
+                repetition_eligible = false;
             }
             // V is non-display (implied decimal)
             'V' => {
                 // Don't add to width
+                repetition_eligible = false;
             }
             // S prefix is non-display
             'S' => {
                 // Don't add to width
+                repetition_eligible = false;
             }
             // Whitespace
             ' ' | '\t' => {
                 // Skip
+            }
+            '(' | ')' => {
+                let reason = if ch == '(' && !repetition_eligible {
+                    "repetition count must follow `9`, `Z`, `*`, or `0`"
+                } else {
+                    "malformed repetition delimiter"
+                };
+                return Err(invalid_pic(pic_str, reason));
             }
             _ => {
                 // Unknown character - for now, just skip it
@@ -429,6 +468,7 @@ fn compute_edited_pic_scale(pic_str: &str) -> Result<i16> {
     let mut chars = pic_str.chars().peekable();
     let mut found_decimal = false;
     let mut scale = 0i16;
+    let mut repetition_eligible = false;
 
     // Skip leading 'S' if present
     if chars.peek() == Some(&'S') || chars.peek() == Some(&'s') {
@@ -445,6 +485,7 @@ fn compute_edited_pic_scale(pic_str: &str) -> Result<i16> {
                     ));
                 }
                 found_decimal = true;
+                repetition_eligible = false;
             }
             'V' => {
                 // Implicit decimal point
@@ -455,42 +496,35 @@ fn compute_edited_pic_scale(pic_str: &str) -> Result<i16> {
                     ));
                 }
                 found_decimal = true;
+                repetition_eligible = false;
             }
             '9' | 'Z' | '*' | '0' => {
                 // Check for repetition count
-                let count = if chars.peek() == Some(&'(') {
+                let repeated = chars.peek() == Some(&'(');
+                let count = if repeated {
                     chars.next(); // consume '('
-                    let mut count_str = String::new();
-                    while let Some(&ch) = chars.peek() {
-                        if ch == ')' {
-                            chars.next(); // consume ')'
-                            break;
-                        } else if ch.is_ascii_digit() {
-                            count_str.push(ch);
-                            chars.next();
-                        } else {
-                            return Err(Error::new(
-                                ErrorCode::CBKP001_SYNTAX,
-                                format!("Invalid repetition count in edited PIC: {pic_str}"),
-                            ));
-                        }
-                    }
-                    count_str.parse::<i16>().map_err(|_| {
-                        Error::new(
-                            ErrorCode::CBKP001_SYNTAX,
-                            format!("Invalid repetition count: {count_str}"),
-                        )
-                    })?
+                    parse_repetition_count(&mut chars, pic_str)?
                 } else {
                     1
                 };
 
                 if found_decimal {
-                    scale = scale.saturating_add(count);
+                    let count = i16::try_from(count)
+                        .map_err(|_| invalid_pic(pic_str, "PIC scale exceeds i16::MAX"))?;
+                    scale = checked_add_i16(scale, count, pic_str, "PIC scale")?;
                 }
+                repetition_eligible = !repeated;
+            }
+            '(' | ')' => {
+                let reason = if ch == '(' && !repetition_eligible {
+                    "repetition count must follow `9`, `Z`, `*`, or `0`"
+                } else {
+                    "malformed repetition delimiter"
+                };
+                return Err(invalid_pic(pic_str, reason));
             }
             // Other characters (comma, slash, $, +, -, etc.) don't affect scale
-            _ => {}
+            _ => repetition_eligible = false,
         }
     }
 
@@ -578,5 +612,73 @@ mod tests {
             "S9(7)V9(2)"
         );
         assert_eq!(PicClause::parse("9V9").unwrap().to_string(), "9V9");
+    }
+
+    #[test]
+    fn repetition_counts_require_positive_closed_u16_values() {
+        for invalid in [
+            "9(10",
+            "9()",
+            "9(0)",
+            "9(65536)",
+            "9(999999999999999999999999999999)",
+            "9((2))",
+            "9(2)(3)",
+            "9V(2)",
+            "S(2)9",
+            "9)",
+            "Z(10",
+            "Z()",
+            "Z(0)",
+            "Z(65536)",
+            "Z(2)(3)",
+            "ZV(2)",
+            "Z)",
+        ] {
+            let error = PicClause::parse(invalid).unwrap_err();
+            assert_eq!(error.code, ErrorCode::CBKP001_SYNTAX, "{invalid}");
+        }
+    }
+
+    #[test]
+    fn repetition_arithmetic_preserves_maximum_boundaries() {
+        let plain = PicClause::parse("9(65535)").unwrap();
+        assert_eq!(plain.digits, u16::MAX);
+        assert_eq!(plain.scale, 0);
+
+        let edited = PicClause::parse("Z(65535)").unwrap();
+        assert_eq!(edited.digits, u16::MAX);
+        assert_eq!(edited.scale, 0);
+
+        let fractional = PicClause::parse("ZV9(32767)").unwrap();
+        assert_eq!(fractional.scale, i16::MAX);
+
+        for invalid in ["9(65535)9", "Z(65535)9", "ZV9(32767)9"] {
+            let error = PicClause::parse(invalid).unwrap_err();
+            assert_eq!(error.code, ErrorCode::CBKP001_SYNTAX, "{invalid}");
+        }
+
+        let error = PicClause::parse("Z(65535)V9(32768)").unwrap_err();
+        assert!(error.message.contains("edited PIC width"));
+    }
+
+    #[test]
+    fn mixed_type_validation_precedes_later_repetition_overflow() {
+        let error = PicClause::parse("9X(65536)").unwrap_err();
+        assert_eq!(error.code, ErrorCode::CBKP001_SYNTAX);
+        assert!(error.message.contains("Mixed PIC types"));
+    }
+
+    #[test]
+    fn parser_maps_hostile_repetitions_to_invalid_pic() {
+        for copybook in [
+            "01 ROOT.\n   05 FIELD PIC 9(10",
+            "01 ROOT.\n   05 FIELD PIC 9(65535)9.",
+            "01 ROOT.\n   05 FIELD PIC Z(10",
+            "01 ROOT.\n   05 FIELD PIC Z(65535)9.",
+        ] {
+            let error = crate::parse_copybook(copybook).unwrap_err();
+            assert_eq!(error.code, ErrorCode::CBKP101_INVALID_PIC, "{copybook}");
+        }
     }
 }

--- a/crates/copybook-core/src/pic.rs
+++ b/crates/copybook-core/src/pic.rs
@@ -182,6 +182,7 @@ impl PicClause {
                 }
                 ' ' | '\t' => {
                     // Skip whitespace
+                    repetition_eligible = false;
                 }
                 _ => {
                     return Err(Error::new(
@@ -423,6 +424,7 @@ fn compute_edited_pic_width(pic_str: &str) -> Result<u16> {
             // Whitespace
             ' ' | '\t' => {
                 // Skip
+                repetition_eligible = false;
             }
             '(' | ')' => {
                 let reason = if ch == '(' && !repetition_eligible {
@@ -623,6 +625,8 @@ mod tests {
             "9(65536)",
             "9(999999999999999999999999999999)",
             "9((2))",
+            "9 (2)",
+            "X\t(2)",
             "9(2)(3)",
             "9V(2)",
             "S(2)9",
@@ -631,6 +635,8 @@ mod tests {
             "Z()",
             "Z(0)",
             "Z(65536)",
+            "Z (2)",
+            "*\t(2)",
             "Z(2)(3)",
             "ZV(2)",
             "Z)",
@@ -663,6 +669,12 @@ mod tests {
     }
 
     #[test]
+    fn ordinary_pic_whitespace_remains_supported_without_detached_repetition() {
+        assert_eq!(PicClause::parse("9 9").unwrap().digits, 2);
+        assert_eq!(PicClause::parse("Z Z").unwrap().digits, 2);
+    }
+
+    #[test]
     fn mixed_type_validation_precedes_later_repetition_overflow() {
         let error = PicClause::parse("9X(65536)").unwrap_err();
         assert_eq!(error.code, ErrorCode::CBKP001_SYNTAX);
@@ -679,6 +691,15 @@ mod tests {
         ] {
             let error = crate::parse_copybook(copybook).unwrap_err();
             assert_eq!(error.code, ErrorCode::CBKP101_INVALID_PIC, "{copybook}");
+        }
+
+        for copybook in [
+            "01 ROOT.\n   05 FIELD PIC 9 (2).",
+            "01 ROOT.\n   05 FIELD PIC Z\t(2).",
+        ] {
+            let error = crate::parse_copybook(copybook).unwrap_err();
+            assert_eq!(error.code, ErrorCode::CBKP101_INVALID_PIC, "{copybook}");
+            assert!(error.message.contains("must be attached"), "{copybook}");
         }
     }
 }


### PR DESCRIPTION
# Pull Request

## Summary

Reject malformed, unterminated, unattached, zero, oversized, and arithmetic-overflowing PIC repetition counts across plain and edited PIC parsing. A shared count parser now requires positive decimal digits followed by `)`, while checked width/digit/scale arithmetic preserves the exact supported maxima without saturation or debug overflow.

Direct `PicClause::parse` retains `CBKP001_SYNTAX`; copybook parser integration retains the canonical `CBKP101_INVALID_PIC` mapping.

## Type of Change

- [x] Bugfix (fixes an issue)
- [x] Tests (test additions or improvements)

## COBOL/Mainframe Context

- **COBOL features affected**: plain and edited PIC repetition counts
- **Data processing impact**: copybook parsing and schema validation
- **Mainframe compatibility**: supported PIC precision is unchanged; malformed syntax now fails closed

## Workspace Crates Affected

- [x] copybook-core (parsing, schema, AST)

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (N/A: behavior and error contracts are unchanged)
- [x] CHANGELOG.md updated (N/A: narrow malformed-input correctness fix)
- [x] Scoped `cargo fmt -p copybook-core -- --check` passes
- [ ] Workspace/test-target Clippy passes (existing unrelated snapshot-test lint debt; changed core library passes pedantic Clippy)
- [ ] Workspace test passes (scoped core library and parser integration proof recorded below)
- [x] Governance/BDD smoke N/A
- [x] Follows conventional commit format
- [x] MSRV compliance N/A (no dependency or toolchain changes)
- [x] Golden fixtures N/A

## Testing Instructions

```text
PASS: rtk cargo test -p copybook-core --lib pic::tests                # 14 passed
PASS: rtk cargo test -p copybook-core --lib                           # 109 passed
PASS: rtk cargo test -p copybook-core --test parser_edge_cases_deep   # 47 passed
PASS: rtk cargo fmt -p copybook-core -- --check
PASS: rtk cargo clippy -p copybook-core --lib -- -D warnings -W clippy::pedantic
PASS: rtk cargo run -p xtask -- docs verify-stable-errors             # 65 codes (57 direct, 8 pending)
PASS: rtk cargo run -p xtask -- docs verify-record-pipeline            # 11 scenarios; digest unchanged
FAIL (pre-existing, untouched): rtk cargo clippy -p copybook-core --tests -- -D warnings -W clippy::pedantic
  22 existing snapshot-test lints in snapshot_inspect.rs/snapshot_schema.rs/schema_snapshot_tests.rs.
```

Coverage includes LF-independent in-memory parser inputs for missing/empty/zero/oversized counts, unmatched and unattached delimiters (`9(2)(3)`, `9V(2)`, `S(2)9`), plain and edited width overflow, edited scale overflow, exact `u16::MAX` width and `i16::MAX` scale boundaries, width-before-scale ordering, mixed-type precedence, span-preserving space/tab/newline attachment checks, immediate repeated clauses, ordinary non-repetition whitespace, and integration error-code mapping without panic.

## Performance Impact

- [x] No material performance impact expected; checked arithmetic and count validation are confined to schema parsing.

## Infrastructure/Tooling Changes

N/A.

**Adversarial Testing**:
- [x] Tested with malformed input
- [x] Verified exact numeric boundaries
- [x] Verified stable-error registry drift detection remains green

## Breaking Changes

- [x] No breaking changes. Previously accepted malformed/overflowing inputs now return the existing typed parse errors.

## Related Issues

Closes #768

## Additional Notes

The edited parser continues to compute width before scale, preserving validation order. This PR does not expand PIC syntax, change supported precision, edit taxonomy/docs, or alter valid schema shapes.

