### PR TITLE
test(bench): make workflow invariant EOL-agnostic

### DIFF
--- a/tools/copybook-bench/tests/external_input_preflight_cli.rs
+++ b/tools/copybook-bench/tests/external_input_preflight_cli.rs
@@ -46,6 +46,38 @@ fn copy_fixture(name: &str) -> Result<(TempDir, PathBuf)> {
     Ok((temp, manifest))
 }
 
+fn has_adjacent_lines(text: &str, first: &str, second: &str) -> bool {
+    let mut previous = None;
+    for line in text.lines() {
+        if previous == Some(first) && line == second {
+            return true;
+        }
+        previous = Some(line);
+    }
+    false
+}
+
+#[test]
+fn adjacent_lines_are_eol_agnostic_but_layout_sensitive() -> Result<()> {
+    let first = "permissions:";
+    let second = "  contents: read";
+    for accepted in [
+        "permissions:\n  contents: read\n",
+        "permissions:\r\n  contents: read\r\n",
+    ] {
+        ensure!(has_adjacent_lines(accepted, first, second));
+    }
+    for rejected in [
+        "permissions:\n contents: read\n",
+        "permissions:\n\n  contents: read\n",
+        "permissions:\n  unrelated: value\n  contents: read\n",
+        "  contents: read\npermissions:\n",
+    ] {
+        ensure!(!has_adjacent_lines(rejected, first, second));
+    }
+    Ok(())
+}
+
 fn require_success(output: &Output) -> Result<()> {
     ensure!(
         output.status.success(),
@@ -214,7 +246,11 @@ fn workflow_is_manual_fixed_inventory_telemetry_only() -> Result<()> {
     ensure!(!workflow.contains("schedule:"));
     ensure!(!workflow.contains("matrix:"));
     ensure!(!workflow.contains("inputs:"));
-    ensure!(workflow.contains("permissions:\n  contents: read"));
+    ensure!(has_adjacent_lines(
+        &workflow,
+        "permissions:",
+        "  contents: read"
+    ));
     ensure!(workflow.contains("timeout-minutes: 15"));
     ensure!(!workflow.contains("continue-on-error"));
 


### PR DESCRIPTION
# Pull Request

## Summary

Makes the external-input preflight workflow permissions assertion EOL-agnostic without weakening its layout contract. The test now uses an allocation-free adjacent-line scan through `str::lines()`, so exact LF and CRLF forms pass while indentation, order, and immediate adjacency remain strict.

Root cause: the post-merge Windows proof for #786 read a clean CRLF checkout, but the invariant searched for an LF-only multiline byte substring.

## Type of Change

- [ ] Feature (new functionality)
- [x] Bugfix (fixes an issue)
- [ ] Refactor (code improvement without behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (README, docs/, code comments)
- [x] Tests (test additions or improvements)
- [ ] CI/CD (workflow or tooling changes)
- [ ] Chore (dependencies, formatting, etc.)

## COBOL/Mainframe Context

- **COBOL features affected**: none
- **Data processing impact**: none; test-only workflow metadata validation
- **Mainframe compatibility**: unchanged

## Workspace Crates Affected

- [x] copybook-bench (test surface only)

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (N/A; no contract change)
- [x] CHANGELOG.md updated (N/A; test-only)
- [ ] `cargo fmt --all` passes (scoped package check passed)
- [ ] workspace Clippy passes (scoped tests Clippy passed)
- [ ] workspace tests pass (focused integration suite passed)
- [x] Governance/BDD smoke N/A
- [x] Conventional commit format
- [x] MSRV verification N/A; no dependency change
- [x] Golden fixtures N/A

## Testing Instructions

```bash
cargo test -p copybook-bench --test external_input_preflight_cli
cargo fmt -p copybook-bench -- --check
cargo clippy -p copybook-bench --tests -- -D warnings
git diff --check
```

Baseline on the isolated clean CRLF worktree: 5 passed, 1 failed at the LF-only permissions assertion.

Current result: 7 passed. Formatting, tests Clippy, and diff checks pass.

The focused helper tests accept exact adjacent LF and CRLF forms and reject wrong indentation, blank or unrelated intervening lines, and reversed ordering.

## Performance Impact

- [x] No performance impact expected
- [ ] Performance improvement
- [ ] Performance regression acceptable
- [ ] Performance tested with baseline comparison

## Infrastructure/Tooling Changes

**Areas modified:**
- [ ] Support matrix registry or CLI
- [ ] Performance receipt parsing or SLO evaluation
- [x] CI validation test only; no workflow change
- [ ] xtask automation or docs verification tools

**Adversarial Testing:**
- [x] LF and CRLF acceptance
- [x] Wrong indentation rejection
- [x] Intervening blank/unrelated line rejection
- [x] Reversed-order rejection

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes with migration path

## Related Issues

Closes #787

## Additional Notes

One file changes. No workflow, production source, schema, documentation, performance receipt, or SLO surface changes.