### PR TITLE
ci(bench): publish external input preflight telemetry

### DIFF
--- a/.github/workflows/external-input-preflight.yml
+++ b/.github/workflows/external-input-preflight.yml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+name: External Input Decode Preflight
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: external-input-preflight-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  decode-preflight:
+    name: Decode checked-in external inputs
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build preflight publisher
+        run: cargo build --release -p copybook-bench --bin external-input-preflight
+
+      - name: Decode fixed external-input inventory
+        run: |
+          mkdir -p artifacts/external-input-preflight
+          ./target/release/external-input-preflight tools/copybook-bench/test_fixtures/external_input/fixed-ascii.json artifacts/external-input-preflight/fixed-ascii.json
+          ./target/release/external-input-preflight tools/copybook-bench/test_fixtures/external_input/fixed-cp037.json artifacts/external-input-preflight/fixed-cp037.json
+          ./target/release/external-input-preflight tools/copybook-bench/test_fixtures/external_input/rdw-ascii.json artifacts/external-input-preflight/rdw-ascii.json
+          ./target/release/external-input-preflight tools/copybook-bench/test_fixtures/external_input/rdw-cp037.json artifacts/external-input-preflight/rdw-cp037.json
+
+      - name: Upload decode telemetry
+        uses: actions/upload-artifact@v7
+        with:
+          name: external-input-preflight-${{ github.sha }}
+          path: artifacts/external-input-preflight/*.json
+          retention-days: 30
+          if-no-files-found: error

--- a/docs/PERFORMANCE_GOVERNANCE.md
+++ b/docs/PERFORMANCE_GOVERNANCE.md
@@ -7,9 +7,7 @@
 
 All performance claims in copybook-rs documentation MUST reference canonical receipts from [`scripts/bench/perf.json`](../scripts/bench/perf.json). Historical performance targets are archived in [`HISTORICAL_PERFORMANCE.md`](HISTORICAL_PERFORMANCE.md) and MUST NOT be referenced as current metrics.
 
-## Canonical Receipt Requirements
-
-### External-input decode telemetry
+## External-input Decode Telemetry
 
 The manual-only `.github/workflows/external-input-preflight.yml` workflow emits
 closed decode-preflight reports for the four checked-in external-input
@@ -18,7 +16,10 @@ accounting, and commit/input identity only. They contain no clock, duration, or
 throughput fields and are not performance receipts, benchmark results, gates,
 baselines, thresholds, or SLO evidence.
 
+## Canonical Receipt Requirements
+
 ### Required Elements for Performance Claims
+
 Every performance claim must include:
 1. **Receipt Reference**: Direct link to specific [`scripts/bench/perf.json`](../scripts/bench/perf.json) with commit hash
 2. **Timestamp**: When measurement was taken (from receipt)

--- a/docs/PERFORMANCE_GOVERNANCE.md
+++ b/docs/PERFORMANCE_GOVERNANCE.md
@@ -9,6 +9,15 @@ All performance claims in copybook-rs documentation MUST reference canonical rec
 
 ## Canonical Receipt Requirements
 
+### External-input decode telemetry
+
+The manual-only `.github/workflows/external-input-preflight.yml` workflow emits
+closed decode-preflight reports for the four checked-in external-input
+manifests. These artifacts prove manifest validation, record consumption, byte
+accounting, and commit/input identity only. They contain no clock, duration, or
+throughput fields and are not performance receipts, benchmark results, gates,
+baselines, thresholds, or SLO evidence.
+
 ### Required Elements for Performance Claims
 Every performance claim must include:
 1. **Receipt Reference**: Direct link to specific [`scripts/bench/perf.json`](../scripts/bench/perf.json) with commit hash

--- a/docs/TESTING_COMMANDS.md
+++ b/docs/TESTING_COMMANDS.md
@@ -39,6 +39,7 @@ This document provides a canonical reference for all testing commands in copyboo
 | **Mutation Testing** | `cargo mutants --package <crate> --timeout <timeout> --test-tool nextest --in-place --json --file mutants.toml` | Local only (`just mutants`); CI uses the advisory RIPR lane instead | 15-60 min per crate | `mutants.out/outcomes.json`, `mutants-summary.csv` |
 | **Performance Benchmarks** | `BENCH_FILTER=slo_validation bash scripts/bench.sh` | Scheduled | 10-15 min | `target/perf.json` |
 | **Weekly Benchmark Gate** | `bash scripts/soak-dispatch.sh` | Weekly + manual | ~20 min | Sealed `scripts/bench/perf.json`, workflow job conclusion |
+| **External-input Decode Preflight** | `gh workflow run external-input-preflight.yml` | Manual only | Bounded | Four commit-keyed decode telemetry reports |
 
 ---
 
@@ -682,6 +683,25 @@ vary code pages, or prove absence of memory leaks.
 
 **Trigger schedule**: Weekly at 3:00 AM UTC on Saturday, plus manual dispatch,
 via `.github/workflows/soak.yml`
+
+---
+
+### External-input Decode Preflight
+
+**Purpose**: Decode the fixed checked-in inventory of fixed/RDW ASCII/CP037
+manifests and publish deterministic input identity, record count, byte totals,
+and exact payload ranges.
+
+**Manual dispatch**:
+```bash
+gh workflow run external-input-preflight.yml
+```
+
+The workflow is manual-only, Linux-only, sequential, and fixed to four
+repository manifests. Its reports prove successful validation and decode
+consumption at the recorded commit. They do not contain timing or throughput,
+do not update `scripts/bench/perf.json`, and do not establish benchmark,
+threshold, performance-gate, or SLO evidence.
 
 ---
 

--- a/docs/TESTING_COMMANDS.md
+++ b/docs/TESTING_COMMANDS.md
@@ -704,6 +704,13 @@ consumption at the recorded commit. They do not contain timing or throughput,
 do not update `scripts/bench/perf.json`, and do not establish benchmark,
 threshold, performance-gate, or SLO evidence.
 
+For a missing, unreadable, or malformed manifest, the publisher returns nonzero
+and preserves any existing output because the referenced inputs cannot be
+verified safely. Once a readable manifest proves that the output aliases none
+of the manifest, copybook, or dataset inputs, the publisher removes stale
+output before the remaining validation and decode. The process exit status is
+authoritative; preserved output from a pre-parse failure is not current proof.
+
 ---
 
 ## Section 4: Artifact Locations

--- a/docs/TESTING_COMMANDS.md
+++ b/docs/TESTING_COMMANDS.md
@@ -693,6 +693,7 @@ manifests and publish deterministic input identity, record count, byte totals,
 and exact payload ranges.
 
 **Manual dispatch**:
+
 ```bash
 gh workflow run external-input-preflight.yml
 ```

--- a/docs/TEST_INFRASTRUCTURE_LANDSCAPE.md
+++ b/docs/TEST_INFRASTRUCTURE_LANDSCAPE.md
@@ -345,6 +345,14 @@ Tests use tags for categorization:
 - Publishes one receipt artifact; the job conclusion records the gate decision
 - Can be triggered manually with `bash scripts/soak-dispatch.sh`
 
+#### external-input-preflight.yml (Manual Decode Telemetry)
+- Runs only through `workflow_dispatch` on Ubuntu
+- Decodes the fixed four-manifest external-input inventory sequentially
+- Publishes commit-keyed closed JSON reports after every manifest succeeds
+- Proves validation, decode consumption, input identity, ranges, and byte totals
+- Does not measure duration or throughput and is not a benchmark, receipt, gate,
+  threshold, schedule, or SLO owner
+
 #### security-scan.yml (Security Validation)
 - Security scanning integration
 - Dependency auditing
@@ -376,6 +384,15 @@ bash scripts/soak-dispatch.sh
 The dedicated workflow proves only its canonical in-memory Criterion workloads
 and absolute-floor decision. Generated RDW, dataset-size, code-page, external-
 input, and leak-absence claims are not proven.
+
+**External-input decode telemetry (manual workflow dispatch)**:
+```bash
+gh workflow run external-input-preflight.yml
+```
+
+This separate manual lane proves only that the four checked-in fixed/RDW
+ASCII/CP037 manifests validate and decode at one commit with deterministic byte
+and range telemetry. It makes no performance or soak claim.
 
 **Performance Tests (Gated)**:
 ```bash

--- a/docs/TEST_INFRASTRUCTURE_LANDSCAPE.md
+++ b/docs/TEST_INFRASTRUCTURE_LANDSCAPE.md
@@ -353,6 +353,10 @@ Tests use tags for categorization:
 - Proves validation, decode consumption, input identity, ranges, and byte totals
 - Does not measure duration or throughput and is not a benchmark, receipt, gate,
   threshold, schedule, or SLO owner
+- Returns nonzero and preserves unverifiable existing output when the manifest
+  is missing, unreadable, or malformed; after a readable manifest proves all
+  input paths are distinct, stale output is removed before later validation
+  and decode failures
 
 #### security-scan.yml (Security Validation)
 - Security scanning integration

--- a/docs/TEST_INFRASTRUCTURE_LANDSCAPE.md
+++ b/docs/TEST_INFRASTRUCTURE_LANDSCAPE.md
@@ -346,6 +346,7 @@ Tests use tags for categorization:
 - Can be triggered manually with `bash scripts/soak-dispatch.sh`
 
 #### external-input-preflight.yml (Manual Decode Telemetry)
+
 - Runs only through `workflow_dispatch` on Ubuntu
 - Decodes the fixed four-manifest external-input inventory sequentially
 - Publishes commit-keyed closed JSON reports after every manifest succeeds
@@ -386,6 +387,7 @@ and absolute-floor decision. Generated RDW, dataset-size, code-page, external-
 input, and leak-absence claims are not proven.
 
 **External-input decode telemetry (manual workflow dispatch)**:
+
 ```bash
 gh workflow run external-input-preflight.yml
 ```

--- a/schemas/external-input-preflight-report.json
+++ b/schemas/external-input-preflight-report.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/copybook-rs/schemas/external-input-preflight-report.json",
+  "title": "External Input Decode Preflight Report",
+  "description": "Deterministic decode telemetry for one validated external-input manifest; not benchmark, throughput, threshold, or SLO evidence.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "status",
+    "commit",
+    "manifest_sha256",
+    "copybook_sha256",
+    "dataset_sha256",
+    "record_format",
+    "codepage",
+    "workload",
+    "decoded_records",
+    "physical_bytes",
+    "payload_bytes",
+    "framing_bytes",
+    "payload_ranges"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0.0" },
+    "status": { "const": "decoded" },
+    "commit": { "type": "string", "pattern": "^[a-f0-9]{40}$" },
+    "manifest_sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "copybook_sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "dataset_sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "record_format": { "type": "string", "enum": ["fixed", "rdw"] },
+    "codepage": {
+      "type": "string",
+      "enum": ["ascii", "cp037", "cp273", "cp500", "cp1047", "cp1140"]
+    },
+    "workload": {
+      "type": "string",
+      "enum": ["display-heavy", "comp3-heavy", "mixed"]
+    },
+    "decoded_records": { "type": "integer", "minimum": 1 },
+    "physical_bytes": { "type": "integer", "minimum": 1 },
+    "payload_bytes": { "type": "integer", "minimum": 1 },
+    "framing_bytes": { "type": "integer", "minimum": 0 },
+    "payload_ranges": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["start", "end"],
+        "properties": {
+          "start": { "type": "integer", "minimum": 0 },
+          "end": { "type": "integer", "minimum": 1 }
+        }
+      }
+    }
+  }
+}

--- a/tools/copybook-bench/Cargo.toml
+++ b/tools/copybook-bench/Cargo.toml
@@ -41,9 +41,9 @@ num_cpus = { workspace = true }
 chrono = { workspace = true, features = ["serde", "std", "clock"] }
 serde = { workspace = true }
 anyhow.workspace = true
+tempfile.workspace = true
 
 [dev-dependencies]
-tempfile.workspace = true
 regex.workspace = true
 [lints]
 workspace = true

--- a/tools/copybook-bench/src/bin/external-input-preflight.rs
+++ b/tools/copybook-bench/src/bin/external-input-preflight.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::env;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, ensure};
+use copybook_bench::external_input::publish_external_input_preflight;
+
+fn main() -> Result<()> {
+    let mut arguments = env::args_os();
+    let program = arguments
+        .next()
+        .unwrap_or_else(|| "external-input-preflight".into());
+    let usage = || {
+        format!(
+            "usage: {} <manifest.json> <output.json>",
+            PathBuf::from(&program).display()
+        )
+    };
+    let manifest = arguments.next().map(PathBuf::from).context(usage())?;
+    let output = arguments.next().map(PathBuf::from).context(usage())?;
+    ensure!(arguments.next().is_none(), usage());
+    let commit = env::var("GITHUB_SHA").context("GITHUB_SHA must identify the report commit")?;
+    publish_external_input_preflight(&manifest, &output, &commit)?;
+    Ok(())
+}

--- a/tools/copybook-bench/src/external_input.rs
+++ b/tools/copybook-bench/src/external_input.rs
@@ -3,6 +3,7 @@
 
 use std::fmt;
 use std::fs;
+use std::io::Write;
 use std::ops::Range;
 use std::path::{Component, Path, PathBuf};
 
@@ -449,13 +450,16 @@ fn run_external_input_preflight(
 ///
 /// Returns an error for an invalid commit identity, manifest validation or decode
 /// failure, report serialization failure, or output filesystem failure. Any
-/// distinct pre-existing output is removed before decode begins, and no output
-/// is retained after a failure. Input aliases are rejected without mutation.
+/// Once a readable manifest establishes that the output is distinct from all
+/// three inputs, a pre-existing output is removed before validation and decode.
+/// Missing or malformed manifests leave the unverifiable output untouched;
+/// input aliases are always rejected without mutation.
 pub fn publish_external_input_preflight(
     manifest_path: &Path,
     output_path: &Path,
     commit: &str,
 ) -> Result<ExternalInputPreflightReport> {
+    let output_lock = PreflightOutputLock::acquire(output_path)?;
     let preflight = run_external_input_preflight(manifest_path, Some(output_path))?;
     validate_commit(commit)?;
     let report = ExternalInputPreflightReport {
@@ -483,7 +487,7 @@ pub fn publish_external_input_preflight(
     };
     let bytes = serde_json::to_vec_pretty(&report)
         .context("failed to serialize external-input preflight report")?;
-    write_report_atomically(output_path, &bytes)?;
+    write_report_atomically(&output_lock, output_path, &bytes)?;
     Ok(report)
 }
 
@@ -551,7 +555,46 @@ fn lexical_absolute(path: &Path) -> Result<PathBuf> {
     Ok(normalized)
 }
 
-fn write_report_atomically(output_path: &Path, bytes: &[u8]) -> Result<()> {
+struct PreflightOutputLock {
+    path: PathBuf,
+}
+
+impl PreflightOutputLock {
+    fn acquire(output_path: &Path) -> Result<Self> {
+        let parent = output_path
+            .parent()
+            .filter(|path| !path.as_os_str().is_empty())
+            .unwrap_or(Path::new("."));
+        ensure!(
+            parent.is_dir(),
+            "preflight output directory does not exist: {}",
+            parent.display()
+        );
+        let file_name = output_path
+            .file_name()
+            .context("preflight output path must name a file")?;
+        let path = parent.join(format!(".{}.lock", file_name.to_string_lossy()));
+        fs::create_dir(&path).with_context(|| {
+            format!(
+                "failed to acquire exclusive preflight output lock {}",
+                path.display()
+            )
+        })?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for PreflightOutputLock {
+    fn drop(&mut self) {
+        let _cleanup = fs::remove_dir(&self.path);
+    }
+}
+
+fn write_report_atomically(
+    _output_lock: &PreflightOutputLock,
+    output_path: &Path,
+    bytes: &[u8],
+) -> Result<()> {
     let parent = output_path
         .parent()
         .filter(|path| !path.as_os_str().is_empty())
@@ -564,29 +607,42 @@ fn write_report_atomically(output_path: &Path, bytes: &[u8]) -> Result<()> {
     let file_name = output_path
         .file_name()
         .context("preflight output path must name a file")?;
-    let temporary_path = parent.join(format!(".{}.tmp", file_name.to_string_lossy()));
-    remove_output_if_present(&temporary_path)?;
-
-    let result = (|| -> Result<()> {
-        fs::write(&temporary_path, bytes).with_context(|| {
+    let prefix = format!(".{}.", file_name.to_string_lossy());
+    let mut temporary = tempfile::Builder::new()
+        .prefix(&prefix)
+        .suffix(".tmp")
+        .tempfile_in(parent)
+        .with_context(|| {
             format!(
-                "failed to write temporary preflight report {}",
-                temporary_path.display()
+                "failed to create exclusive temporary preflight report in {}",
+                parent.display()
             )
         })?;
-        fs::rename(&temporary_path, output_path).with_context(|| {
-            format!(
-                "failed to publish preflight report {}",
-                output_path.display()
-            )
-        })?;
-        Ok(())
-    })();
-    if result.is_err() {
-        let _cleanup = fs::remove_file(&temporary_path);
-        let _cleanup = fs::remove_file(output_path);
-    }
-    result
+    temporary.write_all(bytes).with_context(|| {
+        format!(
+            "failed to write temporary preflight report for {}",
+            output_path.display()
+        )
+    })?;
+    temporary.flush().with_context(|| {
+        format!(
+            "failed to flush temporary preflight report for {}",
+            output_path.display()
+        )
+    })?;
+    temporary.as_file().sync_all().with_context(|| {
+        format!(
+            "failed to sync temporary preflight report for {}",
+            output_path.display()
+        )
+    })?;
+    temporary.persist(output_path).with_context(|| {
+        format!(
+            "failed to atomically publish preflight report {}",
+            output_path.display()
+        )
+    })?;
+    Ok(())
 }
 
 fn remove_output_if_present(path: &Path) -> Result<()> {
@@ -769,7 +825,8 @@ mod tests {
     use super::{
         ExternalCodepage, ExternalRecordFormat, ExternalWorkload, IntegrityArtifact,
         ManifestIntegrityError, PreflightInputArtifact, PreflightOutputAliasError,
-        load_external_input, publish_external_input_preflight, run_external_input_preflight,
+        PreflightOutputLock, load_external_input, publish_external_input_preflight,
+        run_external_input_preflight, write_report_atomically,
     };
 
     fn fixtures() -> PathBuf {
@@ -988,6 +1045,47 @@ mod tests {
             .context("invalid commit unexpectedly published preflight telemetry")?;
         ensure!(error.to_string().contains("40 lowercase hexadecimal"));
         ensure!(!output.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn external_input_report_publish_lock_prevents_concurrent_clobber() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let output = temp.path().join("report.json");
+        let first = PreflightOutputLock::acquire(&output)?;
+        let second = PreflightOutputLock::acquire(&output)
+            .err()
+            .context("concurrent preflight output lock unexpectedly succeeded")?;
+        ensure!(
+            second
+                .to_string()
+                .contains("exclusive preflight output lock")
+        );
+        write_report_atomically(&first, &output, b"first")?;
+        ensure!(fs::read(&output)? == b"first");
+        drop(first);
+        let next = PreflightOutputLock::acquire(&output)?;
+        write_report_atomically(&next, &output, b"second")?;
+        ensure!(fs::read(&output)? == b"second");
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn external_input_report_publish_ignores_predictable_temp_symlink() -> Result<()> {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir()?;
+        let output = temp.path().join("report.json");
+        let victim = temp.path().join("victim.json");
+        let predictable = temp.path().join(".report.json.tmp");
+        fs::write(&victim, b"victim")?;
+        symlink(&victim, &predictable)?;
+        let output_lock = PreflightOutputLock::acquire(&output)?;
+        write_report_atomically(&output_lock, &output, b"report")?;
+        ensure!(fs::read(&output)? == b"report");
+        ensure!(fs::read(&victim)? == b"victim");
+        ensure!(fs::symlink_metadata(&predictable)?.file_type().is_symlink());
         Ok(())
     }
 

--- a/tools/copybook-bench/src/external_input.rs
+++ b/tools/copybook-bench/src/external_input.rs
@@ -150,6 +150,46 @@ impl fmt::Display for ManifestIntegrityError {
 
 impl std::error::Error for ManifestIntegrityError {}
 
+/// Input artifact that an external-input preflight output must not alias.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PreflightInputArtifact {
+    /// Manifest JSON input.
+    Manifest,
+    /// Copybook source input.
+    Copybook,
+    /// Physical dataset input.
+    Dataset,
+}
+
+impl fmt::Display for PreflightInputArtifact {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Manifest => formatter.write_str("manifest"),
+            Self::Copybook => formatter.write_str("copybook"),
+            Self::Dataset => formatter.write_str("dataset"),
+        }
+    }
+}
+
+/// Typed rejection for a preflight output path that aliases an input.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PreflightOutputAliasError {
+    /// Input artifact aliased by the requested output.
+    pub input: PreflightInputArtifact,
+}
+
+impl fmt::Display for PreflightOutputAliasError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "preflight output path must not alias the {} input",
+            self.input
+        )
+    }
+}
+
+impl std::error::Error for PreflightOutputAliasError {}
+
 /// Fully read and structurally validated external input.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ValidatedExternalInput {
@@ -246,16 +286,40 @@ impl ValidatedExternalInput {
 /// Returns an error for unreadable or unsafe paths, malformed metadata,
 /// copybook layout disagreement, integrity mismatch, or invalid record framing.
 pub fn load_external_input(manifest_path: &Path) -> Result<ValidatedExternalInput> {
-    Ok(load_external_input_bundle(manifest_path)?.validated)
+    Ok(load_external_input_bundle(manifest_path, None)?.validated)
 }
 
-fn load_external_input_bundle(manifest_path: &Path) -> Result<LoadedExternalInput> {
+fn load_external_input_bundle(
+    manifest_path: &Path,
+    stale_output: Option<&Path>,
+) -> Result<LoadedExternalInput> {
+    if let Some(output_path) = stale_output {
+        reject_output_alias(output_path, manifest_path, PreflightInputArtifact::Manifest)?;
+    }
     reject_symlink_or_non_file(manifest_path, "manifest")?;
     let manifest_bytes = fs::read(manifest_path)
         .with_context(|| format!("failed to read manifest {}", manifest_path.display()))?;
-    let manifest_sha256 = format!("{:x}", Sha256::digest(&manifest_bytes));
     let manifest: ExternalInputManifest = serde_json::from_slice(&manifest_bytes)
         .with_context(|| format!("failed to parse manifest {}", manifest_path.display()))?;
+    let manifest_sha256 = format!("{:x}", Sha256::digest(&manifest_bytes));
+
+    let base = manifest_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or(Path::new("."));
+    if let Some(output_path) = stale_output {
+        reject_output_alias(
+            output_path,
+            &base.join(&manifest.copybook),
+            PreflightInputArtifact::Copybook,
+        )?;
+        reject_output_alias(
+            output_path,
+            &base.join(&manifest.dataset),
+            PreflightInputArtifact::Dataset,
+        )?;
+        remove_output_if_present(output_path)?;
+    }
 
     ensure!(
         manifest.schema_version == EXTERNAL_INPUT_SCHEMA_VERSION,
@@ -279,10 +343,6 @@ fn load_external_input_bundle(manifest_path: &Path) -> Result<LoadedExternalInpu
         &manifest.dataset_sha256,
     )?;
 
-    let base = manifest_path
-        .parent()
-        .filter(|path| !path.as_os_str().is_empty())
-        .unwrap_or(Path::new("."));
     let copybook_path = resolve_local_file(base, &manifest.copybook, "copybook")?;
     let dataset_path = resolve_local_file(base, &manifest.dataset, "dataset")?;
     let copybook_source = fs::read_to_string(&copybook_path)
@@ -328,8 +388,11 @@ fn load_external_input_bundle(manifest_path: &Path) -> Result<LoadedExternalInpu
     })
 }
 
-fn run_external_input_preflight(manifest_path: &Path) -> Result<ExternalInputPreflight> {
-    let loaded = load_external_input_bundle(manifest_path)?;
+fn run_external_input_preflight(
+    manifest_path: &Path,
+    stale_output: Option<&Path>,
+) -> Result<ExternalInputPreflight> {
+    let loaded = load_external_input_bundle(manifest_path, stale_output)?;
     let options = loaded.validated.decode_options();
     let mut scratch = ScratchBuffers::new();
     let mut decoded_records = 0_usize;
@@ -386,16 +449,15 @@ fn run_external_input_preflight(manifest_path: &Path) -> Result<ExternalInputPre
 ///
 /// Returns an error for an invalid commit identity, manifest validation or decode
 /// failure, report serialization failure, or output filesystem failure. Any
-/// pre-existing output is removed before work begins, and no output is retained
-/// after a failure.
+/// distinct pre-existing output is removed before decode begins, and no output
+/// is retained after a failure. Input aliases are rejected without mutation.
 pub fn publish_external_input_preflight(
     manifest_path: &Path,
     output_path: &Path,
     commit: &str,
 ) -> Result<ExternalInputPreflightReport> {
-    remove_output_if_present(output_path)?;
+    let preflight = run_external_input_preflight(manifest_path, Some(output_path))?;
     validate_commit(commit)?;
-    let preflight = run_external_input_preflight(manifest_path)?;
     let report = ExternalInputPreflightReport {
         schema_version: EXTERNAL_INPUT_PREFLIGHT_REPORT_VERSION.to_string(),
         status: "decoded".to_string(),
@@ -434,6 +496,59 @@ fn validate_commit(commit: &str) -> Result<()> {
         "commit must be 40 lowercase hexadecimal characters"
     );
     Ok(())
+}
+
+fn reject_output_alias(
+    output_path: &Path,
+    input_path: &Path,
+    input: PreflightInputArtifact,
+) -> Result<()> {
+    let output_lexical = lexical_absolute(output_path)?;
+    let input_lexical = lexical_absolute(input_path)?;
+    let output_resolved = comparable_path(&output_lexical);
+    let input_resolved = comparable_path(&input_lexical);
+    if output_lexical == input_lexical || output_resolved == input_resolved {
+        return Err(PreflightOutputAliasError { input }.into());
+    }
+    Ok(())
+}
+
+fn comparable_path(absolute_path: &Path) -> PathBuf {
+    if let Ok(canonical) = fs::canonicalize(absolute_path) {
+        return canonical;
+    }
+    let Some(file_name) = absolute_path.file_name() else {
+        return absolute_path.to_path_buf();
+    };
+    if let Some(parent) = absolute_path.parent()
+        && let Ok(canonical_parent) = fs::canonicalize(parent)
+    {
+        return canonical_parent.join(file_name);
+    }
+    absolute_path.to_path_buf()
+}
+
+fn lexical_absolute(path: &Path) -> Result<PathBuf> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .context("failed to resolve current directory for preflight output")?
+            .join(path)
+    };
+    let mut normalized = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
+                normalized.push(component.as_os_str());
+            }
+        }
+    }
+    Ok(normalized)
 }
 
 fn write_report_atomically(output_path: &Path, bytes: &[u8]) -> Result<()> {
@@ -653,8 +768,8 @@ mod tests {
 
     use super::{
         ExternalCodepage, ExternalRecordFormat, ExternalWorkload, IntegrityArtifact,
-        ManifestIntegrityError, load_external_input, publish_external_input_preflight,
-        run_external_input_preflight,
+        ManifestIntegrityError, PreflightInputArtifact, PreflightOutputAliasError,
+        load_external_input, publish_external_input_preflight, run_external_input_preflight,
     };
 
     fn fixtures() -> PathBuf {
@@ -772,7 +887,7 @@ mod tests {
         ];
         for (name, format, codepage, workload, physical, framing, expected_range) in cases {
             let path = fixtures().join(name);
-            let telemetry = run_external_input_preflight(&path)?;
+            let telemetry = run_external_input_preflight(&path, None)?;
             let expected_identity = format!("{:x}", Sha256::digest(fs::read(&path)?));
             ensure!(telemetry.manifest_sha256 == expected_identity);
             ensure!(telemetry.record_format == format);
@@ -790,7 +905,10 @@ mod tests {
     #[test]
     fn external_input_preflight_is_deterministic() -> Result<()> {
         let path = fixtures().join("rdw-cp037.json");
-        ensure!(run_external_input_preflight(&path)? == run_external_input_preflight(&path)?);
+        ensure!(
+            run_external_input_preflight(&path, None)?
+                == run_external_input_preflight(&path, None)?
+        );
         Ok(())
     }
 
@@ -809,7 +927,7 @@ mod tests {
 
         let validated = load_external_input(&manifest)?;
         ensure!(validated.manifest.record_length == 5);
-        let error = run_external_input_preflight(&manifest)
+        let error = run_external_input_preflight(&manifest, None)
             .err()
             .context("invalid numeric payload unexpectedly passed decode preflight")?;
         let message = error.to_string();
@@ -829,6 +947,46 @@ mod tests {
                 .to_string()
                 .contains("failed to decode record 0 payload range 0..5")
         );
+        ensure!(!output.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn external_input_preflight_rejects_typed_input_aliases_without_removal() -> Result<()> {
+        let cases = [
+            ("fixed-ascii.json", PreflightInputArtifact::Manifest),
+            ("simple.cpy", PreflightInputArtifact::Copybook),
+            ("fixed-ascii.bin", PreflightInputArtifact::Dataset),
+        ];
+        for (output_name, expected_input) in cases {
+            let (temp, manifest) = copy_fixture("fixed-ascii.json")?;
+            let output = temp.path().join(output_name);
+            let before = fs::read(&output)?;
+            let error = publish_external_input_preflight(
+                &manifest,
+                &output,
+                "0123456789abcdef0123456789abcdef01234567",
+            )
+            .err()
+            .context("aliased preflight output unexpectedly succeeded")?;
+            let typed = error
+                .downcast_ref::<PreflightOutputAliasError>()
+                .context("alias rejection did not retain its typed error")?;
+            ensure!(typed.input == expected_input);
+            ensure!(fs::read(&output)? == before);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn external_input_preflight_removes_distinct_stale_output_on_commit_failure() -> Result<()> {
+        let (temp, manifest) = copy_fixture("fixed-ascii.json")?;
+        let output = temp.path().join("preflight.json");
+        fs::write(&output, b"stale-success")?;
+        let error = publish_external_input_preflight(&manifest, &output, "invalid")
+            .err()
+            .context("invalid commit unexpectedly published preflight telemetry")?;
+        ensure!(error.to_string().contains("40 lowercase hexadecimal"));
         ensure!(!output.exists());
         Ok(())
     }

--- a/tools/copybook-bench/src/external_input.rs
+++ b/tools/copybook-bench/src/external_input.rs
@@ -449,7 +449,7 @@ fn run_external_input_preflight(
 /// # Errors
 ///
 /// Returns an error for an invalid commit identity, manifest validation or decode
-/// failure, report serialization failure, or output filesystem failure. Any
+/// failure, report serialization failure, or output filesystem failure.
 /// Once a readable manifest establishes that the output is distinct from all
 /// three inputs, a pre-existing output is removed before validation and decode.
 /// Missing, unreadable, or malformed manifests leave the unverifiable output

--- a/tools/copybook-bench/src/external_input.rs
+++ b/tools/copybook-bench/src/external_input.rs
@@ -452,8 +452,9 @@ fn run_external_input_preflight(
 /// failure, report serialization failure, or output filesystem failure. Any
 /// Once a readable manifest establishes that the output is distinct from all
 /// three inputs, a pre-existing output is removed before validation and decode.
-/// Missing or malformed manifests leave the unverifiable output untouched;
-/// input aliases are always rejected without mutation.
+/// Missing, unreadable, or malformed manifests leave the unverifiable output
+/// untouched and return an error; the nonzero CLI exit is authoritative. Input
+/// aliases are always rejected without mutation.
 pub fn publish_external_input_preflight(
     manifest_path: &Path,
     output_path: &Path,

--- a/tools/copybook-bench/src/external_input.rs
+++ b/tools/copybook-bench/src/external_input.rs
@@ -11,14 +11,14 @@ use copybook_codec::{
     Codepage, DecodeOptions, RecordFormat, decode_record_with_scratch, memory::ScratchBuffers,
 };
 use copybook_core::Schema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 /// The only manifest schema version understood by this loader.
 pub const EXTERNAL_INPUT_SCHEMA_VERSION: &str = "1.0.0";
 
 /// Record framing declared by an external-input manifest.
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ExternalRecordFormat {
     /// Fixed-length payload records with no framing bytes.
@@ -37,7 +37,7 @@ impl From<ExternalRecordFormat> for RecordFormat {
 }
 
 /// Code pages accepted by the deterministic dataset generator.
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum ExternalCodepage {
     /// Seven-bit ASCII.
     #[serde(rename = "ascii")]
@@ -73,7 +73,7 @@ impl From<ExternalCodepage> for Codepage {
 }
 
 /// Workload labels already supported by `scripts/gen_dataset.sh`.
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ExternalWorkload {
     /// Mostly DISPLAY fields.
@@ -172,6 +172,8 @@ struct LoadedExternalInput {
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct ExternalInputPreflight {
     manifest_sha256: String,
+    copybook_sha256: String,
+    dataset_sha256: String,
     record_format: ExternalRecordFormat,
     codepage: ExternalCodepage,
     workload: ExternalWorkload,
@@ -180,6 +182,51 @@ struct ExternalInputPreflight {
     payload_bytes: usize,
     framing_bytes: usize,
     payload_ranges: Vec<Range<usize>>,
+}
+
+/// Schema version emitted by the external-input preflight publisher.
+pub const EXTERNAL_INPUT_PREFLIGHT_REPORT_VERSION: &str = "1.0.0";
+
+/// One decoded payload range in the physical dataset.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ExternalInputPayloadRange {
+    /// Inclusive physical byte offset.
+    pub start: usize,
+    /// Exclusive physical byte offset.
+    pub end: usize,
+}
+
+/// Deterministic decode telemetry for one external-input manifest.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ExternalInputPreflightReport {
+    /// Closed report schema version.
+    pub schema_version: String,
+    /// Completed decode state; always `decoded` for a published report.
+    pub status: String,
+    /// Commit whose checked-in manifest and tool produced this report.
+    pub commit: String,
+    /// SHA-256 of the exact manifest bytes.
+    pub manifest_sha256: String,
+    /// SHA-256 of the exact copybook bytes.
+    pub copybook_sha256: String,
+    /// SHA-256 of the exact physical dataset bytes.
+    pub dataset_sha256: String,
+    /// Record framing selected by the manifest.
+    pub record_format: ExternalRecordFormat,
+    /// Character code page selected by the manifest.
+    pub codepage: ExternalCodepage,
+    /// Workload label selected by the manifest.
+    pub workload: ExternalWorkload,
+    /// Number of records successfully decoded.
+    pub decoded_records: usize,
+    /// Complete physical dataset byte count.
+    pub physical_bytes: usize,
+    /// Sum of decoded payload byte counts.
+    pub payload_bytes: usize,
+    /// Physical framing byte count.
+    pub framing_bytes: usize,
+    /// Exact payload ranges decoded in record order.
+    pub payload_ranges: Vec<ExternalInputPayloadRange>,
 }
 
 impl ValidatedExternalInput {
@@ -281,13 +328,6 @@ fn load_external_input_bundle(manifest_path: &Path) -> Result<LoadedExternalInpu
     })
 }
 
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "issue #776 stages the private decode preflight before benchmark wiring"
-    )
-)]
 fn run_external_input_preflight(manifest_path: &Path) -> Result<ExternalInputPreflight> {
     let loaded = load_external_input_bundle(manifest_path)?;
     let options = loaded.validated.decode_options();
@@ -327,6 +367,8 @@ fn run_external_input_preflight(manifest_path: &Path) -> Result<ExternalInputPre
         .context("external-input payload bytes exceed physical dataset bytes")?;
     Ok(ExternalInputPreflight {
         manifest_sha256: loaded.manifest_sha256,
+        copybook_sha256: loaded.validated.manifest.copybook_sha256.clone(),
+        dataset_sha256: loaded.validated.manifest.dataset_sha256.clone(),
         record_format: loaded.validated.manifest.record_format,
         codepage: loaded.validated.manifest.codepage,
         workload: loaded.validated.manifest.workload,
@@ -336,6 +378,109 @@ fn run_external_input_preflight(manifest_path: &Path) -> Result<ExternalInputPre
         framing_bytes,
         payload_ranges: loaded.validated.payload_ranges,
     })
+}
+
+/// Decode one validated external input and atomically publish deterministic telemetry.
+///
+/// # Errors
+///
+/// Returns an error for an invalid commit identity, manifest validation or decode
+/// failure, report serialization failure, or output filesystem failure. Any
+/// pre-existing output is removed before work begins, and no output is retained
+/// after a failure.
+pub fn publish_external_input_preflight(
+    manifest_path: &Path,
+    output_path: &Path,
+    commit: &str,
+) -> Result<ExternalInputPreflightReport> {
+    remove_output_if_present(output_path)?;
+    validate_commit(commit)?;
+    let preflight = run_external_input_preflight(manifest_path)?;
+    let report = ExternalInputPreflightReport {
+        schema_version: EXTERNAL_INPUT_PREFLIGHT_REPORT_VERSION.to_string(),
+        status: "decoded".to_string(),
+        commit: commit.to_string(),
+        manifest_sha256: preflight.manifest_sha256,
+        copybook_sha256: preflight.copybook_sha256,
+        dataset_sha256: preflight.dataset_sha256,
+        record_format: preflight.record_format,
+        codepage: preflight.codepage,
+        workload: preflight.workload,
+        decoded_records: preflight.decoded_records,
+        physical_bytes: preflight.physical_bytes,
+        payload_bytes: preflight.payload_bytes,
+        framing_bytes: preflight.framing_bytes,
+        payload_ranges: preflight
+            .payload_ranges
+            .into_iter()
+            .map(|range| ExternalInputPayloadRange {
+                start: range.start,
+                end: range.end,
+            })
+            .collect(),
+    };
+    let bytes = serde_json::to_vec_pretty(&report)
+        .context("failed to serialize external-input preflight report")?;
+    write_report_atomically(output_path, &bytes)?;
+    Ok(report)
+}
+
+fn validate_commit(commit: &str) -> Result<()> {
+    ensure!(
+        commit.len() == 40
+            && commit
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
+        "commit must be 40 lowercase hexadecimal characters"
+    );
+    Ok(())
+}
+
+fn write_report_atomically(output_path: &Path, bytes: &[u8]) -> Result<()> {
+    let parent = output_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or(Path::new("."));
+    ensure!(
+        parent.is_dir(),
+        "preflight output directory does not exist: {}",
+        parent.display()
+    );
+    let file_name = output_path
+        .file_name()
+        .context("preflight output path must name a file")?;
+    let temporary_path = parent.join(format!(".{}.tmp", file_name.to_string_lossy()));
+    remove_output_if_present(&temporary_path)?;
+
+    let result = (|| -> Result<()> {
+        fs::write(&temporary_path, bytes).with_context(|| {
+            format!(
+                "failed to write temporary preflight report {}",
+                temporary_path.display()
+            )
+        })?;
+        fs::rename(&temporary_path, output_path).with_context(|| {
+            format!(
+                "failed to publish preflight report {}",
+                output_path.display()
+            )
+        })?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _cleanup = fs::remove_file(&temporary_path);
+        let _cleanup = fs::remove_file(output_path);
+    }
+    result
+}
+
+fn remove_output_if_present(path: &Path) -> Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error)
+            .with_context(|| format!("failed to remove stale preflight output {}", path.display())),
+    }
 }
 
 fn validate_declared_sha256(artifact: IntegrityArtifact, field: &str, value: &str) -> Result<()> {
@@ -508,7 +653,8 @@ mod tests {
 
     use super::{
         ExternalCodepage, ExternalRecordFormat, ExternalWorkload, IntegrityArtifact,
-        ManifestIntegrityError, load_external_input, run_external_input_preflight,
+        ManifestIntegrityError, load_external_input, publish_external_input_preflight,
+        run_external_input_preflight,
     };
 
     fn fixtures() -> PathBuf {
@@ -668,6 +814,22 @@ mod tests {
             .context("invalid numeric payload unexpectedly passed decode preflight")?;
         let message = error.to_string();
         ensure!(message.contains("failed to decode record 0 payload range 0..5"));
+
+        let output = temp.path().join("preflight.json");
+        fs::write(&output, b"stale-success")?;
+        let publish = publish_external_input_preflight(
+            &manifest,
+            &output,
+            "0123456789abcdef0123456789abcdef01234567",
+        )
+        .err()
+        .context("invalid numeric payload unexpectedly published decode telemetry")?;
+        ensure!(
+            publish
+                .to_string()
+                .contains("failed to decode record 0 payload range 0..5")
+        );
+        ensure!(!output.exists());
         Ok(())
     }
 

--- a/tools/copybook-bench/test_fixtures/external_input/README.md
+++ b/tools/copybook-bench/test_fixtures/external_input/README.md
@@ -12,6 +12,8 @@ its calculated LRECL remains the same.
 
 The fixtures prove parsing, path safety, integrity, framing, deterministic
 payload boundaries, and successful decode consumption through the private
-external-input preflight. They are not benchmark measurements, are not
-consumed by the weekly soak workflow, and establish no throughput or threshold
-claim.
+external-input preflight. The manual `External Input Decode Preflight` workflow
+runs this fixed four-manifest inventory sequentially and publishes deterministic
+decode telemetry. Those reports are not benchmark measurements, are not
+performance receipts, are not consumed by the weekly soak workflow, and
+establish no duration, throughput, threshold, or SLO claim.

--- a/tools/copybook-bench/tests/external_input_preflight_cli.rs
+++ b/tools/copybook-bench/tests/external_input_preflight_cli.rs
@@ -8,6 +8,7 @@ use std::process::{Command, Output};
 use anyhow::{Context, Result, ensure};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
+use tempfile::TempDir;
 
 const COMMIT: &str = "0123456789abcdef0123456789abcdef01234567";
 
@@ -20,12 +21,29 @@ fn fixtures() -> PathBuf {
 }
 
 fn run_cli(manifest: &Path, output: &Path) -> Result<Output> {
+    run_cli_in(&workspace_root(), manifest, output)
+}
+
+fn run_cli_in(current_dir: &Path, manifest: &Path, output: &Path) -> Result<Output> {
     Command::new(env!("CARGO_BIN_EXE_external-input-preflight"))
         .arg(manifest)
         .arg(output)
+        .current_dir(current_dir)
         .env("GITHUB_SHA", COMMIT)
         .output()
         .context("failed to run external-input-preflight binary")
+}
+
+fn copy_fixture(name: &str) -> Result<(TempDir, PathBuf)> {
+    let temp = tempfile::tempdir()?;
+    for entry in fs::read_dir(fixtures())? {
+        let entry = entry?;
+        if entry.file_type()?.is_file() {
+            fs::copy(entry.path(), temp.path().join(entry.file_name()))?;
+        }
+    }
+    let manifest = temp.path().join(name);
+    Ok((temp, manifest))
 }
 
 fn require_success(output: &Output) -> Result<()> {
@@ -107,8 +125,12 @@ fn report_matches_closed_schema_inventory() -> Result<()> {
 fn cli_removes_stale_output_on_validation_and_write_failure() -> Result<()> {
     let temp = tempfile::tempdir()?;
     let stale = temp.path().join("stale.json");
+    let (_fixture, manifest) = copy_fixture("fixed-ascii.json")?;
+    let mut invalid: Value = serde_json::from_slice(&fs::read(&manifest)?)?;
+    invalid["schema_version"] = Value::String("unsupported".into());
+    fs::write(&manifest, serde_json::to_vec_pretty(&invalid)?)?;
     fs::write(&stale, b"stale-success")?;
-    let validation = run_cli(&temp.path().join("missing.json"), &stale)?;
+    let validation = run_cli(&manifest, &stale)?;
     ensure!(!validation.status.success());
     ensure!(!stale.exists());
 
@@ -117,6 +139,50 @@ fn cli_removes_stale_output_on_validation_and_write_failure() -> Result<()> {
     let write = run_cli(&fixtures().join("fixed-ascii.json"), &unwritable)?;
     ensure!(!write.status.success());
     ensure!(!unwritable.exists());
+    Ok(())
+}
+
+#[test]
+fn cli_rejects_relative_input_aliases_without_mutating_inputs() -> Result<()> {
+    let cases = [
+        ("fixed-ascii.json", "manifest"),
+        ("./simple.cpy", "copybook"),
+        ("fixed-ascii.bin", "dataset"),
+    ];
+    for (output_name, artifact) in cases {
+        let (temp, manifest) = copy_fixture("fixed-ascii.json")?;
+        let output = temp.path().join(output_name);
+        let before = fs::read(&output)?;
+        let result = run_cli_in(
+            temp.path(),
+            Path::new("fixed-ascii.json"),
+            Path::new(output_name),
+        )?;
+        ensure!(!result.status.success());
+        ensure!(fs::read(&output)? == before);
+        ensure!(
+            String::from_utf8_lossy(&result.stderr)
+                .contains(&format!("must not alias the {artifact} input"))
+        );
+        ensure!(manifest.exists());
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn cli_rejects_copybook_alias_through_symlinked_parent() -> Result<()> {
+    use std::os::unix::fs::symlink;
+
+    let (temp, manifest) = copy_fixture("fixed-ascii.json")?;
+    let linked_parent = temp.path().join("linked-parent");
+    symlink(temp.path(), &linked_parent)?;
+    let copybook = temp.path().join("simple.cpy");
+    let before = fs::read(&copybook)?;
+    let result = run_cli(&manifest, &linked_parent.join("simple.cpy"))?;
+    ensure!(!result.status.success());
+    ensure!(fs::read(&copybook)? == before);
+    ensure!(String::from_utf8_lossy(&result.stderr).contains("must not alias the copybook input"));
     Ok(())
 }
 

--- a/tools/copybook-bench/tests/external_input_preflight_cli.rs
+++ b/tools/copybook-bench/tests/external_input_preflight_cli.rs
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use anyhow::{Context, Result, ensure};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+const COMMIT: &str = "0123456789abcdef0123456789abcdef01234567";
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn fixtures() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("test_fixtures/external_input")
+}
+
+fn run_cli(manifest: &Path, output: &Path) -> Result<Output> {
+    Command::new(env!("CARGO_BIN_EXE_external-input-preflight"))
+        .arg(manifest)
+        .arg(output)
+        .env("GITHUB_SHA", COMMIT)
+        .output()
+        .context("failed to run external-input-preflight binary")
+}
+
+fn require_success(output: &Output) -> Result<()> {
+    ensure!(
+        output.status.success(),
+        "preflight CLI failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(())
+}
+
+#[test]
+fn cli_publishes_closed_deterministic_report() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let first = temp.path().join("first.json");
+    let second = temp.path().join("second.json");
+    let manifest = fixtures().join("rdw-cp037.json");
+    require_success(&run_cli(&manifest, &first)?)?;
+    require_success(&run_cli(&manifest, &second)?)?;
+
+    let first_bytes = fs::read(&first)?;
+    let second_bytes = fs::read(&second)?;
+    ensure!(Sha256::digest(&first_bytes) == Sha256::digest(&second_bytes));
+    let report: Value = serde_json::from_slice(&first_bytes)?;
+    ensure!(report.pointer("/schema_version") == Some(&Value::String("1.0.0".into())));
+    ensure!(report.pointer("/status") == Some(&Value::String("decoded".into())));
+    ensure!(report.pointer("/commit") == Some(&Value::String(COMMIT.into())));
+    ensure!(report.pointer("/record_format") == Some(&Value::String("rdw".into())));
+    ensure!(report.pointer("/codepage") == Some(&Value::String("cp037".into())));
+    ensure!(report.pointer("/decoded_records") == Some(&Value::from(1)));
+    ensure!(report.pointer("/physical_bytes") == Some(&Value::from(9)));
+    ensure!(report.pointer("/payload_bytes") == Some(&Value::from(5)));
+    ensure!(report.pointer("/framing_bytes") == Some(&Value::from(4)));
+    ensure!(report.pointer("/payload_ranges/0/start") == Some(&Value::from(4)));
+    ensure!(report.pointer("/payload_ranges/0/end") == Some(&Value::from(9)));
+    Ok(())
+}
+
+#[test]
+fn report_matches_closed_schema_inventory() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let output = temp.path().join("report.json");
+    require_success(&run_cli(&fixtures().join("fixed-ascii.json"), &output)?)?;
+    let report: Value = serde_json::from_slice(&fs::read(output)?)?;
+    let schema: Value = serde_json::from_slice(&fs::read(
+        workspace_root().join("schemas/external-input-preflight-report.json"),
+    )?)?;
+    ensure!(schema.pointer("/additionalProperties") == Some(&Value::Bool(false)));
+    ensure!(
+        schema.pointer("/properties/schema_version/const") == Some(&Value::String("1.0.0".into()))
+    );
+    ensure!(schema.pointer("/properties/status/const") == Some(&Value::String("decoded".into())));
+    let required = schema
+        .pointer("/required")
+        .and_then(Value::as_array)
+        .context("report schema required inventory is missing")?;
+    let required: BTreeSet<&str> = required.iter().filter_map(Value::as_str).collect();
+    let actual: BTreeSet<&str> = report
+        .as_object()
+        .context("preflight report is not an object")?
+        .keys()
+        .map(String::as_str)
+        .collect();
+    ensure!(actual == required);
+    for field in ["manifest_sha256", "copybook_sha256", "dataset_sha256"] {
+        let value = report
+            .get(field)
+            .and_then(Value::as_str)
+            .with_context(|| format!("report field {field} is missing"))?;
+        ensure!(value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit()));
+    }
+    for forbidden in ["timestamp", "duration", "throughput", "pass", "slo"] {
+        ensure!(!actual.contains(forbidden));
+    }
+    Ok(())
+}
+
+#[test]
+fn cli_removes_stale_output_on_validation_and_write_failure() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let stale = temp.path().join("stale.json");
+    fs::write(&stale, b"stale-success")?;
+    let validation = run_cli(&temp.path().join("missing.json"), &stale)?;
+    ensure!(!validation.status.success());
+    ensure!(!stale.exists());
+
+    let missing_parent = temp.path().join("missing-parent");
+    let unwritable = missing_parent.join("report.json");
+    let write = run_cli(&fixtures().join("fixed-ascii.json"), &unwritable)?;
+    ensure!(!write.status.success());
+    ensure!(!unwritable.exists());
+    Ok(())
+}
+
+#[test]
+fn workflow_is_manual_fixed_inventory_telemetry_only() -> Result<()> {
+    let workflow = fs::read_to_string(
+        workspace_root().join(".github/workflows/external-input-preflight.yml"),
+    )?;
+    ensure!(workflow.contains("workflow_dispatch: {}"));
+    ensure!(!workflow.contains("schedule:"));
+    ensure!(!workflow.contains("matrix:"));
+    ensure!(!workflow.contains("inputs:"));
+    ensure!(workflow.contains("permissions:\n  contents: read"));
+    ensure!(workflow.contains("timeout-minutes: 15"));
+    ensure!(!workflow.contains("continue-on-error"));
+
+    let manifests = [
+        "fixed-ascii.json",
+        "fixed-cp037.json",
+        "rdw-ascii.json",
+        "rdw-cp037.json",
+    ];
+    let mut prior = 0_usize;
+    for manifest in manifests {
+        let inventory_entry = format!("external_input/{manifest} ");
+        ensure!(workflow.matches(&inventory_entry).count() == 1);
+        let position = workflow
+            .find(&inventory_entry)
+            .with_context(|| format!("workflow omits {manifest}"))?;
+        ensure!(position > prior);
+        prior = position;
+    }
+    let upload = workflow
+        .find("uses: actions/upload-artifact@v7")
+        .context("workflow omits artifact upload")?;
+    ensure!(upload > prior);
+    ensure!(workflow.contains("name: external-input-preflight-${{ github.sha }}"));
+    ensure!(workflow.contains("if-no-files-found: error"));
+    for forbidden in ["threshold", "throughput", "perf.json", "soak.yml"] {
+        ensure!(!workflow.contains(forbidden));
+    }
+    Ok(())
+}

--- a/tools/copybook-bench/tests/external_input_preflight_cli.rs
+++ b/tools/copybook-bench/tests/external_input_preflight_cli.rs
@@ -143,6 +143,25 @@ fn cli_removes_stale_output_on_validation_and_write_failure() -> Result<()> {
 }
 
 #[test]
+fn cli_preserves_unverifiable_output_for_missing_and_malformed_manifests() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    for (manifest, label) in [
+        (temp.path().join("missing.json"), "missing"),
+        (temp.path().join("malformed.json"), "malformed"),
+    ] {
+        if label == "malformed" {
+            fs::write(&manifest, b"{not-json")?;
+        }
+        let output = temp.path().join(format!("{label}-output.json"));
+        fs::write(&output, b"unverifiable-stale-output")?;
+        let result = run_cli(&manifest, &output)?;
+        ensure!(!result.status.success());
+        ensure!(fs::read(&output)? == b"unverifiable-stale-output");
+    }
+    Ok(())
+}
+
+#[test]
 fn cli_rejects_relative_input_aliases_without_mutating_inputs() -> Result<()> {
     let cases = [
         ("fixed-ascii.json", "manifest"),


### PR DESCRIPTION
# Pull Request

## Summary

Adds a manual-only external-input decode telemetry lane. A tool-crate CLI publishes one closed, deterministic JSON report per fixed manifest after validation and full decode consumption; the workflow runs the four checked-in fixed/RDW ASCII/CP037 manifests sequentially and uploads commit-keyed artifacts only after all succeed.

This is telemetry, not benchmarking: there are no clocks, durations, throughput values, thresholds, performance receipts, schedules, matrices, or SLO claims.

## Type of Change

- [x] Feature (new functionality)
- [ ] Bugfix
- [ ] Refactor
- [ ] Performance optimization
- [x] Documentation
- [x] Tests
- [x] CI/CD
- [ ] Chore

## COBOL/Mainframe Context

- **COBOL features affected**: fixed and RDW records using ASCII and CP037 fixture metadata
- **Data processing impact**: validation and decode consumption telemetry only
- **Mainframe compatibility**: no parser, codec, or support-matrix contract change

## Workspace Crates Affected

- [x] copybook-bench (unpublished tooling crate)

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [ ] CHANGELOG.md updated (not user-facing)
- [ ] `cargo fmt --all` passes (scoped package formatting passed)
- [ ] workspace Clippy passes (scoped lib/bin pedantic and tests Clippy passed)
- [ ] workspace tests pass (scoped suites passed)
- [ ] governance/BDD smoke (not applicable)
- [x] Conventional commit format
- [ ] MSRV verification (no version or compatibility change)
- [ ] Golden fixtures updated (not applicable)

## Testing Instructions

```bash
cargo test -p copybook-bench --test external_input_preflight_cli
cargo test -p copybook-bench external_input
cargo test -p copybook-bench --lib
cargo clippy -p copybook-bench --lib --bins -- -D warnings -W clippy::pedantic
cargo clippy -p copybook-bench --tests -- -D warnings
cargo fmt -p copybook-bench -- --check
cargo test -p xtask docs_verify
cargo run -p xtask -- docs verify-record-pipeline
cargo deny check
python -m json.tool schemas/external-input-preflight-report.json
git diff --check
```

Local results at `803b22e`: CLI/report/schema/workflow integration 6 passed; external-input suite 15 passed; library suite 45 passed; both Clippy commands passed; docs verifier 61 passed; cargo-deny passed with existing warnings; record-pipeline evidence remained 11 scenarios at digest `4d80c7d4817d2bd990c6bec65118d3da0eadea651c5a59c9e078251222c74df3`; formatting, schema JSON, and diff checks passed.

`actionlint`: **NOT RUN** locally because the binary is unavailable (`exit 127`). Hosted workflow validation remains required.

## Performance Impact

- [x] No performance claim or measurement change
- [ ] Performance improvement
- [ ] Performance regression acceptable
- [ ] Performance tested with baseline comparison

The new lane records no time or throughput and does not touch `soak.yml`, any performance gate, `scripts/bench/perf.json`, or receipt evaluation.

## Infrastructure/Tooling Changes

**Areas modified:**
- [ ] Support matrix registry or CLI
- [ ] Performance receipt parsing or SLO evaluation
- [x] Manual CI workflow and decode telemetry publisher
- [ ] xtask automation or docs verification tools

**Adversarial testing:**
- [x] Missing, unreadable, or malformed manifest returns nonzero and preserves unverifiable existing output; exit status is authoritative
- [x] Once a readable manifest proves non-aliasing, stale output is removed before remaining validation/decode
- [x] Manifest, copybook, and dataset output aliases are rejected without mutation, including relative and symlinked forms
- [x] Decode and output-filesystem failures publish no current output
- [x] Exclusive output ownership and unique temporary files prevent concurrent clobber and predictable-temp symlink writes
- [x] Repeated identical runs produce identical report hashes
- [x] Closed schema and exact workflow inventory are verified
- [x] Workflow test rejects schedule, matrix, arbitrary inputs, thresholds, throughput, perf receipt, or soak ownership

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes with migration path

## Related Issues

Closes #785
Relates to #776

## Additional Notes

The workflow has `contents: read`, checkout credentials disabled, a 15-minute timeout, one fixed sequential four-manifest command list, and no user-supplied path. Artifact upload occurs only after every publisher command succeeds, so preserved output after a pre-parse failure is never uploaded as current evidence.

A real manual `workflow_dispatch` artifact is **NOT_PROVEN** in this PR and must not be claimed until run against a merged/current commit. Criterion, generator, threshold policy, scheduled ownership, and broader external datasets remain with #776. Stable CBKF/CBKI codes are not added: `copybook-bench` is an unpublished tooling crate whose current boundary is `anyhow`; decode causes remain preserved, and changing the public product error taxonomy is outside this telemetry slice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered external-input preflight workflow that validates four fixed manifests and publishes commit-linked JSON telemetry.
  * Added deterministic reports containing input identities, decode settings, record counts, byte totals, and payload ranges.
  * Added safeguards for invalid inputs, stale outputs, aliases, concurrent execution, and temporary-file safety.

* **Documentation**
  * Documented preflight usage, report contents, validation behavior, and artifact handling.
  * Clarified that reports are validation telemetry, not benchmarks or performance evidence.

* **Tests**
  * Added coverage for report generation, failure handling, output protection, workflow constraints, and metadata integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->