### PR TITLE
fix(codec): preserve raw capture provenance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,8 +203,10 @@ sampled locally via `just scheduled`.
 ### Raw capture contract
 
 - `RawMode::Record` emits the record payload as canonical `raw_b64`; legacy
-  `__raw_b64` is also emitted/accepted for compatibility.
+  `__raw_b64` is also emitted/accepted for compatibility. Whole-record raw
+  output includes `raw_capture: "record"` provenance.
 - `RawMode::RecordRDW` captures the RDW header plus record payload.
+  Whole-record raw output includes `raw_capture: "record+rdw"` provenance.
 - `RawMode::Field` emits only `<FIELD_NAME>_raw_b64` values and no whole-record
   raw payload.
 - `RawMode::Off` emits no raw payload.

--- a/crates/copybook-codec/AGENTS.md
+++ b/crates/copybook-codec/AGENTS.md
@@ -13,7 +13,8 @@ benchmark before making throughput claims.
 
 Raw capture follows the root contract: record mode emits payload-level
 `raw_b64` plus compatibility `__raw_b64`; record-RDW includes header and
-payload; field mode emits only `<FIELD_NAME>_raw_b64`; off emits none. Add a
+payload. Whole-record output carries the matching `raw_capture` value
+(`record` or `record+rdw`); field mode emits only `<FIELD_NAME>_raw_b64`; off emits none. Add a
 regression test whenever that output shape changes and keep the library API,
 CLI reference, and JSONL schema synchronized.
 

--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -51,6 +51,72 @@ struct RawRecord {
     capture: RawCapture,
 }
 
+fn parse_raw_rdw_frame(frame: &[u8]) -> Result<(u16, &[u8])> {
+    let (raw_header, raw_payload) = frame.split_at_checked(4).ok_or_else(|| {
+        Error::new(
+            ErrorCode::CBKF102_RECORD_LENGTH_INVALID,
+            format!(
+                "Raw RDW record is {} bytes; expected at least a 4-byte header",
+                frame.len()
+            ),
+        )
+    })?;
+    let header_bytes: [u8; 4] = raw_header.try_into().map_err(|_| {
+        Error::new(
+            ErrorCode::CBKF102_RECORD_LENGTH_INVALID,
+            "Raw RDW record does not contain a complete 4-byte header",
+        )
+    })?;
+    let header = copybook_rdw::RdwHeader::from_bytes(header_bytes);
+    let declared_payload_len = usize::from(header.length());
+    if declared_payload_len != raw_payload.len() {
+        return Err(Error::new(
+            ErrorCode::CBKF102_RECORD_LENGTH_INVALID,
+            format!(
+                "Raw RDW header declares {declared_payload_len} payload bytes, but {} bytes follow",
+                raw_payload.len()
+            ),
+        ));
+    }
+    Ok((header.reserved(), raw_payload))
+}
+
+fn validate_captured_raw_rdw(frame: &[u8], expected_payload: &[u8]) -> Result<()> {
+    let (_, raw_payload) = parse_raw_rdw_frame(frame)?;
+    if raw_payload != expected_payload {
+        return Err(Error::new(
+            ErrorCode::CBKF102_RECORD_LENGTH_INVALID,
+            "Raw RDW payload does not match the decoded record payload",
+        ));
+    }
+    Ok(())
+}
+
+fn captured_raw_record(
+    data: &[u8],
+    supplied_raw: Option<&[u8]>,
+    mode: crate::options::RawMode,
+) -> Result<Option<RawRecord>> {
+    let (bytes, capture) = match mode {
+        crate::options::RawMode::Off | crate::options::RawMode::Field => return Ok(None),
+        crate::options::RawMode::Record => (supplied_raw.unwrap_or(data), RawCapture::Record),
+        crate::options::RawMode::RecordRDW => {
+            let frame = supplied_raw.ok_or_else(|| {
+                Error::new(
+                    ErrorCode::CBKF102_RECORD_LENGTH_INVALID,
+                    "RawMode::RecordRDW requires an RDW header plus payload",
+                )
+            })?;
+            validate_captured_raw_rdw(frame, data)?;
+            (frame, RawCapture::RecordRdw)
+        }
+    };
+    Ok(Some(RawRecord {
+        b64: base64::engine::general_purpose::STANDARD.encode(bytes),
+        capture,
+    }))
+}
+
 /// Decode one fixed-size COBOL record into the public JSON envelope.
 ///
 /// This uses the supplied schema and decode options, returning the same
@@ -117,38 +183,16 @@ fn decode_record_with_scratch_and_raw(
     schema: &Schema,
     data: &[u8],
     options: &DecodeOptions,
-    raw_data: Option<Vec<u8>>,
+    raw_data: Option<&[u8]>,
     record_index: u64,
     record_offset: Option<u64>,
     scratch: &mut crate::memory::ScratchBuffers,
 ) -> Result<Value> {
     use serde_json::Map;
 
-    if matches!(options.emit_raw, crate::options::RawMode::RecordRDW) && raw_data.is_none() {
-        return Err(Error::new(
-            ErrorCode::CBKF102_RECORD_LENGTH_INVALID,
-            "RawMode::RecordRDW requires an RDW header plus payload",
-        ));
-    }
-
     let mut fields_map = Map::new();
-    let mut record_raw = None;
     let mut encoding_acc = Vec::new();
-
-    if let Some(raw_bytes) = raw_data.filter(|_| {
-        matches!(
-            options.emit_raw,
-            crate::options::RawMode::Record | crate::options::RawMode::RecordRDW
-        )
-    }) {
-        record_raw = Some(RawRecord {
-            b64: base64::engine::general_purpose::STANDARD.encode(raw_bytes),
-            capture: match options.emit_raw {
-                crate::options::RawMode::RecordRDW => RawCapture::RecordRdw,
-                _ => RawCapture::Record,
-            },
-        });
-    }
+    let record_raw = captured_raw_record(data, raw_data, options.emit_raw)?;
 
     process_fields_recursive_with_scratch(
         &schema.fields,
@@ -205,7 +249,6 @@ fn decode_record_with_raw_data_at_offset(
     record_index: u64,
     record_offset: Option<u64>,
 ) -> Result<Value> {
-    use crate::options::RawMode;
     use serde_json::Map;
 
     let mut fields_map = Map::new();
@@ -222,30 +265,7 @@ fn decode_record_with_raw_data_at_offset(
         &mut encoding_acc,
     )?;
 
-    let mut record_raw = None;
-    match options.emit_raw {
-        RawMode::Off | RawMode::Field => {}
-        RawMode::Record => {
-            let raw_b64 = base64::engine::general_purpose::STANDARD.encode(data);
-            record_raw = Some(RawRecord {
-                b64: raw_b64,
-                capture: RawCapture::Record,
-            });
-        }
-        RawMode::RecordRDW => {
-            let full_raw = raw_data_with_header.ok_or_else(|| {
-                Error::new(
-                    ErrorCode::CBKF102_RECORD_LENGTH_INVALID,
-                    "RawMode::RecordRDW requires an RDW header plus payload",
-                )
-            })?;
-            let raw_b64 = base64::engine::general_purpose::STANDARD.encode(full_raw);
-            record_raw = Some(RawRecord {
-                b64: raw_b64,
-                capture: RawCapture::RecordRdw,
-            });
-        }
-    }
+    let record_raw = captured_raw_record(data, raw_data_with_header, options.emit_raw)?;
 
     Ok(build_json_envelope(
         fields_map,
@@ -1600,88 +1620,8 @@ pub fn encode_record(schema: &Schema, json: &Value, options: &EncodeOptions) -> 
         json
     };
 
-    // Check if we should use raw data
-    if options.use_raw
-        && let Some(raw_b64_value) = root_obj
-            .get("raw_b64")
-            .or_else(|| root_obj.get("__raw_b64"))
-        && let Some(raw_str) = raw_b64_value.as_str()
-    {
-        let raw_capture = match root_obj.get("raw_capture") {
-            None => None,
-            Some(Value::String(value)) if value == "record" => Some(RawCapture::Record),
-            Some(Value::String(value)) if value == "record+rdw" => Some(RawCapture::RecordRdw),
-            Some(value) => {
-                return Err(Error::new(
-                    ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
-                    format!("Invalid raw_capture {value}; expected 'record' or 'record+rdw'"),
-                ));
-            }
-        };
-        // Decode base64 raw data
-        let raw_data = base64::engine::general_purpose::STANDARD
-            .decode(raw_str)
-            .map_err(|e| {
-                Error::new(
-                    ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
-                    format!("Invalid base64 in raw_b64: {e}"),
-                )
-            })?;
-
-        match options.format {
-            RecordFormat::RDW => {
-                if matches!(raw_capture, Some(RawCapture::Record)) {
-                    return Ok(crate::record::RDWRecord::try_with_reserved(raw_data, 0)?.as_bytes());
-                }
-
-                let (raw_header, raw_payload) = raw_data.split_at_checked(4).ok_or_else(|| {
-                    Error::new(
-                        ErrorCode::CBKF102_RECORD_LENGTH_INVALID,
-                        format!(
-                            "Raw RDW record is {} bytes; expected at least a 4-byte header",
-                            raw_data.len()
-                        ),
-                    )
-                })?;
-                let header_bytes: [u8; 4] = raw_header.try_into().map_err(|_| {
-                    Error::new(
-                        ErrorCode::CBKF102_RECORD_LENGTH_INVALID,
-                        "Raw RDW record does not contain a complete 4-byte header",
-                    )
-                })?;
-                let header = copybook_rdw::RdwHeader::from_bytes(header_bytes);
-                let declared_payload_len = usize::from(header.length());
-                if declared_payload_len != raw_payload.len() {
-                    return Err(Error::new(
-                        ErrorCode::CBKF102_RECORD_LENGTH_INVALID,
-                        format!(
-                            "Raw RDW header declares {declared_payload_len} payload bytes, but {} bytes follow",
-                            raw_payload.len()
-                        ),
-                    ));
-                }
-                let reserved = header.reserved();
-                let field_payload = encode_fields_to_bytes(schema, fields_value, options)?;
-
-                if field_payload == raw_payload {
-                    return Ok(raw_data);
-                }
-
-                return Ok(
-                    crate::record::RDWRecord::try_with_reserved(field_payload, reserved)?
-                        .as_bytes(),
-                );
-            }
-            RecordFormat::Fixed => {
-                if matches!(raw_capture, Some(RawCapture::RecordRdw)) {
-                    return Err(Error::new(
-                        ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
-                        "raw_capture 'record+rdw' conflicts with fixed record format",
-                    ));
-                }
-                return Ok(raw_data);
-            }
-        }
+    if let Some(raw_replay) = encode_raw_replay(root_obj, fields_value, schema, options)? {
+        return Ok(raw_replay);
     }
 
     // No raw data or not using raw - encode from fields
@@ -1704,6 +1644,86 @@ pub fn encode_record(schema: &Schema, json: &Value, options: &EncodeOptions) -> 
             Ok(result)
         }
     }
+}
+
+fn parse_raw_capture(root: &serde_json::Map<String, Value>) -> Result<Option<RawCapture>> {
+    match root.get("raw_capture") {
+        None => Ok(None),
+        Some(Value::String(value)) if value == "record" => Ok(Some(RawCapture::Record)),
+        Some(Value::String(value)) if value == "record+rdw" => Ok(Some(RawCapture::RecordRdw)),
+        Some(value) => Err(Error::new(
+            ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
+            format!("Invalid raw_capture {value}; expected 'record' or 'record+rdw'"),
+        )),
+    }
+}
+
+fn encode_raw_replay(
+    root: &serde_json::Map<String, Value>,
+    fields: &Value,
+    schema: &Schema,
+    options: &EncodeOptions,
+) -> Result<Option<Vec<u8>>> {
+    if !options.use_raw {
+        return Ok(None);
+    }
+    let Some(raw_str) = root
+        .get("raw_b64")
+        .or_else(|| root.get("__raw_b64"))
+        .and_then(Value::as_str)
+    else {
+        return Ok(None);
+    };
+    let capture = parse_raw_capture(root)?;
+    let raw_data = base64::engine::general_purpose::STANDARD
+        .decode(raw_str)
+        .map_err(|error| {
+            Error::new(
+                ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
+                format!("Invalid base64 in raw_b64: {error}"),
+            )
+        })?;
+
+    match options.format {
+        RecordFormat::Fixed => encode_fixed_raw_replay(raw_data, capture),
+        RecordFormat::RDW => encode_rdw_raw_replay(raw_data, capture, fields, schema, options),
+    }
+    .map(Some)
+}
+
+fn encode_fixed_raw_replay(raw_data: Vec<u8>, capture: Option<RawCapture>) -> Result<Vec<u8>> {
+    if matches!(capture, Some(RawCapture::RecordRdw)) {
+        return Err(Error::new(
+            ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
+            "raw_capture 'record+rdw' conflicts with fixed record format",
+        ));
+    }
+    Ok(raw_data)
+}
+
+fn encode_rdw_raw_replay(
+    raw_data: Vec<u8>,
+    capture: Option<RawCapture>,
+    fields: &Value,
+    schema: &Schema,
+    options: &EncodeOptions,
+) -> Result<Vec<u8>> {
+    if matches!(capture, Some(RawCapture::Record)) {
+        return Ok(crate::record::RDWRecord::try_with_reserved(raw_data, 0)?.as_bytes());
+    }
+
+    let field_payload = encode_fields_to_bytes(schema, fields, options)?;
+    let (reserved, raw_payload) = parse_raw_rdw_frame(&raw_data)?;
+    if matches!(capture, Some(RawCapture::RecordRdw)) && field_payload != raw_payload {
+        return Err(Error::new(
+            ErrorCode::CBKF102_RECORD_LENGTH_INVALID,
+            "raw_capture 'record+rdw' payload does not match encoded fields",
+        ));
+    }
+    if field_payload == raw_payload {
+        return Ok(raw_data);
+    }
+    Ok(crate::record::RDWRecord::try_with_reserved(field_payload, reserved)?.as_bytes())
 }
 
 /// Validate REDEFINES encoding constraints for direct `lib_api` encoding.
@@ -2814,7 +2834,7 @@ fn process_fixed_records<R: Read, W: Write>(
             schema,
             &record_data,
             options,
-            raw_data_for_decode,
+            raw_data_for_decode.as_deref(),
             record_index,
             Some(current_offset),
             &mut scratch,
@@ -2874,7 +2894,7 @@ fn decode_worker_pool(
                 &schema,
                 &work.payload,
                 &options,
-                work.raw_data,
+                work.raw_data.as_deref(),
                 work.record_index,
                 Some(work.record_offset),
                 scratch,
@@ -3083,7 +3103,7 @@ fn process_rdw_records<R: Read, W: Write>(
             schema,
             &rdw_record.payload,
             options,
-            full_raw_data,
+            full_raw_data.as_deref(),
             record_index,
             Some(current_offset),
             &mut scratch,

--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -99,7 +99,7 @@ fn captured_raw_record(
 ) -> Result<Option<RawRecord>> {
     let (bytes, capture) = match mode {
         crate::options::RawMode::Off | crate::options::RawMode::Field => return Ok(None),
-        crate::options::RawMode::Record => (supplied_raw.unwrap_or(data), RawCapture::Record),
+        crate::options::RawMode::Record => (data, RawCapture::Record),
         crate::options::RawMode::RecordRDW => {
             let frame = supplied_raw.ok_or_else(|| {
                 Error::new(

--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -31,6 +31,26 @@ use warnings::{reset_warning_counter, warning_count};
 
 const MAX_WORKERS: usize = 64;
 
+#[derive(Clone, Copy)]
+enum RawCapture {
+    Record,
+    RecordRdw,
+}
+
+impl RawCapture {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Record => "record",
+            Self::RecordRdw => "record+rdw",
+        }
+    }
+}
+
+struct RawRecord {
+    b64: String,
+    capture: RawCapture,
+}
+
 /// Decode one fixed-size COBOL record into the public JSON envelope.
 ///
 /// This uses the supplied schema and decode options, returning the same
@@ -104,6 +124,13 @@ fn decode_record_with_scratch_and_raw(
 ) -> Result<Value> {
     use serde_json::Map;
 
+    if matches!(options.emit_raw, crate::options::RawMode::RecordRDW) && raw_data.is_none() {
+        return Err(Error::new(
+            ErrorCode::CBKF102_RECORD_LENGTH_INVALID,
+            "RawMode::RecordRDW requires an RDW header plus payload",
+        ));
+    }
+
     let mut fields_map = Map::new();
     let mut record_raw = None;
     let mut encoding_acc = Vec::new();
@@ -114,7 +141,13 @@ fn decode_record_with_scratch_and_raw(
             crate::options::RawMode::Record | crate::options::RawMode::RecordRDW
         )
     }) {
-        record_raw = Some(base64::engine::general_purpose::STANDARD.encode(raw_bytes));
+        record_raw = Some(RawRecord {
+            b64: base64::engine::general_purpose::STANDARD.encode(raw_bytes),
+            capture: match options.emit_raw {
+                crate::options::RawMode::RecordRDW => RawCapture::RecordRdw,
+                _ => RawCapture::Record,
+            },
+        });
     }
 
     process_fields_recursive_with_scratch(
@@ -194,16 +227,23 @@ fn decode_record_with_raw_data_at_offset(
         RawMode::Off | RawMode::Field => {}
         RawMode::Record => {
             let raw_b64 = base64::engine::general_purpose::STANDARD.encode(data);
-            record_raw = Some(raw_b64);
+            record_raw = Some(RawRecord {
+                b64: raw_b64,
+                capture: RawCapture::Record,
+            });
         }
         RawMode::RecordRDW => {
-            if let Some(full_raw) = raw_data_with_header {
-                let raw_b64 = base64::engine::general_purpose::STANDARD.encode(full_raw);
-                record_raw = Some(raw_b64);
-            } else {
-                let raw_b64 = base64::engine::general_purpose::STANDARD.encode(data);
-                record_raw = Some(raw_b64);
-            }
+            let full_raw = raw_data_with_header.ok_or_else(|| {
+                Error::new(
+                    ErrorCode::CBKF102_RECORD_LENGTH_INVALID,
+                    "RawMode::RecordRDW requires an RDW header plus payload",
+                )
+            })?;
+            let raw_b64 = base64::engine::general_purpose::STANDARD.encode(full_raw);
+            record_raw = Some(RawRecord {
+                b64: raw_b64,
+                capture: RawCapture::RecordRdw,
+            });
         }
     }
 
@@ -1567,6 +1607,17 @@ pub fn encode_record(schema: &Schema, json: &Value, options: &EncodeOptions) -> 
             .or_else(|| root_obj.get("__raw_b64"))
         && let Some(raw_str) = raw_b64_value.as_str()
     {
+        let raw_capture = match root_obj.get("raw_capture") {
+            None => None,
+            Some(Value::String(value)) if value == "record" => Some(RawCapture::Record),
+            Some(Value::String(value)) if value == "record+rdw" => Some(RawCapture::RecordRdw),
+            Some(value) => {
+                return Err(Error::new(
+                    ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
+                    format!("Invalid raw_capture {value}; expected 'record' or 'record+rdw'"),
+                ));
+            }
+        };
         // Decode base64 raw data
         let raw_data = base64::engine::general_purpose::STANDARD
             .decode(raw_str)
@@ -1579,6 +1630,10 @@ pub fn encode_record(schema: &Schema, json: &Value, options: &EncodeOptions) -> 
 
         match options.format {
             RecordFormat::RDW => {
+                if matches!(raw_capture, Some(RawCapture::Record)) {
+                    return Ok(crate::record::RDWRecord::try_with_reserved(raw_data, 0)?.as_bytes());
+                }
+
                 let (raw_header, raw_payload) = raw_data.split_at_checked(4).ok_or_else(|| {
                     Error::new(
                         ErrorCode::CBKF102_RECORD_LENGTH_INVALID,
@@ -1618,6 +1673,12 @@ pub fn encode_record(schema: &Schema, json: &Value, options: &EncodeOptions) -> 
                 );
             }
             RecordFormat::Fixed => {
+                if matches!(raw_capture, Some(RawCapture::RecordRdw)) {
+                    return Err(Error::new(
+                        ErrorCode::CBKE501_JSON_TYPE_MISMATCH,
+                        "raw_capture 'record+rdw' conflicts with fixed record format",
+                    ));
+                }
                 return Ok(raw_data);
             }
         }

--- a/crates/copybook-codec/src/lib_api.rs
+++ b/crates/copybook-codec/src/lib_api.rs
@@ -251,6 +251,10 @@ fn decode_record_with_raw_data_at_offset(
 ) -> Result<Value> {
     use serde_json::Map;
 
+    // Validate whole-record framing before field decoding so a malformed
+    // RecordRDW capture cannot be masked by an unrelated field error.
+    let record_raw = captured_raw_record(data, raw_data_with_header, options.emit_raw)?;
+
     let mut fields_map = Map::new();
     let mut scratch_buffers: Option<crate::memory::ScratchBuffers> = None;
     let mut encoding_acc = Vec::new();
@@ -264,8 +268,6 @@ fn decode_record_with_raw_data_at_offset(
         record_index,
         &mut encoding_acc,
     )?;
-
-    let record_raw = captured_raw_record(data, raw_data_with_header, options.emit_raw)?;
 
     Ok(build_json_envelope(
         fields_map,
@@ -1712,14 +1714,10 @@ fn encode_rdw_raw_replay(
         return Ok(crate::record::RDWRecord::try_with_reserved(raw_data, 0)?.as_bytes());
     }
 
-    let field_payload = encode_fields_to_bytes(schema, fields, options)?;
+    // Validate framing before field encoding so a malformed raw frame cannot
+    // be masked by an unrelated field error.
     let (reserved, raw_payload) = parse_raw_rdw_frame(&raw_data)?;
-    if matches!(capture, Some(RawCapture::RecordRdw)) && field_payload != raw_payload {
-        return Err(Error::new(
-            ErrorCode::CBKF102_RECORD_LENGTH_INVALID,
-            "raw_capture 'record+rdw' payload does not match encoded fields",
-        ));
-    }
+    let field_payload = encode_fields_to_bytes(schema, fields, options)?;
     if field_payload == raw_payload {
         return Ok(raw_data);
     }

--- a/crates/copybook-codec/src/lib_api/envelope.rs
+++ b/crates/copybook-codec/src/lib_api/envelope.rs
@@ -6,6 +6,8 @@ use crate::options::{DecodeOptions, ZonedEncodingFormat};
 use copybook_core::Schema;
 use serde_json::Value;
 
+use super::RawRecord;
+
 pub(super) struct RecordMetadata {
     pub(super) length: usize,
     pub(super) offset: Option<u64>,
@@ -37,7 +39,7 @@ pub(super) fn build_json_envelope(
     options: &DecodeOptions,
     record_index: u64,
     record_metadata: &RecordMetadata,
-    raw_b64: Option<String>,
+    raw_record: Option<RawRecord>,
     encoding_metadata: Vec<(String, ZonedEncodingFormat)>,
 ) -> Value {
     let mut root = serde_json::Map::new();
@@ -88,9 +90,14 @@ pub(super) fn build_json_envelope(
         }
     }
 
-    if let Some(raw) = raw_b64 {
+    if let Some(raw_record) = raw_record {
+        let raw = raw_record.b64;
         root.insert(String::from("raw_b64"), Value::String(raw.clone()));
         root.insert(String::from("__raw_b64"), Value::String(raw));
+        root.insert(
+            String::from("raw_capture"),
+            Value::String(raw_record.capture.as_str().into()),
+        );
     }
 
     if options.preserve_zoned_encoding && !encoding_metadata.is_empty() {

--- a/crates/copybook-codec/src/options.rs
+++ b/crates/copybook-codec/src/options.rs
@@ -339,6 +339,9 @@ impl JsonNumberMode {
 /// - `RecordRDW` — RDW header plus record payload in `raw_b64` and compatibility `__raw_b64`
 /// - `Field` — only per-field raw bytes in `<FIELD_NAME>_raw_b64`
 ///
+/// Whole-record capture also emits `raw_capture` with `record` or `record+rdw`
+/// so RDW replay does not infer framing from byte contents.
+///
 /// # Examples
 ///
 /// ```
@@ -453,6 +456,8 @@ impl DecodeOptions {
     /// - `RawMode::Record` — record payload in `raw_b64` and compatibility `__raw_b64`
     /// - `RawMode::RecordRDW` — RDW header plus payload in `raw_b64` and compatibility `__raw_b64`
     /// - `RawMode::Field` — only per-field raw values in `<FIELD>_raw_b64`
+    ///
+    /// Whole-record capture also emits matching `raw_capture` provenance.
     #[must_use]
     #[inline]
     pub fn with_emit_raw(mut self, emit_raw: RawMode) -> Self {

--- a/crates/copybook-codec/tests/raw_rdw_mutation.rs
+++ b/crates/copybook-codec/tests/raw_rdw_mutation.rs
@@ -136,16 +136,29 @@ fn explicit_record_rdw_provenance_rejects_malformed_frame() -> Result<()> {
 }
 
 #[test]
-fn explicit_record_rdw_provenance_rejects_field_payload_mismatch() -> Result<()> {
+fn explicit_record_rdw_provenance_rebuilds_changed_fields_and_preserves_reserved() -> Result<()> {
     let schema = parse_copybook("01 REC PIC X(3).")?;
     let json = json!({
         "fields": {"REC": "XYZ"},
         "raw_b64": raw_b64(b"ABC", RESERVED)?,
         "raw_capture": "record+rdw",
     });
+    let encoded = encode_record(&schema, &json, &rdw_options(true, 1, true))?;
+    anyhow::ensure!(encoded == [b"\0\x03\xA5\x5A".as_slice(), b"XYZ"].concat());
+    Ok(())
+}
+
+#[test]
+fn malformed_record_rdw_precedes_field_encode_errors() -> Result<()> {
+    let schema = parse_copybook("01 REC PIC 9.")?;
+    let json = json!({
+        "fields": {"REC": {"invalid": true}},
+        "raw_b64": payload_b64(&[0x7E; 3]),
+        "raw_capture": "record+rdw",
+    });
     let error = encode_record(&schema, &json, &rdw_options(true, 1, true))
         .err()
-        .context("explicit framed payload mismatch unexpectedly rebuilt")?;
+        .context("malformed explicit frame unexpectedly reached field encoding")?;
     anyhow::ensure!(error.code == ErrorCode::CBKF102_RECORD_LENGTH_INVALID);
     Ok(())
 }
@@ -197,6 +210,20 @@ fn direct_record_rdw_capture_validates_frame_against_payload() -> Result<()> {
 }
 
 #[test]
+fn malformed_record_rdw_precedes_field_decode_errors() -> Result<()> {
+    let schema = parse_copybook("01 REC PIC 9.")?;
+    let options = DecodeOptions::new()
+        .with_codepage(Codepage::ASCII)
+        .with_format(RecordFormat::RDW)
+        .with_emit_raw(RawMode::RecordRDW);
+    let error = decode_record_with_raw_data(&schema, b"X", &options, Some(&[0x7E; 3]), 1)
+        .err()
+        .context("malformed captured frame unexpectedly reached field decoding")?;
+    anyhow::ensure!(error.code == ErrorCode::CBKF102_RECORD_LENGTH_INVALID);
+    Ok(())
+}
+
+#[test]
 fn scratch_record_capture_matches_normal_envelope() -> Result<()> {
     let schema = parse_copybook("01 REC PIC X(3).")?;
     let options = DecodeOptions::new()
@@ -219,6 +246,7 @@ fn raw_rdw_mutation_preserves_reserved_bytes_at_max_payload() -> Result<()> {
     let json = json!({
         "fields": {"REC": changed},
         "raw_b64": raw_b64(b"", RESERVED)?,
+        "raw_capture": "record+rdw",
     });
 
     let encoded = encode_record(&schema, &json, &rdw_options(true, 1, true))?;
@@ -235,6 +263,7 @@ fn raw_rdw_mutation_above_max_payload_is_cbkf102() -> Result<()> {
     let json = json!({
         "fields": {"A": "A".repeat(u16::MAX as usize), "B": "B"},
         "raw_b64": raw_b64(b"", RESERVED)?,
+        "raw_capture": "record+rdw",
     });
 
     let error = encode_record(&schema, &json, &rdw_options(true, 1, true))
@@ -277,7 +306,10 @@ fn raw_rdw_declared_length_mismatch_is_cbkf102_before_replay_or_rebuild() -> Res
 
         for raw_key in ["raw_b64", "__raw_b64"] {
             for field_value in [json!("ABC"), json!("XYZ"), json!(123)] {
-                let mut json = json!({"fields": {"REC": field_value}});
+                let mut json = json!({
+                    "fields": {"REC": field_value},
+                    "raw_capture": "record+rdw",
+                });
                 json[raw_key] = Value::String(encoded_raw.clone());
 
                 let error = encode_record(&schema, &json, &rdw_options(true, 1, true))

--- a/crates/copybook-codec/tests/raw_rdw_mutation.rs
+++ b/crates/copybook-codec/tests/raw_rdw_mutation.rs
@@ -210,6 +210,23 @@ fn direct_record_rdw_capture_validates_frame_against_payload() -> Result<()> {
 }
 
 #[test]
+fn direct_record_capture_ignores_supplied_rdw_frame() -> Result<()> {
+    let schema = parse_copybook("01 REC PIC X(3).")?;
+    let options = DecodeOptions::new()
+        .with_codepage(Codepage::ASCII)
+        .with_format(RecordFormat::RDW)
+        .with_emit_raw(RawMode::Record);
+    let frame = [b"\0\x03\xA5\x5A".as_slice(), b"ABC"].concat();
+
+    let decoded = decode_record_with_raw_data(&schema, b"ABC", &options, Some(&frame), 1)?;
+
+    anyhow::ensure!(decoded["raw_capture"] == "record");
+    anyhow::ensure!(decoded["raw_b64"] == payload_b64(b"ABC"));
+    anyhow::ensure!(decoded["__raw_b64"] == payload_b64(b"ABC"));
+    Ok(())
+}
+
+#[test]
 fn malformed_record_rdw_precedes_field_decode_errors() -> Result<()> {
     let schema = parse_copybook("01 REC PIC 9.")?;
     let options = DecodeOptions::new()

--- a/crates/copybook-codec/tests/raw_rdw_mutation.rs
+++ b/crates/copybook-codec/tests/raw_rdw_mutation.rs
@@ -2,9 +2,12 @@
 
 use anyhow::{Context, Result};
 use base64::Engine;
-use copybook_codec::{EncodeOptions, encode_jsonl_to_file, encode_record};
+use copybook_codec::{
+    DecodeOptions, EncodeOptions, decode_record, decode_record_with_scratch, encode_jsonl_to_file,
+    encode_record,
+};
 use copybook_core::{ErrorCode, parse_copybook};
-use copybook_options::{Codepage, RecordFormat};
+use copybook_options::{Codepage, RawMode, RecordFormat};
 use serde_json::{Value, json};
 
 const RESERVED: [u8; 2] = [0xA5, 0x5A];
@@ -27,6 +30,10 @@ fn raw_b64(payload: &[u8], reserved: [u8; 2]) -> Result<String> {
     Ok(base64::engine::general_purpose::STANDARD.encode(record))
 }
 
+fn payload_b64(payload: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD.encode(payload)
+}
+
 #[test]
 fn raw_rdw_unchanged_replay_is_byte_identical_and_canonical_key_wins() -> Result<()> {
     let schema = parse_copybook("01 REC PIC X(3).")?;
@@ -36,11 +43,114 @@ fn raw_rdw_unchanged_replay_is_byte_identical_and_canonical_key_wins() -> Result
         "fields": {"REC": "ABC"},
         "raw_b64": canonical,
         "__raw_b64": legacy,
+        "raw_capture": "record+rdw",
     });
 
     let encoded = encode_record(&schema, &json, &rdw_options(true, 1, true))?;
 
     anyhow::ensure!(encoded == [b"\0\x03\xA5\x5A".as_slice(), b"ABC"].concat());
+    Ok(())
+}
+
+#[test]
+fn raw_record_provenance_wraps_payload_without_length_guessing() -> Result<()> {
+    let schema = parse_copybook("01 REC PIC X.")?;
+    for payload in [
+        Vec::new(),
+        vec![b'A'],
+        vec![b'A', b'B'],
+        vec![b'A', b'B', b'C'],
+        vec![0, 0, 0xA5, 0x5A],
+        b"ABCDE".to_vec(),
+    ] {
+        let json = json!({
+            "raw_b64": payload_b64(&payload),
+            "raw_capture": "record",
+        });
+        let encoded = encode_record(&schema, &json, &rdw_options(true, 1, true))?;
+        let length = u16::try_from(payload.len()).context("fixture payload exceeds u16")?;
+        let expected = [length.to_be_bytes().as_slice(), &[0, 0], payload.as_slice()].concat();
+        anyhow::ensure!(encoded == expected);
+    }
+    Ok(())
+}
+
+#[test]
+fn invalid_or_conflicting_raw_capture_is_cbke501() -> Result<()> {
+    let schema = parse_copybook("01 REC PIC X.")?;
+    for marker in [json!("unknown"), json!(3)] {
+        let json = json!({
+            "raw_b64": payload_b64(b"A"),
+            "raw_capture": marker,
+        });
+        let error = encode_record(&schema, &json, &rdw_options(true, 1, true))
+            .err()
+            .context("invalid raw_capture unexpectedly succeeded")?;
+        anyhow::ensure!(error.code == ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+    }
+
+    let fixed_options = EncodeOptions::new()
+        .with_codepage(Codepage::ASCII)
+        .with_format(RecordFormat::Fixed)
+        .with_use_raw(true);
+    let conflicting = json!({
+        "raw_b64": payload_b64(b"A"),
+        "raw_capture": "record+rdw",
+    });
+    let error = encode_record(&schema, &conflicting, &fixed_options)
+        .err()
+        .context("RDW provenance unexpectedly accepted for fixed replay")?;
+    anyhow::ensure!(error.code == ErrorCode::CBKE501_JSON_TYPE_MISMATCH);
+    Ok(())
+}
+
+#[test]
+fn fixed_record_provenance_keeps_raw_replay_unchanged() -> Result<()> {
+    let schema = parse_copybook("01 REC PIC X(5).")?;
+    let fixed_options = EncodeOptions::new()
+        .with_codepage(Codepage::ASCII)
+        .with_format(RecordFormat::Fixed)
+        .with_use_raw(true);
+    let json = json!({
+        "fields": {"REC": "XXXXX"},
+        "raw_b64": payload_b64(b"HELLO"),
+        "raw_capture": "record",
+    });
+    anyhow::ensure!(encode_record(&schema, &json, &fixed_options)? == b"HELLO");
+    Ok(())
+}
+
+#[test]
+fn explicit_record_rdw_provenance_rejects_malformed_frame() -> Result<()> {
+    let schema = parse_copybook("01 REC PIC X.")?;
+    let json = json!({
+        "raw_b64": payload_b64(&[0x7E; 3]),
+        "raw_capture": "record+rdw",
+    });
+    let error = encode_record(&schema, &json, &rdw_options(true, 1, true))
+        .err()
+        .context("short explicit raw RDW unexpectedly succeeded")?;
+    anyhow::ensure!(error.code == ErrorCode::CBKF102_RECORD_LENGTH_INVALID);
+    Ok(())
+}
+
+#[test]
+fn direct_record_rdw_capture_without_header_is_cbkf102() -> Result<()> {
+    let schema = parse_copybook("01 REC PIC X.")?;
+    let options = DecodeOptions::new()
+        .with_codepage(Codepage::ASCII)
+        .with_format(RecordFormat::RDW)
+        .with_emit_raw(RawMode::RecordRDW);
+    let error = decode_record(&schema, b"A", &options)
+        .err()
+        .context("RecordRDW capture without a physical header unexpectedly succeeded")?;
+    anyhow::ensure!(error.code == ErrorCode::CBKF102_RECORD_LENGTH_INVALID);
+
+    let mut scratch = copybook_codec::runtime::ScratchBuffers::new();
+    let scratch_error = decode_record_with_scratch(&schema, b"A", &options, &mut scratch)
+        .err()
+        .context("scratch RecordRDW capture without a physical header unexpectedly succeeded")?;
+    anyhow::ensure!(scratch_error.code == ErrorCode::CBKF102_RECORD_LENGTH_INVALID);
     Ok(())
 }
 

--- a/crates/copybook-codec/tests/raw_rdw_mutation.rs
+++ b/crates/copybook-codec/tests/raw_rdw_mutation.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{Context, Result};
 use base64::Engine;
+use copybook_codec::lib_api::decode_record_with_raw_data;
 use copybook_codec::{
     DecodeOptions, EncodeOptions, decode_record, decode_record_with_scratch, encode_jsonl_to_file,
     encode_record,
@@ -135,6 +136,21 @@ fn explicit_record_rdw_provenance_rejects_malformed_frame() -> Result<()> {
 }
 
 #[test]
+fn explicit_record_rdw_provenance_rejects_field_payload_mismatch() -> Result<()> {
+    let schema = parse_copybook("01 REC PIC X(3).")?;
+    let json = json!({
+        "fields": {"REC": "XYZ"},
+        "raw_b64": raw_b64(b"ABC", RESERVED)?,
+        "raw_capture": "record+rdw",
+    });
+    let error = encode_record(&schema, &json, &rdw_options(true, 1, true))
+        .err()
+        .context("explicit framed payload mismatch unexpectedly rebuilt")?;
+    anyhow::ensure!(error.code == ErrorCode::CBKF102_RECORD_LENGTH_INVALID);
+    Ok(())
+}
+
+#[test]
 fn direct_record_rdw_capture_without_header_is_cbkf102() -> Result<()> {
     let schema = parse_copybook("01 REC PIC X.")?;
     let options = DecodeOptions::new()
@@ -151,6 +167,48 @@ fn direct_record_rdw_capture_without_header_is_cbkf102() -> Result<()> {
         .err()
         .context("scratch RecordRDW capture without a physical header unexpectedly succeeded")?;
     anyhow::ensure!(scratch_error.code == ErrorCode::CBKF102_RECORD_LENGTH_INVALID);
+    Ok(())
+}
+
+#[test]
+fn direct_record_rdw_capture_validates_frame_against_payload() -> Result<()> {
+    let schema = parse_copybook("01 REC PIC X(3).")?;
+    let options = DecodeOptions::new()
+        .with_codepage(Codepage::ASCII)
+        .with_format(RecordFormat::RDW)
+        .with_emit_raw(RawMode::RecordRDW);
+    let valid = [b"\0\x03\xA5\x5A".as_slice(), b"ABC"].concat();
+    let decoded = decode_record_with_raw_data(&schema, b"ABC", &options, Some(&valid), 1)?;
+    anyhow::ensure!(decoded["raw_capture"] == "record+rdw");
+    anyhow::ensure!(decoded["raw_b64"] == payload_b64(&valid));
+
+    let malformed = [
+        vec![0x7E; 3],
+        [b"\0\x02\xA5\x5A".as_slice(), b"ABC"].concat(),
+        [b"\0\x03\xA5\x5A".as_slice(), b"XYZ"].concat(),
+    ];
+    for frame in malformed {
+        let error = decode_record_with_raw_data(&schema, b"ABC", &options, Some(&frame), 1)
+            .err()
+            .context("invalid captured RDW frame unexpectedly succeeded")?;
+        anyhow::ensure!(error.code == ErrorCode::CBKF102_RECORD_LENGTH_INVALID);
+    }
+    Ok(())
+}
+
+#[test]
+fn scratch_record_capture_matches_normal_envelope() -> Result<()> {
+    let schema = parse_copybook("01 REC PIC X(3).")?;
+    let options = DecodeOptions::new()
+        .with_codepage(Codepage::ASCII)
+        .with_format(RecordFormat::Fixed)
+        .with_emit_raw(RawMode::Record);
+    let normal = decode_record(&schema, b"ABC", &options)?;
+    let mut scratch = copybook_codec::runtime::ScratchBuffers::new();
+    let optimized = decode_record_with_scratch(&schema, b"ABC", &options, &mut scratch)?;
+    anyhow::ensure!(optimized == normal);
+    anyhow::ensure!(optimized["raw_b64"] == payload_b64(b"ABC"));
+    anyhow::ensure!(optimized["raw_capture"] == "record");
     Ok(())
 }
 

--- a/crates/copybook-codec/tests/streaming_file_tests.rs
+++ b/crates/copybook-codec/tests/streaming_file_tests.rs
@@ -1024,6 +1024,7 @@ fn decode_file_to_jsonl_raw_mode_records_emit_fixed_raw_payload() {
 
     for decoded in lines.iter() {
         assert!(decoded.get("raw_b64").is_some());
+        assert_eq!(decoded["raw_capture"], "record");
         assert_eq!(
             parse_raw_b64_field_from_any(decoded, "raw_b64"),
             parse_raw_b64_field(decoded),
@@ -1067,6 +1068,52 @@ fn decode_file_to_jsonl_raw_mode_rdw_emits_header_and_payload() {
     assert_eq!(decoded_raws, rdw_raw_expectations);
     for decoded in lines.iter() {
         assert!(decoded.get("raw_b64").is_some());
+        assert_eq!(decoded["raw_capture"], "record+rdw");
+    }
+}
+
+#[test]
+fn rdw_payload_raw_capture_round_trips_across_workers() {
+    let schema = parse_copybook(RDW_SCHEMA).unwrap();
+    let rdw_data = build_rdw_records(&["ABCDE", "FGHIJ"]);
+    let mut baseline = None;
+
+    for threads in [1_usize, 4] {
+        let decode_options = ascii_decode_opts()
+            .with_format(RecordFormat::RDW)
+            .with_emit_raw(RawMode::Record)
+            .with_threads(threads);
+        let mut jsonl = Vec::new();
+        let summary =
+            decode_file_to_jsonl(&schema, Cursor::new(&rdw_data), &mut jsonl, &decode_options)
+                .unwrap();
+        assert_eq!(summary.records_processed, 2);
+
+        let values: Vec<serde_json::Value> = String::from_utf8(jsonl.clone())
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+        assert!(values.iter().all(|value| value["raw_capture"] == "record"));
+        assert_eq!(parse_raw_b64_field(&values[0]), b"ABCDE");
+        assert_eq!(parse_raw_b64_field(&values[1]), b"FGHIJ");
+
+        let encode_options = ascii_encode_opts()
+            .with_format(RecordFormat::RDW)
+            .with_use_raw(true)
+            .with_threads(threads);
+        let mut encoded = Vec::new();
+        let encode_summary =
+            encode_jsonl_to_file(&schema, Cursor::new(jsonl), &mut encoded, &encode_options)
+                .unwrap();
+        assert_eq!(encode_summary.records_processed, 2);
+        assert_eq!(encoded, rdw_data);
+
+        if let Some(expected) = &baseline {
+            assert_eq!(&encoded, expected);
+        } else {
+            baseline = Some(encoded);
+        }
     }
 }
 
@@ -1105,6 +1152,7 @@ fn decode_file_to_jsonl_raw_mode_rdw_is_stable_across_workers() {
         for line in &lines {
             assert!(line.get("raw_b64").is_some());
             assert!(line.get("__raw_b64").is_some());
+            assert_eq!(line["raw_capture"], "record+rdw");
         }
         let actual_raw: Vec<_> = lines.iter().map(parse_raw_b64_field).collect();
         assert_eq!(actual_raw, expected_raw);

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -211,7 +211,8 @@ copybook encode <COPYBOOK> <JSONL> [OPTIONS]
 - `--codepage <CP>` - Character encoding: cp037, cp273, cp500, cp1047, cp1140, ascii (default: cp037)
 
 **Encoding Options:**
-- `--use-raw` - Use raw bytes from `raw_b64` (or legacy `__raw_b64`) when available
+- `--use-raw` - Use raw bytes from `raw_b64` (or legacy `__raw_b64`) when available; `raw_capture`
+  distinguishes payload-only `record` bytes from framed `record+rdw` bytes for RDW output
 - `--bwz-encode` - Encode zero values as spaces for BLANK WHEN ZERO fields
 - `--coerce-numbers` - Coerce non-string JSON numbers to strings before encoding
 
@@ -668,6 +669,7 @@ Binary field sizes are determined by PIC digits: ≤4→16b, 5–9→32b, 10–1
 
 **Raw Bytes (--emit-raw):**
 - `raw_b64` - Canonical base64-encoded raw record bytes (record/record+rdw modes); legacy `__raw_b64` is also emitted for backward compatibility
+- `raw_capture` - Whole-record raw provenance: `record` for payload bytes or `record+rdw` for an RDW header plus payload
 - `<FIELD>__raw_b64` - Base64 payload for individual fields (field mode)
 - Enables byte-perfect round trips when re-encoding
 

--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -10,7 +10,7 @@
 # content-addressed, so squash merges cannot invalidate it.
 schema_version = 1
 scope = "fixed-rdw-pipeline"
-content_digest = "dfbaf94df515303d8335bf92627bd841c835290137ea1f84a9223006447b67bd"
+content_digest = "4809af796df39ec815717a6762ff9f5df6e4add0a5ddb218e5a24e5bc99ae22c"
 
 [[scenarios]]
 id = "format.fixed.basic"

--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -10,7 +10,7 @@
 # content-addressed, so squash merges cannot invalidate it.
 schema_version = 1
 scope = "fixed-rdw-pipeline"
-content_digest = "806847ede20e20221f43c3361d8a8488bff5958c1f0d65e3966f857a06799043"
+content_digest = "46cc87c41180d1d96af5f2004b4994ffb43381b39e43f960c976389720eb9df0"
 
 [[scenarios]]
 id = "format.fixed.basic"

--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -10,7 +10,7 @@
 # content-addressed, so squash merges cannot invalidate it.
 schema_version = 1
 scope = "fixed-rdw-pipeline"
-content_digest = "4809af796df39ec815717a6762ff9f5df6e4add0a5ddb218e5a24e5bc99ae22c"
+content_digest = "4d80c7d4817d2bd990c6bec65118d3da0eadea651c5a59c9e078251222c74df3"
 
 [[scenarios]]
 id = "format.fixed.basic"

--- a/docs/evidence/fixed-rdw-pipeline.toml
+++ b/docs/evidence/fixed-rdw-pipeline.toml
@@ -10,7 +10,7 @@
 # content-addressed, so squash merges cannot invalidate it.
 schema_version = 1
 scope = "fixed-rdw-pipeline"
-content_digest = "46cc87c41180d1d96af5f2004b4994ffb43381b39e43f960c976389720eb9df0"
+content_digest = "dfbaf94df515303d8335bf92627bd841c835290137ea1f84a9223006447b67bd"
 
 [[scenarios]]
 id = "format.fixed.basic"

--- a/docs/jsonl-schema.md
+++ b/docs/jsonl-schema.md
@@ -16,6 +16,7 @@ copybook-rs emits a versioned JSON envelope for each decoded record. Each line i
 | `offset` | integer | Optional byte offset in the source stream (present when `--emit-meta`). |
 | `length` | integer | Optional decoded record length in bytes (present when `--emit-meta`). |
 | `raw_b64` | string | Optional base64-encoded record bytes when `--emit-raw` is `record` or `record+rdw`. |
+| `raw_capture` | string | Present with whole-record `raw_b64`; `record` means payload only and `record+rdw` means a four-byte RDW header plus payload. |
 | `<field>_raw_b64` | string | Optional field-level payloads when `--emit-raw` is `field`. |
 | `_encoding_metadata` | object | Optional zoned encoding metadata (present when `--preserve-zoned-encoding`). |
 | `errors` | array | Optional structured error diagnostics for lenient decoding. |
@@ -39,9 +40,17 @@ copybook-rs emits a versioned JSON envelope for each decoded record. Each line i
   "schema_fingerprint": "4b0f5e64d9f6ec98f1a1d8e584c9d1e2f6879c16efac5aa1f77adbc2e7c8d2f5",
   "offset": 1280,
   "length": 80,
+  "raw_capture": "record",
   "raw_b64": "AAECAwQFBgcICQoLDA0ODxA="
 }
 ```
+
+`raw_capture` is the authoritative provenance for newly emitted whole-record
+raw data. During RDW encoding with `--use-raw`, `record` is wrapped in a new RDW
+header and `record+rdw` is validated as an existing frame. For compatibility,
+an input with `raw_b64` or legacy `__raw_b64` but no marker retains the
+historical RDW header-plus-payload interpretation; the encoder never guesses
+from byte length or contents.
 
 ## Field Ordering
 

--- a/docs/jsonl-schema.md
+++ b/docs/jsonl-schema.md
@@ -47,7 +47,9 @@ copybook-rs emits a versioned JSON envelope for each decoded record. Each line i
 
 `raw_capture` is the authoritative provenance for newly emitted whole-record
 raw data. During RDW encoding with `--use-raw`, `record` is wrapped in a new RDW
-header and `record+rdw` is validated as an existing frame. For compatibility,
+header and `record+rdw` is validated as an existing frame whose reserved bytes
+are preserved when changed fields rebuild its payload and length. The marker
+selects framing, not immutability. For compatibility,
 an input with `raw_b64` or legacy `__raw_b64` but no marker retains the
 historical RDW header-plus-payload interpretation; the encoder never guesses
 from byte length or contents.

--- a/docs/reference/LIBRARY_API.md
+++ b/docs/reference/LIBRARY_API.md
@@ -376,8 +376,10 @@ assert_eq!(original_data, encoded_data);
 **RDW-Specific Considerations**:
 - **Reserved Bytes**: `RawMode::RecordRDW` preserves bytes 2-3 of RDW header (reserved, typically zero)
 - **Raw Capture Mode**: RDW `use_raw=true` wraps `raw_capture: "record"` bytes in a new header;
-  `raw_capture: "record+rdw"` validates and preserves the supplied header. Missing markers retain
-  the legacy framed interpretation; provenance is never inferred from byte length or contents.
+  `raw_capture: "record+rdw"` validates the supplied frame and preserves its reserved bytes.
+  The marker selects framing, not immutability: changed fields rebuild the framed payload and
+  length. Missing markers retain the legacy framed interpretation; provenance is never inferred
+  from byte length or contents.
 - **Length Recomputation**: When fields change under `use_raw=true`, the encoder recomputes the
   RDW payload length while preserving reserved bytes. Unchanged valid raw RDW data is replayed
   byte-for-byte. With `use_raw=false`, the encoder constructs a new RDW header from the payload.

--- a/docs/reference/LIBRARY_API.md
+++ b/docs/reference/LIBRARY_API.md
@@ -333,17 +333,19 @@ Decoded records are wrapped in a stable JSON envelope:
   `emit_meta` is enabled for streaming decode; `offset` is the zero-based physical source offset
   of the decoded record
 
-When `emit_raw` is enabled, record-level payloads are emitted as **`raw_b64`** (with the canonical
-`__raw_b64` key also present). Field-level capture uses the `<FIELD>__raw_b64` naming pattern:
+When `emit_raw` is enabled, record-level payloads are emitted as **`raw_b64`** (with the legacy
+`__raw_b64` key also present). The `raw_capture` marker records whether those bytes are payload-only
+(`record`) or an RDW header plus payload (`record+rdw`). Field-level capture uses the
+`<FIELD>__raw_b64` naming pattern:
 
 ```rust
 // RawMode::Record - capture record payload only
 let opts = DecodeOptions::new().with_emit_raw(RawMode::Record);
-// JSON excerpt: { "raw_b64": "AAABBBCCC...", "__raw_b64": "AAABBBCCC..." }
+// JSON excerpt: { "raw_capture": "record", "raw_b64": "AAABBBCCC...", "__raw_b64": "AAABBBCCC..." }
 
 // RawMode::RecordRDW - capture payload + 4-byte RDW header
 let opts = DecodeOptions::new().with_emit_raw(RawMode::RecordRDW);
-// JSON excerpt: { "raw_b64": "AAAAAAhBBBCCC...", "__raw_b64": "AAAAAAhBBBCCC..." }
+// JSON excerpt: { "raw_capture": "record+rdw", "raw_b64": "AAAAAAhBBBCCC...", "__raw_b64": "AAAAAAhBBBCCC..." }
 
 // RawMode::Field - capture individual field payloads
 let opts = DecodeOptions::new().with_emit_raw(RawMode::Field);
@@ -352,7 +354,9 @@ let opts = DecodeOptions::new().with_emit_raw(RawMode::Field);
 
 **Roundtrip Encoding**:
 When `use_raw` is enabled in `EncodeOptions`, the encoder consumes `raw_b64` (or the legacy
-`__raw_b64`) from the JSON input to produce **bit-exact** output:
+`__raw_b64`) from the JSON input. For RDW output, `raw_capture` routes payload-only and framed
+bytes explicitly; marker-absent legacy input retains the historical header-plus-payload
+interpretation:
 
 ```rust
 // Decode with raw preservation
@@ -371,8 +375,9 @@ assert_eq!(original_data, encoded_data);
 
 **RDW-Specific Considerations**:
 - **Reserved Bytes**: `RawMode::RecordRDW` preserves bytes 2-3 of RDW header (reserved, typically zero)
-- **Raw Capture Mode**: RDW `use_raw=true` replay requires raw data captured with
-  `RawMode::RecordRDW`; payload-only `RawMode::Record` does not carry an RDW header
+- **Raw Capture Mode**: RDW `use_raw=true` wraps `raw_capture: "record"` bytes in a new header;
+  `raw_capture: "record+rdw"` validates and preserves the supplied header. Missing markers retain
+  the legacy framed interpretation; provenance is never inferred from byte length or contents.
 - **Length Recomputation**: When fields change under `use_raw=true`, the encoder recomputes the
   RDW payload length while preserving reserved bytes. Unchanged valid raw RDW data is replayed
   byte-for-byte. With `use_raw=false`, the encoder constructs a new RDW header from the payload.
@@ -385,6 +390,7 @@ assert_eq!(original_data, encoded_data);
   - `CBKR211_RDW_RESERVED_NONZERO` - Non-zero reserved bytes warning (lenient mode)
   - `CBKF221_RDW_UNDERFLOW` - Incomplete RDW header or payload
   - `CBKE501_JSON_TYPE_MISMATCH` - Invalid base64 in `raw_b64` / `__raw_b64`
+    or invalid/conflicting `raw_capture`
 
 ## Core Functions
 

--- a/schemas/record-format.json
+++ b/schemas/record-format.json
@@ -38,6 +38,11 @@
       "pattern": "^[A-Za-z0-9+/]*={0,2}$",
       "description": "Base64-encoded record bytes (when `emit_raw` is enabled)"
     },
+    "raw_capture": {
+      "type": "string",
+      "enum": ["record", "record+rdw"],
+      "description": "Provenance of raw_b64: payload-only record bytes or RDW header plus payload"
+    },
     "fields": {
       "type": "object",
       "patternProperties": {
@@ -84,5 +89,8 @@
     }
   },
   "required": ["schema", "record_index", "codepage", "fields"],
+  "dependencies": {
+    "raw_capture": ["raw_b64"]
+  },
   "additionalProperties": false
 }


### PR DESCRIPTION
# Pull Request

## Summary

Add `raw_capture` provenance to whole-record raw JSON envelopes so RDW replay distinguishes payload-only `record` bytes from `record+rdw` framed bytes without inspecting their length or contents.

RDW encode wraps explicit payload bytes with a canonical zero-reserved header. Explicit framed provenance must contain a complete, internally consistent RDW frame. The marker selects framing, not immutability: unchanged fields replay the exact frame, while changed fields rebuild the payload and length through the canonical constructor while preserving reserved bytes. Malformed frames fail with CBKF102 before unrelated field errors. Marker-absent legacy input retains the historical framed interpretation. Invalid or format-conflicting provenance fails with CBKE501.

All `RawMode::Record` producer paths emit payload-only bytes with `raw_capture: "record"`, even when an RDW frame is separately available. Only `RawMode::RecordRDW` consumes and validates the supplied physical frame. The scratch API matches normal decode behavior.

## Type of Change

- [x] Bugfix (fixes an issue)
- [x] Documentation
- [x] Tests

## COBOL/Mainframe Context

- **COBOL features affected**: raw record capture and RDW replay
- **Data processing impact**: additive JSON envelope marker; deterministic framing selection
- **Mainframe compatibility**: fixed-record replay and marker-absent legacy RDW behavior remain compatible

## Workspace Crates Affected

- [x] copybook-codec

## Checklist

- [x] Tests added/updated
- [x] Documentation and JSON schema updated
- [x] Governed fixed/RDW evidence digest synchronized
- [x] Changed surfaces pass formatting and pedantic Clippy
- [x] Conventional commit title

## Testing Instructions

```text
PASS: cargo test -p copybook-codec --test raw_rdw_mutation (19)
PASS: cargo test -p copybook-codec --test streaming_file_tests (64)
PASS: cargo build -p copybook-cli --bin copybook, then binary_roundtrip_fidelity_tests with CARGO_BIN_EXE_copybook set (13)
PASS: cargo test -p xtask docs_verify (61)
PASS: cargo clippy -p copybook-codec --lib --bins -- -D warnings -W clippy::pedantic
PASS: cargo clippy -p copybook-codec --test raw_rdw_mutation -- -D warnings -W clippy::pedantic
PASS: cargo fmt -p copybook-codec -- --check
PASS: cargo run -p xtask -- docs verify-record-pipeline (digest 4d80c7d4817d2bd990c6bec65118d3da0eadea651c5a59c9e078251222c74df3)
PASS: record-format schema closed enum/dependency structural proof
PARTIAL: workspace all-target pedantic Clippy reaches pre-existing warnings in untouched tests; changed library/binary and raw regression test surfaces are clean
PARTIAL: cargo run -p xtask -- docs verify-all passed stable-error and record-pipeline registries, then stopped because no local nextest JUnit artifact existed
```

## Breaking Changes

- [x] No supported envelope key is removed or reinterpreted

Newly produced whole-record envelopes include `raw_capture`. Direct `RawMode::RecordRDW` decode calls without an RDW header now fail closed instead of emitting payload bytes under a header-preserving mode.

## Related Issues

Closes #772

## Non-goals

This does not change RDW wire length conventions, the u16 payload bound, RDW I/O error mapping in #756, or remove legacy `__raw_b64`. It does not infer provenance for old marker-absent envelopes.
