### PR TITLE
ci(soak): make benchmark evidence truthful

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-name: Soak
+name: Weekly Benchmark Gate
 
 on:
   workflow_dispatch: {}
@@ -12,97 +12,65 @@ concurrency:
 
 permissions:
   contents: read
-  checks: write
 
 jobs:
-  soak:
+  benchmark-gate:
+    name: Benchmark SLO gate
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        format: [fixed, rdw]
-        workload: [mixed, display-heavy, comp3-heavy]
-        size: [128MiB, 256MiB]
-        codepage: [cp037, cp273, cp500, cp1047, cp1140]
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Build release
-        run: cargo build --workspace --release
+      - name: Run canonical SLO benchmarks
+        id: measurement
+        continue-on-error: true
+        run: BUILD_PROFILE=release bash scripts/bench-enhanced.sh
 
-      - name: Generate dataset
-        env:
-          WORKLOAD: ${{ matrix.workload }}
-          ZONED_POLICY: preferred
-          SOAK_SEED: soak-${{ matrix.format }}-${{ matrix.workload }}-${{ matrix.size }}-${{ matrix.codepage }}
+      - name: Validate sealed receipt
+        id: receipt
+        if: always()
+        continue-on-error: true
+        run: bash scripts/validate-perf-receipt.sh scripts/bench/perf.json
+
+      - name: Build gate tool
+        if: always()
+        run: cargo build --release -p copybook-bench --bin bench-report
+
+      - name: Evaluate measured thresholds
+        id: gate
+        if: always()
+        continue-on-error: true
         run: |
-          DATASET="/tmp/dataset-${{ matrix.format }}-${{ matrix.workload }}-${{ matrix.size }}-${{ matrix.codepage }}.bin"
-          scripts/gen_dataset.sh "${{ matrix.format }}" "${{ matrix.codepage }}" "${{ matrix.size }}" "${DATASET}"
-          echo "DATASET=${DATASET}" >> "$GITHUB_ENV"
-
-      - name: Run benches (BENCH_FILTER=slo_validation)
-        run: |
-          : "${DATASET:?missing dataset path}"
-          BENCH_INPUT="${DATASET}" bash scripts/bench.sh
-
-      - name: Annotate perf with host info
-        run: bash scripts/perf-annotate-host.sh
-
-      - name: Aggregate percentiles
-        run: bash scripts/soak-aggregate.sh
+          ./target/release/bench-report gate scripts/bench/perf.json \
+            --regression-threshold 5.0
 
       - name: Perf headline (summary)
+        if: always()
         run: |
           jq -r '
             (.summary // {}) as $s
-            | ([
-                $s.host_cpu,
-                (if $s.host_cores != null then ($s.host_cores|tostring + "c") else empty end),
-                (if ($s.host_os // "") != "" or ($s.host_kernel // "") != "" then [($s.host_os // ""), ($s.host_kernel // "")] | join("/") else empty end)
-              ] | map(select(. != "")) | join(" • ")) as $host
-            | "DISPLAY: \($s.display_mibps // "n/a") MiB/s\nCOMP-3: \($s.comp3_mibps // "n/a") MiB/s\nMax RSS: \($s.max_rss_mib // "n/a") MiB\nHost: \($host // "n/a")\nP50/P90/P99: \($s.p50_mibps // "n/a")/\($s.p90_mibps // "n/a")/\($s.p99_mibps // "n/a") MiB/s"
+            | "DISPLAY: \($s.display_mibps // "n/a") MiB/s\nCOMP-3: \($s.comp3_mibps // "n/a") MiB/s\nP50/P90/P99: \($s.p50_mibps // "n/a")/\($s.p90_mibps // "n/a")/\($s.p99_mibps // "n/a") MiB/s"
           ' scripts/bench/perf.json >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload perf artifact
+        if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: perf-${{ matrix.format }}-${{ matrix.workload }}-${{ matrix.size }}-${{ matrix.codepage }}
+          name: weekly-benchmark-${{ github.sha }}
           path: scripts/bench/perf.json
           retention-days: 90
+          if-no-files-found: warn
 
-      - name: Publish soak check-run
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const fs = require('fs');
-            const path = 'scripts/bench/perf.json';
-            const perf = JSON.parse(fs.readFileSync(path, 'utf8'));
-            const summary = perf.summary || {};
-            const hostParts = [
-              summary.host_cpu,
-              summary.host_cores != null ? `${summary.host_cores}c` : null,
-              summary.host_os && summary.host_kernel ? `${summary.host_os}/${summary.host_kernel}` :
-                (summary.host_os || summary.host_kernel || null),
-            ].filter(Boolean).join(' • ');
-            await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: `soak:${{ matrix.format }}:${{ matrix.workload }}:${{ matrix.size }}:${{ matrix.codepage }}`,
-              head_sha: context.sha,
-              status: "completed",
-              conclusion: "success",
-              output: {
-                title: "Soak SLOs",
-                summary:
-                  `DISPLAY: ${summary.display_mibps ?? 'n/a'} MiB/s\n` +
-                  `COMP-3:  ${summary.comp3_mibps ?? 'n/a'} MiB/s\n` +
-                  `Max RSS: ${summary.max_rss_mib ?? 'n/a'} MiB\n` +
-                  `P50/P90/P99: ${summary.p50_mibps ?? 'n/a'}/${summary.p90_mibps ?? 'n/a'}/${summary.p99_mibps ?? 'n/a'} MiB/s\n` +
-                  (hostParts ? `Host: ${hostParts}` : '')
-              }
-            });
+      - name: Enforce benchmark evidence and gate result
+        if: >-
+          always() &&
+          (steps.measurement.outcome != 'success' ||
+           steps.receipt.outcome != 'success' ||
+           steps.gate.outcome != 'success')
+        run: exit 1

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -36,7 +36,7 @@ jobs:
         id: receipt
         if: always()
         continue-on-error: true
-        run: bash scripts/validate-perf-receipt.sh scripts/bench/perf.json
+        run: bash scripts/ci/validate-soak-receipt.sh scripts/bench/perf.json "$GITHUB_SHA"
 
       - name: Build gate tool
         if: always()
@@ -46,17 +46,19 @@ jobs:
         id: gate
         if: always()
         continue-on-error: true
-        run: |
-          ./target/release/bench-report gate scripts/bench/perf.json \
-            --regression-threshold 5.0
+        run: ./target/release/bench-report gate scripts/bench/perf.json
 
       - name: Perf headline (summary)
         if: always()
         run: |
-          jq -r '
-            (.summary // {}) as $s
-            | "DISPLAY: \($s.display_mibps // "n/a") MiB/s\nCOMP-3: \($s.comp3_mibps // "n/a") MiB/s\nP50/P90/P99: \($s.p50_mibps // "n/a")/\($s.p90_mibps // "n/a")/\($s.p99_mibps // "n/a") MiB/s"
-          ' scripts/bench/perf.json >> "$GITHUB_STEP_SUMMARY"
+          if [[ -f scripts/bench/perf.json ]]; then
+            jq -r '
+              (.summary // {}) as $s
+              | "DISPLAY: \($s.display_mibps // "n/a") MiB/s\nCOMP-3: \($s.comp3_mibps // "n/a") MiB/s\nP50/P90/P99: \($s.p50_mibps // "n/a")/\($s.p90_mibps // "n/a")/\($s.p99_mibps // "n/a") MiB/s"
+            ' scripts/bench/perf.json >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Measurement failed: no current receipt was produced." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Upload perf artifact
         if: always()
@@ -65,7 +67,7 @@ jobs:
           name: weekly-benchmark-${{ github.sha }}
           path: scripts/bench/perf.json
           retention-days: 90
-          if-no-files-found: warn
+          if-no-files-found: ignore
 
       - name: Enforce benchmark evidence and gate result
         if: >-

--- a/docs/CI_GATING_POLICY.md
+++ b/docs/CI_GATING_POLICY.md
@@ -71,7 +71,7 @@ jobs are non-blocking and provide additional quality signals.
 | `fuzz` | Timeboxed fuzzing with crash artifacts | Weekly | ~60 min |
 | `mutants` | Timeboxed mutation testing | Weekly | ~30 min |
 | `bench` | Performance benchmarks with receipts | Nightly | ~20 min |
-| `soak` | Generated workload matrix with performance/SLO receipts | Weekly | Matrix-dependent |
+| `soak` | Sealed benchmark receipt plus enforced absolute floors | Weekly | ~20 min |
 
 ### Job Details
 
@@ -106,10 +106,11 @@ jobs are non-blocking and provide additional quality signals.
 
 #### `soak`
 - Is owned by the dedicated `.github/workflows/soak.yml` workflow
-- Exercises fixed and RDW workloads across workload, size, and code-page axes
-- Publishes per-cell performance receipts and `soak:*` check runs
+- Runs the canonical in-memory DISPLAY-heavy and COMP-3-heavy Criterion workloads
+- Validates the sealed receipt, then evaluates the 80/8 MiB/s absolute floors
+- Publishes the receipt; the workflow job conclusion records the gate decision
 - Can be manually dispatched with `bash scripts/soak-dispatch.sh`
-- Provides workload/resource telemetry, not leak-detection proof
+- Does not exercise generated fixed/RDW datasets, code-page/size axes, or prove leak absence
 
 ## Promoting Tests from Scheduled to PR Lane
 

--- a/docs/PERF_RECEIPTS.md
+++ b/docs/PERF_RECEIPTS.md
@@ -31,7 +31,7 @@ This generates [`scripts/bench/perf.json`](../scripts/bench/perf.json) with the 
   "timestamp": "2025-12-16T17:05:22Z",
   "commit": "85b9f07",
   "toolchain": "cargo bench (criterion)",
-  "status": "pass",
+  "status": "measured",
   "display_mibps": 3545.011041717901,
   "comp3_mibps": 26.04498724409417,
   "benchmarks": [...],
@@ -49,6 +49,12 @@ This generates [`scripts/bench/perf.json`](../scripts/bench/perf.json) with the 
   }
 }
 ```
+
+`measured` records that the producer completed a measurement; it is not a gate
+decision. The generic receipt schema continues to accept historical
+`pass`/`fail`/`warn` and `success`/`failure`/`warning` values, while the weekly
+benchmark workflow requires `measured`, the exact workflow commit, and a
+separate successful threshold evaluation.
 
 ### CI/CD Generation
 

--- a/docs/TESTING_COMMANDS.md
+++ b/docs/TESTING_COMMANDS.md
@@ -38,7 +38,7 @@ This document provides a canonical reference for all testing commands in copyboo
 | **Fuzzing** | `cargo fuzz run <target> -- -runs=0 -max_total_time=300` | Scheduled | 5-10 min per target | `fuzz/artifacts/<target>/`, `fuzz/corpus/<target>/` |
 | **Mutation Testing** | `cargo mutants --package <crate> --timeout <timeout> --test-tool nextest --in-place --json --file mutants.toml` | Local only (`just mutants`); CI uses the advisory RIPR lane instead | 15-60 min per crate | `mutants.out/outcomes.json`, `mutants-summary.csv` |
 | **Performance Benchmarks** | `BENCH_FILTER=slo_validation bash scripts/bench.sh` | Scheduled | 10-15 min | `target/perf.json` |
-| **Workload Soak** | `bash scripts/soak-dispatch.sh` | Weekly + manual | Matrix-dependent | `scripts/bench/perf.json`, `soak:*` check runs |
+| **Weekly Benchmark Gate** | `bash scripts/soak-dispatch.sh` | Weekly + manual | ~20 min | Sealed `scripts/bench/perf.json`, workflow job conclusion |
 
 ---
 
@@ -658,11 +658,11 @@ cat target/perf.json
 
 ---
 
-### Workload Soak
+### Weekly Benchmark Gate
 
-**Purpose**: Exercise generated fixed and RDW workloads across the supported
-code-page matrix and publish performance/SLO evidence. This is workload and
-resource telemetry; it is not leak-detection proof.
+**Purpose**: Run the canonical in-memory DISPLAY-heavy and COMP-3-heavy
+Criterion workloads, preserve their sealed receipt, and enforce the configured
+80 MiB/s DISPLAY and 8 MiB/s COMP-3 floors with `bench-report gate`.
 
 **Manual dispatch**:
 ```bash
@@ -670,15 +670,15 @@ bash scripts/soak-dispatch.sh
 ```
 
 **What it validates**:
-- Generated fixed and RDW workloads complete across the configured matrix
-- Performance receipts satisfy the configured SLO checks
-- Host and resource telemetry is captured in the published receipts
+- The canonical Criterion receipt contains DISPLAY and COMP-3 measurements
+- Measurements satisfy the configured absolute floors
+- The sealed receipt carries the measured environment and percentile context
 
-The dispatcher triggers `.github/workflows/soak.yml`; reproduce an individual
-matrix cell locally with the dataset, benchmark, annotation, and aggregation
-commands defined by that workflow.
+The dispatcher triggers `.github/workflows/soak.yml`. Despite the retained file
+and command name, this workflow does not consume generated fixed/RDW datasets,
+vary code pages, or prove absence of memory leaks.
 
-**Expected runtime**: Matrix-dependent
+**Expected runtime**: Approximately 20 minutes
 
 **Trigger schedule**: Weekly at 3:00 AM UTC on Saturday, plus manual dispatch,
 via `.github/workflows/soak.yml`

--- a/docs/TEST_INFRASTRUCTURE_LANDSCAPE.md
+++ b/docs/TEST_INFRASTRUCTURE_LANDSCAPE.md
@@ -338,11 +338,11 @@ Tests use tags for categorization:
 - Pedantic linting validation
 - Diff-based checking
 
-#### soak.yml (Canonical Workload Soak)
+#### soak.yml (Canonical Weekly Benchmark Gate)
 - Runs weekly at 3:00 AM UTC on Saturday and supports manual dispatch
-- Exercises a 60-cell Ubuntu matrix across record format, workload, dataset
-  size, and code page
-- Generates performance receipts and publishes per-cell `soak:*` check runs
+- Runs the canonical in-memory DISPLAY-heavy and COMP-3-heavy Criterion workloads
+- Validates a sealed receipt and enforces the 80/8 MiB/s absolute floors
+- Publishes one receipt artifact; the job conclusion records the gate decision
 - Can be triggered manually with `bash scripts/soak-dispatch.sh`
 
 #### security-scan.yml (Security Validation)
@@ -368,12 +368,14 @@ cargo test --workspace --features comp3_fast,audit
 PROPTEST_CASES=512 PROPTEST_SEED="copybook-rs-perf" cargo test
 ```
 
-**Workload Soak (manual workflow dispatch)**:
+**Weekly Benchmark Gate (manual workflow dispatch)**:
 ```bash
 bash scripts/soak-dispatch.sh
 ```
 
-The dedicated workflow is workload/SLO evidence, not leak-detection proof.
+The dedicated workflow proves only its canonical in-memory Criterion workloads
+and absolute-floor decision. Generated RDW, dataset-size, code-page, external-
+input, and leak-absence claims are not proven.
 
 **Performance Tests (Gated)**:
 ```bash

--- a/schemas/perf-receipt-schema.json
+++ b/schemas/perf-receipt-schema.json
@@ -39,6 +39,11 @@
       "type": "string",
       "description": "CPU target flags used during compilation (e.g., native, generic)"
     },
+    "status": {
+      "type": "string",
+      "enum": ["measured", "pass", "fail", "warn", "success", "failure", "warning"],
+      "description": "Optional producer status. 'measured' means measurement completed without asserting policy. Legacy pass/fail/warn and success/failure/warning values remain schema-compatible; consumers must apply their own gate contract."
+    },
     "environment": {
       "type": "object",
       "required": [

--- a/scripts/bench-enhanced.sh
+++ b/scripts/bench-enhanced.sh
@@ -2,6 +2,24 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 set -euo pipefail
 
+PERF_RECEIPT_PATH="${PERF_RECEIPT_PATH:-scripts/bench/perf.json}"
+PERF_RECEIPT_TMP="${PERF_RECEIPT_PATH}.tmp"
+CRITERION_ROOT="${CRITERION_ROOT:-target/criterion/slo_validation}"
+
+# A failed measurement must not leave a committed or prior-run receipt looking
+# current. Criterion's `new` directories are likewise cleared so the receipt
+# assembler cannot reuse stale estimates after a partial benchmark run.
+rm -f "${PERF_RECEIPT_PATH}" "${PERF_RECEIPT_TMP}"
+rm -rf \
+  "${CRITERION_ROOT}/display_heavy_slo_80mbps/new" \
+  "${CRITERION_ROOT}/comp3_heavy_slo_40mbps/new"
+trap 'rm -f "${PERF_RECEIPT_TMP}"' EXIT
+
+if [[ "${COPYBOOK_BENCH_FORCE_FAILURE:-0}" == "1" ]]; then
+  echo "forced benchmark failure after stale evidence cleanup" >&2
+  exit 42
+fi
+
 # Run only the SLO validation benchmarks to capture throughput receipts by default.
 # tripwire: no-op change to trigger perf workflow without affecting behavior.
 # Allow callers to widen scope by exporting BENCH_FILTER. The documented value
@@ -75,15 +93,26 @@ get_kernel_version() {
   fi
 }
 
-python3 <<PY
+WSL2_DETECTED="$(detect_wsl2)" \
+CPU_MODEL="$(get_cpu_info)" \
+CPU_CORES="$(get_cpu_cores)" \
+OS_NAME="$(get_os_info)" \
+KERNEL_VERSION="$(get_kernel_version)" \
+BUILD_PROFILE="${BUILD_PROFILE}" \
+TARGET_CPU="${TARGET_CPU}" \
+PERF_RECEIPT_TMP="${PERF_RECEIPT_TMP}" \
+CRITERION_ROOT="${CRITERION_ROOT}" \
+python3 <<'PY'
 import datetime
 import json
+import os
 import pathlib
 import subprocess
 import sys
 
 ROOT = pathlib.Path.cwd()
-CRITERION_ROOT = ROOT / "target" / "criterion" / "slo_validation"
+CRITERION_ROOT = pathlib.Path(os.environ["CRITERION_ROOT"])
+OUTPUT_PATH = pathlib.Path(os.environ["PERF_RECEIPT_TMP"])
 
 def load_throughput(name: str):
     bench_dir = CRITERION_ROOT / name / "new"
@@ -159,21 +188,19 @@ def compute_percentiles(benchmark_names: list) -> dict:
 
 
 # Get environment data from shell
-build_profile = """${BUILD_PROFILE}"""
-target_cpu = """${TARGET_CPU}"""
-wsl2_detected = """$(detect_wsl2)""" == "true"
-cpu_model = """$(get_cpu_info)"""
-cpu_cores = int("""$(get_cpu_cores)""")
-os_name = """$(get_os_info)"""
-kernel_version = """$(get_kernel_version)"""
+build_profile = os.environ["BUILD_PROFILE"]
+target_cpu = os.environ["TARGET_CPU"]
+wsl2_detected = os.environ["WSL2_DETECTED"] == "true"
+cpu_model = os.environ["CPU_MODEL"]
+cpu_cores = int(os.environ["CPU_CORES"])
+os_name = os.environ["OS_NAME"]
+kernel_version = os.environ["KERNEL_VERSION"]
 
 display = load_throughput("display_heavy_slo_80mbps")
 comp3 = load_throughput("comp3_heavy_slo_40mbps")
 
 timestamp = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-commit = subprocess.check_output(
-    ["git", "rev-parse", "--short", "HEAD"], cwd=ROOT, text=True
-).strip()
+commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=ROOT, text=True).strip()
 
 # Compute percentiles from criterion sample data BEFORE building report
 benchmark_names = ["display_heavy_slo_80mbps", "comp3_heavy_slo_40mbps"]
@@ -214,13 +241,13 @@ report = {
     "summary": summary
 }
 
-output_dir = ROOT / "scripts" / "bench"
-output_dir.mkdir(parents=True, exist_ok=True)
-output_path = output_dir / "perf.json"
-output_path.write_text(json.dumps(report, indent=2) + "\n")
+OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+OUTPUT_PATH.write_text(json.dumps(report, indent=2) + "\n")
 PY
 
-cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- seal-perf-receipt scripts/bench/perf.json
+cargo run --quiet --manifest-path tools/copybook-scripts/Cargo.toml -- seal-perf-receipt "${PERF_RECEIPT_TMP}"
+mv "${PERF_RECEIPT_TMP}" "${PERF_RECEIPT_PATH}"
+trap - EXIT
 
 # Receipt is complete and immutable - no post-write modifications
 # Note: Percentile aggregation is now done in the Python block above,

--- a/scripts/bench-enhanced.sh
+++ b/scripts/bench-enhanced.sh
@@ -204,7 +204,9 @@ report = {
         "wsl2_detected": wsl2_detected
     },
     "toolchain": "cargo bench (criterion)",
-    "status": "pass",
+    # Receipt generation records measurements; `bench-report gate` owns the
+    # separate pass/fail policy decision and never mutates this sealed receipt.
+    "status": "measured",
     "display_mibps": display["mean_mibps"],
     "display_gibps": display["mean_mibps"] / 1024.0,
     "comp3_mibps": comp3["mean_mibps"],

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -62,7 +62,9 @@ report = {
     "timestamp": timestamp,
     "commit": commit,
     "toolchain": "cargo bench (criterion)",
-    "status": "pass",
+    # Measurement generation does not decide policy. The separate
+    # `bench-report gate` command owns pass/fail threshold evaluation.
+    "status": "measured",
     "display_mibps": display["mean_mibps"],
     "display_gibps": display["mean_mibps"] / 1024.0,
     "comp3_mibps": comp3["mean_mibps"],

--- a/scripts/ci/validate-soak-receipt.sh
+++ b/scripts/ci/validate-soak-receipt.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+RECEIPT_FILE="${1:-scripts/bench/perf.json}"
+EXPECTED_COMMIT="${2:?expected workflow commit is required}"
+
+cargo run --quiet --manifest-path "$ROOT_DIR/tools/copybook-scripts/Cargo.toml" -- \
+  validate-soak-receipt "$RECEIPT_FILE" "$EXPECTED_COMMIT"

--- a/tools/copybook-bench/tests/ci_integration.rs
+++ b/tools/copybook-bench/tests/ci_integration.rs
@@ -964,3 +964,49 @@ fn test_artifact_naming() {
         "Baseline artifacts must have 90-day retention"
     );
 }
+
+/// The legacy `soak.yml` filename is retained for dispatcher compatibility,
+/// but the workflow owns one canonical benchmark gate rather than an
+/// unconsumed generated-dataset matrix.
+#[test]
+fn weekly_benchmark_gate_has_truthful_inputs_and_decision() {
+    let base_path = find_workspace_root();
+    let workflow = std::fs::read_to_string(base_path.join(".github/workflows/soak.yml"))
+        .expect("Failed to read soak workflow YAML");
+
+    assert!(workflow.contains("cron: \"0 3 * * 6\""));
+    assert!(workflow.contains("workflow_dispatch: {}"));
+    assert!(workflow.contains("bash scripts/bench-enhanced.sh"));
+    assert!(workflow.contains("bash scripts/validate-perf-receipt.sh"));
+    assert!(workflow.contains("bench-report gate scripts/bench/perf.json"));
+    assert_eq!(workflow.matches("continue-on-error: true").count(), 3);
+    assert!(workflow.contains("steps.measurement.outcome != 'success'"));
+    assert!(workflow.contains("steps.receipt.outcome != 'success'"));
+    assert!(workflow.contains("steps.gate.outcome != 'success'"));
+    assert!(workflow.contains("name: Perf headline (summary)\n        if: always()"));
+    assert!(workflow.contains("name: Upload perf artifact\n        if: always()"));
+    assert!(workflow.contains("name: Enforce benchmark evidence and gate result"));
+    assert!(workflow.contains("always() &&"));
+    assert!(!workflow.contains("--baseline"));
+    assert!(!workflow.contains("checks: write"));
+    assert!(!workflow.contains("github.rest.checks.create"));
+
+    assert!(!workflow.contains("BENCH_INPUT"));
+    assert!(!workflow.contains("scripts/gen_dataset.sh"));
+    assert!(!workflow.contains("matrix:"));
+}
+
+#[test]
+fn benchmark_receipt_does_not_claim_pass_before_gate_evaluation() {
+    let base_path = find_workspace_root();
+    let bench_script = std::fs::read_to_string(base_path.join("scripts/bench.sh"))
+        .expect("Failed to read benchmark script");
+
+    assert!(bench_script.contains("\"status\": \"measured\""));
+    assert!(!bench_script.contains("\"status\": \"pass\""));
+
+    let enhanced_script = std::fs::read_to_string(base_path.join("scripts/bench-enhanced.sh"))
+        .expect("Failed to read enhanced benchmark script");
+    assert!(enhanced_script.contains("\"status\": \"measured\""));
+    assert!(!enhanced_script.contains("\"status\": \"pass\""));
+}

--- a/tools/copybook-bench/tests/ci_integration.rs
+++ b/tools/copybook-bench/tests/ci_integration.rs
@@ -21,6 +21,7 @@
 use copybook_bench::baseline::BaselineStore;
 use copybook_bench::reporting::PerformanceReport;
 use std::path::PathBuf;
+use std::process::Command;
 
 /// Find workspace root by traversing upward from `CARGO_MANIFEST_DIR`
 fn find_workspace_root() -> PathBuf {
@@ -977,7 +978,9 @@ fn weekly_benchmark_gate_has_truthful_inputs_and_decision() {
     assert!(workflow.contains("cron: \"0 3 * * 6\""));
     assert!(workflow.contains("workflow_dispatch: {}"));
     assert!(workflow.contains("bash scripts/bench-enhanced.sh"));
-    assert!(workflow.contains("bash scripts/validate-perf-receipt.sh"));
+    assert!(workflow.contains(
+        "bash scripts/ci/validate-soak-receipt.sh scripts/bench/perf.json \"$GITHUB_SHA\""
+    ));
     assert!(workflow.contains("bench-report gate scripts/bench/perf.json"));
     assert_eq!(workflow.matches("continue-on-error: true").count(), 3);
     assert!(workflow.contains("steps.measurement.outcome != 'success'"));
@@ -985,15 +988,63 @@ fn weekly_benchmark_gate_has_truthful_inputs_and_decision() {
     assert!(workflow.contains("steps.gate.outcome != 'success'"));
     assert!(workflow.contains("name: Perf headline (summary)\n        if: always()"));
     assert!(workflow.contains("name: Upload perf artifact\n        if: always()"));
+    assert!(workflow.contains("Measurement failed: no current receipt was produced."));
+    assert!(workflow.contains("if-no-files-found: ignore"));
     assert!(workflow.contains("name: Enforce benchmark evidence and gate result"));
     assert!(workflow.contains("always() &&"));
     assert!(!workflow.contains("--baseline"));
+    assert!(!workflow.contains("--regression-threshold"));
     assert!(!workflow.contains("checks: write"));
     assert!(!workflow.contains("github.rest.checks.create"));
 
     assert!(!workflow.contains("BENCH_INPUT"));
     assert!(!workflow.contains("scripts/gen_dataset.sh"));
     assert!(!workflow.contains("matrix:"));
+}
+
+#[test]
+fn failed_measurement_removes_preexisting_receipt_and_criterion_outputs() {
+    let base_path = find_workspace_root();
+    let temp = tempfile::Builder::new()
+        .prefix("soak-failure-")
+        .tempdir_in(base_path.join("target"))
+        .expect("create benchmark failure fixture");
+    let receipt = temp.path().join("perf.json");
+    let criterion = temp.path().join("criterion");
+    for benchmark in ["display_heavy_slo_80mbps", "comp3_heavy_slo_40mbps"] {
+        let output = criterion.join(benchmark).join("new");
+        std::fs::create_dir_all(&output).expect("create stale criterion output");
+        std::fs::write(output.join("estimates.json"), "{}").expect("write stale criterion output");
+    }
+    std::fs::copy(base_path.join("scripts/bench/perf.json"), &receipt)
+        .expect("preseed a schema-valid stale receipt");
+
+    let relative_receipt = receipt
+        .strip_prefix(&base_path)
+        .expect("receipt fixture is inside workspace");
+    let relative_criterion = criterion
+        .strip_prefix(&base_path)
+        .expect("criterion fixture is inside workspace");
+    let slash_path = |path: &std::path::Path| path.to_string_lossy().replace('\\', "/");
+    let command = format!(
+        "COPYBOOK_BENCH_FORCE_FAILURE=1 PERF_RECEIPT_PATH='{}' CRITERION_ROOT='{}' bash scripts/bench-enhanced.sh",
+        slash_path(relative_receipt),
+        slash_path(relative_criterion)
+    );
+    let result = Command::new("bash")
+        .args(["-c", &command])
+        .current_dir(&base_path)
+        .status()
+        .expect("run forced benchmark failure");
+
+    assert!(!result.success());
+    assert!(
+        !receipt.exists(),
+        "stale receipt must not survive measurement"
+    );
+    assert!(!receipt.with_extension("json.tmp").exists());
+    assert!(!criterion.join("display_heavy_slo_80mbps/new").exists());
+    assert!(!criterion.join("comp3_heavy_slo_40mbps/new").exists());
 }
 
 #[test]

--- a/tools/copybook-bench/tests/gate_test.rs
+++ b/tools/copybook-bench/tests/gate_test.rs
@@ -13,6 +13,9 @@ use copybook_bench::slo::{
     COMP3_CI_FLOOR_MIBPS, COMP3_FLOOR_MIBPS, DISPLAY_FLOOR_MIBPS, REGRESSION_THRESHOLD_PCT,
     evaluate_metric as eval,
 };
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
 
 const THRESHOLD: f64 = REGRESSION_THRESHOLD_PCT;
 
@@ -209,6 +212,62 @@ fn regression_exactly_at_threshold_passes() {
         "regression exactly at threshold should pass: {}",
         d.reasons.join("; ")
     );
+}
+
+#[test]
+fn absolute_floor_boundaries_pass() {
+    let display = GateMetric {
+        label: "DISPLAY",
+        current: DISPLAY_FLOOR_MIBPS,
+        baseline: None,
+    };
+    let comp3 = GateMetric {
+        label: "COMP-3",
+        current: COMP3_CI_FLOOR_MIBPS,
+        baseline: None,
+    };
+
+    assert!(!evaluate_metric(&display, true, DISPLAY_FLOOR_MIBPS, THRESHOLD).failed);
+    assert!(!evaluate_metric(&comp3, true, COMP3_CI_FLOOR_MIBPS, THRESHOLD).failed);
+}
+
+#[test]
+fn gate_cli_fails_closed_for_missing_and_malformed_receipts() {
+    let temp = tempdir().expect("create gate fixture directory");
+    let missing = temp.path().join("missing.json");
+    let malformed = temp.path().join("malformed.json");
+    fs::write(&malformed, "{not-json").expect("write malformed gate fixture");
+
+    for receipt in [&missing, &malformed] {
+        let status = Command::new(env!("CARGO_BIN_EXE_bench-report"))
+            .args(["gate", receipt.to_str().expect("fixture path is UTF-8")])
+            .status()
+            .expect("run bench-report gate");
+        assert!(!status.success(), "invalid receipt must fail closed");
+    }
+}
+
+#[test]
+fn gate_cli_exit_status_matches_absolute_floor_decision() {
+    let temp = tempdir().expect("create gate fixture directory");
+    let passing = temp.path().join("passing.json");
+    let failing = temp.path().join("failing.json");
+    fs::write(&passing, r#"{"display_mibps":80.0,"comp3_mibps":8.0}"#)
+        .expect("write passing gate fixture");
+    fs::write(&failing, r#"{"display_mibps":79.9,"comp3_mibps":7.9}"#)
+        .expect("write failing gate fixture");
+
+    let pass_status = Command::new(env!("CARGO_BIN_EXE_bench-report"))
+        .args(["gate", passing.to_str().expect("fixture path is UTF-8")])
+        .status()
+        .expect("run passing bench-report gate fixture");
+    let fail_status = Command::new(env!("CARGO_BIN_EXE_bench-report"))
+        .args(["gate", failing.to_str().expect("fixture path is UTF-8")])
+        .status()
+        .expect("run failing bench-report gate fixture");
+
+    assert!(pass_status.success(), "exact floor boundary must pass");
+    assert!(!fail_status.success(), "below-floor receipt must fail");
 }
 
 // ---------------------------------------------------------------------------

--- a/tools/copybook-scripts/src/main.rs
+++ b/tools/copybook-scripts/src/main.rs
@@ -32,6 +32,12 @@ enum CommandKind {
         #[arg(value_name = "RECEIPT_FILE", default_value = "scripts/bench/perf.json")]
         receipt_file: PathBuf,
     },
+    ValidateSoakReceipt {
+        #[arg(value_name = "RECEIPT_FILE")]
+        receipt_file: PathBuf,
+        #[arg(value_name = "EXPECTED_COMMIT")]
+        expected_commit: String,
+    },
     SealPerfReceipt {
         #[arg(value_name = "RECEIPT_FILE", default_value = "scripts/bench/perf.json")]
         receipt_file: PathBuf,
@@ -62,6 +68,10 @@ fn main() -> Result<()> {
         CommandKind::SoakAggregate => soak_aggregate(),
         CommandKind::SoakDispatch => soak_dispatch(),
         CommandKind::ValidatePerfReceipt { receipt_file } => validate_perf_receipt(&receipt_file),
+        CommandKind::ValidateSoakReceipt {
+            receipt_file,
+            expected_commit,
+        } => validate_soak_receipt(&receipt_file, &expected_commit),
         CommandKind::SealPerfReceipt { receipt_file } => seal_perf_receipt(&receipt_file),
         CommandKind::AuditScriptMigrations => audit_script_migrations(),
         CommandKind::CleanMergeConflicts { file } => clean_merge_conflicts(file),
@@ -1288,10 +1298,62 @@ fn validate_perf_receipt(receipt_file: &Path) -> Result<()> {
     validate_format_version_value(&receipt)?;
     validate_timestamp_value(&receipt)?;
     validate_commit_hash_value(&receipt)?;
+    validate_optional_status_value(&receipt)?;
     validate_performance_values(&receipt)?;
     validate_receipt_integrity(&receipt)?;
 
     println!("✅ All receipt validations passed");
+    Ok(())
+}
+
+fn read_and_validate_perf_receipt(receipt_file: &Path) -> Result<Value> {
+    if !receipt_file.is_file() {
+        bail!("receipt file not found: {}", receipt_file.display());
+    }
+    let receipt: Value = serde_json::from_str(
+        &fs::read_to_string(receipt_file)
+            .with_context(|| format!("failed to read {}", receipt_file.display()))?,
+    )
+    .context("invalid receipt JSON format")?;
+    validate_receipt_structure(&receipt)?;
+    validate_format_version_value(&receipt)?;
+    validate_timestamp_value(&receipt)?;
+    validate_commit_hash_value(&receipt)?;
+    validate_optional_status_value(&receipt)?;
+    validate_performance_values(&receipt)?;
+    validate_receipt_integrity(&receipt)?;
+    Ok(receipt)
+}
+
+fn validate_soak_receipt(receipt_file: &Path, expected_commit: &str) -> Result<()> {
+    let receipt = read_and_validate_perf_receipt(receipt_file)?;
+    let status = required_string(&receipt, "status")?;
+    if status != "measured" {
+        bail!("soak receipt status must be 'measured', found '{status}'");
+    }
+
+    let commit = required_string(&receipt, "commit")?;
+    if commit != expected_commit {
+        bail!("soak receipt commit '{commit}' does not match workflow commit '{expected_commit}'");
+    }
+    println!("âœ… Soak receipt belongs to {expected_commit} and has measured status");
+    Ok(())
+}
+
+fn validate_optional_status_value(receipt: &Value) -> Result<()> {
+    let Some(status) = receipt.get("status") else {
+        return Ok(());
+    };
+    let status = status
+        .as_str()
+        .context("optional string field is invalid: status")?;
+    if ![
+        "measured", "pass", "fail", "warn", "success", "failure", "warning",
+    ]
+    .contains(&status)
+    {
+        bail!("unsupported performance receipt status: {status}");
+    }
     Ok(())
 }
 
@@ -1382,6 +1444,22 @@ fn validate_performance_values(receipt: &Value) -> Result<()> {
         .context("missing required object field: summary")?;
     let display_mibps = required_number(summary, "display_mibps")?;
     let comp3_mibps = required_number(summary, "comp3_mibps")?;
+
+    for (field, summary_value) in [
+        ("display_mibps", display_mibps),
+        ("comp3_mibps", comp3_mibps),
+    ] {
+        if let Some(top_level) = receipt.get(field) {
+            let top_level = top_level
+                .as_f64()
+                .with_context(|| format!("required number field is invalid: {field}"))?;
+            if top_level != summary_value {
+                bail!(
+                    "âŒ Duplicate metric mismatch for {field}: top-level {top_level} != summary {summary_value}"
+                );
+            }
+        }
+    }
 
     if display_mibps < 0.0 {
         bail!("❌ Invalid DISPLAY throughput: {display_mibps} MiB/s (must be >= 0)");
@@ -1798,8 +1876,80 @@ pub fn encode_value(
         validate_format_version_value(&receipt)?;
         validate_timestamp_value(&receipt)?;
         validate_commit_hash_value(&receipt)?;
+        validate_optional_status_value(&receipt)?;
         validate_performance_values(&receipt)?;
         validate_receipt_integrity(&receipt)
+    }
+
+    #[test]
+    fn soak_receipt_requires_measured_status_and_exact_commit() -> Result<()> {
+        let path = temp_shadow_path("test-soak-receipt");
+        let mut receipt = valid_receipt();
+        seal_receipt_integrity(&mut receipt)?;
+        fs::write(&path, serde_json::to_string_pretty(&receipt)?)?;
+
+        validate_soak_receipt(&path, "abcdef1")?;
+        for status in [None, Some("pass"), Some("wrong"), Some("unknown")] {
+            let mut candidate = valid_receipt();
+            match status {
+                Some(value) => candidate["status"] = Value::String(value.to_string()),
+                None => {
+                    candidate
+                        .as_object_mut()
+                        .context("receipt fixture must be an object")?
+                        .remove("status");
+                }
+            }
+            seal_receipt_integrity(&mut candidate)?;
+            fs::write(&path, serde_json::to_string_pretty(&candidate)?)?;
+            assert!(validate_soak_receipt(&path, "abcdef1").is_err());
+        }
+
+        let mut wrong_commit = valid_receipt();
+        seal_receipt_integrity(&mut wrong_commit)?;
+        fs::write(&path, serde_json::to_string_pretty(&wrong_commit)?)?;
+        assert!(validate_soak_receipt(&path, "abcdef2").is_err());
+        let _ = fs::remove_file(path);
+        Ok(())
+    }
+
+    #[test]
+    fn generic_receipt_validation_preserves_known_legacy_statuses() -> Result<()> {
+        let path = temp_shadow_path("test-legacy-receipt-status");
+        for status in [None, Some("pass"), Some("failure"), Some("measured")] {
+            let mut receipt = valid_receipt();
+            match status {
+                Some(value) => receipt["status"] = Value::String(value.to_string()),
+                None => {
+                    receipt
+                        .as_object_mut()
+                        .context("receipt fixture must be an object")?
+                        .remove("status");
+                }
+            }
+            seal_receipt_integrity(&mut receipt)?;
+            fs::write(&path, serde_json::to_string_pretty(&receipt)?)?;
+            validate_perf_receipt(&path)?;
+        }
+
+        let mut unknown = valid_receipt();
+        unknown["status"] = Value::String("unknown".to_string());
+        seal_receipt_integrity(&mut unknown)?;
+        fs::write(&path, serde_json::to_string_pretty(&unknown)?)?;
+        assert!(validate_perf_receipt(&path).is_err());
+        let _ = fs::remove_file(path);
+        Ok(())
+    }
+
+    #[test]
+    fn duplicate_performance_metrics_must_match_summary() {
+        let mut receipt = valid_receipt();
+        receipt["display_mibps"] = json!(127.0);
+        assert!(validate_performance_values(&receipt).is_err());
+
+        receipt["display_mibps"] = json!(128.0);
+        receipt["comp3_mibps"] = json!(64.0);
+        assert!(validate_performance_values(&receipt).is_ok());
     }
 
     #[test]

--- a/tools/copybook-scripts/src/main.rs
+++ b/tools/copybook-scripts/src/main.rs
@@ -1736,6 +1736,7 @@ pub fn encode_value(
             "commit": "abcdef1",
             "build_profile": "release",
             "target_cpu": "native",
+            "status": "measured",
             "environment": {
                 "os": "linux",
                 "kernel": "test",
@@ -1781,6 +1782,23 @@ pub fn encode_value(
                 .and_then(Value::as_str),
             Some(hash.as_str())
         );
+        validate_receipt_integrity(&receipt)
+    }
+
+    #[test]
+    fn measured_receipt_seals_and_validates_without_claiming_gate_status() -> Result<()> {
+        let mut receipt = valid_receipt();
+        seal_receipt_integrity(&mut receipt)?;
+
+        assert_eq!(
+            receipt.get("status").and_then(Value::as_str),
+            Some("measured")
+        );
+        validate_receipt_structure(&receipt)?;
+        validate_format_version_value(&receipt)?;
+        validate_timestamp_value(&receipt)?;
+        validate_commit_hash_value(&receipt)?;
+        validate_performance_values(&receipt)?;
         validate_receipt_integrity(&receipt)
     }
 

--- a/tools/copybook-scripts/src/main.rs
+++ b/tools/copybook-scripts/src/main.rs
@@ -1453,7 +1453,7 @@ fn validate_performance_values(receipt: &Value) -> Result<()> {
             let top_level = top_level
                 .as_f64()
                 .with_context(|| format!("required number field is invalid: {field}"))?;
-            if top_level != summary_value {
+            if top_level.to_bits() != summary_value.to_bits() {
                 bail!(
                     "âŒ Duplicate metric mismatch for {field}: top-level {top_level} != summary {summary_value}"
                 );


### PR DESCRIPTION
# Pull Request

## Summary

Replace the unsupported 60-cell generated-dataset soak claim with one weekly/manual Ubuntu benchmark gate over the Criterion workloads the harness actually measures. The workflow now creates and validates a sealed measurement receipt, evaluates the canonical 80/8 MiB/s absolute floors, always publishes available evidence, and fails only after evidence collection when measurement, receipt validation, or gate evaluation failed.

Receipt producers now record `status: measured`; pass/fail belongs to the separate gate decision. A failed measurement removes prior receipt and Criterion outputs before execution, assembles and seals a temporary receipt, and promotes it only after both current measurements exist. Weekly validation binds the measured receipt to the full workflow SHA; duplicate top-level and summary metrics must agree. Documentation explicitly marks generated RDW, dataset-size, code-page, external-input, and leak-absence axes as not proven.

## Type of Change

- [x] Bugfix (fixes an issue)
- [x] Documentation (README, docs/, code comments)
- [x] Tests (test additions or improvements)
- [x] CI/CD (workflow or tooling changes)

## COBOL/Mainframe Context

- **COBOL features affected**: None
- **Data processing impact**: No codec behavior changes; this narrows benchmark evidence claims
- **Mainframe compatibility**: Unchanged

## Workspace Crates Affected

- [x] copybook-bench (performance benchmarks)

`copybook-scripts` receipt validation fixtures are also strengthened.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [ ] CHANGELOG.md updated (N/A: internal CI evidence correction)
- [x] `cargo fmt --all` passes (scoped packages)
- [x] Relevant Clippy libraries/binaries pass
- [x] Focused tests pass
- [x] Follows conventional commit format
- [ ] MSRV compliance verified (N/A: no dependency or language-baseline change)
- [ ] Golden fixtures updated (N/A)

## Testing Instructions

```text
PASS: cargo test -p copybook-bench --test gate_test (16)
PASS: cargo test -p copybook-bench --test ci_integration (14; includes forced measurement failure with preseeded valid stale evidence)
PASS: cargo test -p copybook-scripts (19; measured/full-SHA contract, legacy status compatibility, duplicate metric mismatch)
PASS: cargo fmt -p copybook-bench -p copybook-scripts -- --check
PASS: cargo clippy -p copybook-scripts --all-targets -- -D warnings
PASS: cargo clippy -p copybook-bench --lib --bins -- -D warnings
PASS: cargo metadata invariant: copybook-cli has no soak feature
PASS: git diff --check
PARTIAL: cargo run -p xtask -- docs verify-all passed stable-error and fixed/RDW registries, then stopped because no local nextest JUnit artifact existed; full docs truth is NOT_PROVEN locally.
FAIL (pre-existing, untouched): test-target Clippy finds existing warnings in regression_detection.rs, baseline_reconciliation.rs, issue_35_security_scanning_integration.rs, and src/regression/tests.rs.
NOT RUN: actionlint is not installed locally; hosted workflow parsing/validation is required.
```

The real scheduled benchmark was not manually dispatched from this draft PR. Runtime receipt and hosted schedule behavior remain NOT_PROVEN until a manual or scheduled run executes the merged workflow.

## Performance Impact

- [x] No runtime product performance impact expected

CI economics: one weekly Ubuntu benchmark replaces 60 nominally distinct jobs that all benchmarked the same internal data. This is a job-count and evidence-quality correction, not a dollar-savings or workload-coverage claim.

## Infrastructure/Tooling Changes

**Areas modified:**
- [x] Performance receipt parsing or SLO evaluation
- [x] CI scripts or validation gates

Adversarial proof covers exact 80/8 boundaries, below-floor failure, malformed/missing receipt failure, workflow outcome cross-checking, forced measurement failure after preseeded stale evidence, strict measured/full-SHA validation, generic legacy-status compatibility, duplicate-metric mismatch rejection, atomic receipt promotion, and absence of the unsupported matrix/generator/custom check.

## Breaking Changes

- [x] No product breaking changes

The custom per-cell `soak:*` checks are intentionally removed because their labels and success conclusions were unsupported. The workflow job conclusion is now the sole gate result.

## Related Issues

Closes #775

Follow-up #776 owns the separate dataset-manifest, external-input benchmark harness, and per-axis threshold-policy architecture.

## Additional Notes

The `.github/workflows/soak.yml` filename and `scripts/soak-dispatch.sh` command remain for operator compatibility. This PR does not restore the removed CLI feature or daily three-OS job, change the canonical performance floors, or claim generated workload/memory coverage.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a canonical weekly benchmark gate with sealed performance receipts and enforced 80/8 MiB/s thresholds.
  * Added receipt validation for measurement status, commit matching, and metric consistency.
  * Added clear gate outcomes for passing, failing, or invalid benchmark results.

* **Bug Fixes**
  * Prevented stale benchmark receipts and outputs from being reused after failed measurements.
  * Improved fail-closed behavior for missing or malformed receipts.

* **Documentation**
  * Updated CI, testing, infrastructure, and performance receipt guidance to reflect the new workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->