### PR TITLE
perf(bench): add external-input decode target

### DIFF
--- a/docs/stability/surface-registry.json
+++ b/docs/stability/surface-registry.json
@@ -122,6 +122,15 @@
           "graduation_criteria": []
         },
         {
+          "name": "external-input",
+          "class": "internal-dev-only",
+          "stability_statement": "Opt-in local Criterion target for one validated external-input manifest.",
+          "limitations": [
+            "No downstream API, threshold, SLO, receipt, or scheduled performance promise."
+          ],
+          "graduation_criteria": []
+        },
+        {
           "name": "perf",
           "class": "internal-dev-only",
           "stability_statement": "Performance-only toggle for internal workflows.",

--- a/tools/copybook-bench/Cargo.toml
+++ b/tools/copybook-bench/Cargo.toml
@@ -31,6 +31,10 @@ name = "diagnostics_benches"
 harness = false
 required-features = ["diagnostics"]
 
+[[bench]]
+name = "external_input_decode"
+harness = false
+
 [dependencies]
 copybook-core = { workspace = true }
 copybook-codec = { workspace = true }

--- a/tools/copybook-bench/Cargo.toml
+++ b/tools/copybook-bench/Cargo.toml
@@ -34,6 +34,7 @@ required-features = ["diagnostics"]
 [[bench]]
 name = "external_input_decode"
 harness = false
+required-features = ["external-input"]
 
 [dependencies]
 copybook-core = { workspace = true }
@@ -58,5 +59,7 @@ default = []
 progressive = []
 # AC5: Diagnostics benchmarks for infrastructure overhead measurement (opt-in)
 diagnostics = []
+# Opt-in local benchmark over a caller-selected validated manifest.
+external-input = []
 # Performance-only tests: throughput assertions for dedicated perf workflow
 perf = []

--- a/tools/copybook-bench/README.md
+++ b/tools/copybook-bench/README.md
@@ -24,7 +24,7 @@ cargo bench -p copybook-bench --bench comp3
 cargo test -p copybook-bench --features perf
 
 COPYBOOK_EXTERNAL_INPUT_MANIFEST="$(pwd)/tools/copybook-bench/test_fixtures/external_input/fixed-ascii.json" \
-  cargo bench -p copybook-bench --bench external_input_decode
+  cargo bench -p copybook-bench --features external-input --bench external_input_decode
 
 cargo test -p copybook-bench --test baseline_reconciliation
 cargo test -p copybook-bench --test regression_detection
@@ -32,8 +32,10 @@ cargo test -p copybook-bench --test ci_integration
 ```
 
 The external-input target is an opt-in local measurement over one validated
-manifest. It reports payload-byte throughput and does not define a threshold,
-SLO, receipt, or scheduled performance claim.
+manifest. Both the `external-input` Cargo feature and the manifest environment
+variable are required, so ordinary benchmark suites do not launch it. It
+reports payload-byte throughput and does not define a threshold, SLO, receipt,
+or scheduled performance claim.
 
 ## Performance baseline
 

--- a/tools/copybook-bench/README.md
+++ b/tools/copybook-bench/README.md
@@ -23,10 +23,17 @@ cargo bench -p copybook-bench
 cargo bench -p copybook-bench --bench comp3
 cargo test -p copybook-bench --features perf
 
+COPYBOOK_EXTERNAL_INPUT_MANIFEST="$(pwd)/tools/copybook-bench/test_fixtures/external_input/fixed-ascii.json" \
+  cargo bench -p copybook-bench --bench external_input_decode
+
 cargo test -p copybook-bench --test baseline_reconciliation
 cargo test -p copybook-bench --test regression_detection
 cargo test -p copybook-bench --test ci_integration
 ```
+
+The external-input target is an opt-in local measurement over one validated
+manifest. It reports payload-byte throughput and does not define a threshold,
+SLO, receipt, or scheduled performance claim.
 
 ## Performance baseline
 

--- a/tools/copybook-bench/benches/external_input_decode.rs
+++ b/tools/copybook-bench/benches/external_input_decode.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Opt-in local Criterion target for one validated external-input manifest.
+
+use std::env;
+use std::hint::black_box;
+use std::path::PathBuf;
+use std::time::Instant;
+
+use anyhow::{Context, Result, bail};
+use copybook_bench::external_input::prepare_external_input_decode_benchmark;
+use criterion::{Criterion, Throughput};
+
+const MANIFEST_ENV: &str = "COPYBOOK_EXTERNAL_INPUT_MANIFEST";
+
+fn main() -> Result<()> {
+    let manifest = env::var_os(MANIFEST_ENV)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .with_context(|| format!("{MANIFEST_ENV} must name one external-input manifest"))?;
+    let mut benchmark = prepare_external_input_decode_benchmark(&manifest)
+        .with_context(|| format!("failed to prepare external input {}", manifest.display()))?;
+    let payload_bytes = u64::try_from(benchmark.payload_bytes())
+        .context("external-input payload byte total does not fit Criterion throughput")?;
+
+    let mut criterion = Criterion::default().configure_from_args();
+    let mut group = criterion.benchmark_group("external_input_decode");
+    group.throughput(Throughput::Bytes(payload_bytes));
+    let mut failure = None;
+    group.bench_function("validated_manifest", |bencher| {
+        bencher.iter_custom(|iterations| {
+            let start = Instant::now();
+            for _ in 0..iterations {
+                match benchmark.decode_pass() {
+                    Ok(decoded) => {
+                        black_box(decoded);
+                    }
+                    Err(error) => {
+                        failure = Some(error);
+                        break;
+                    }
+                }
+            }
+            start.elapsed()
+        });
+    });
+    group.finish();
+    criterion.final_summary();
+    if let Some(error) = failure {
+        bail!(error.context("external-input decode failed during measurement"));
+    }
+    Ok(())
+}

--- a/tools/copybook-bench/benches/external_input_decode.rs
+++ b/tools/copybook-bench/benches/external_input_decode.rs
@@ -4,9 +4,9 @@
 use std::env;
 use std::hint::black_box;
 use std::path::PathBuf;
-use std::time::Instant;
+use std::process;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 use copybook_bench::external_input::prepare_external_input_decode_benchmark;
 use criterion::{Criterion, Throughput};
 
@@ -25,28 +25,22 @@ fn main() -> Result<()> {
     let mut criterion = Criterion::default().configure_from_args();
     let mut group = criterion.benchmark_group("external_input_decode");
     group.throughput(Throughput::Bytes(payload_bytes));
-    let mut failure = None;
-    group.bench_function("validated_manifest", |bencher| {
-        bencher.iter_custom(|iterations| {
-            let start = Instant::now();
-            for _ in 0..iterations {
-                match benchmark.decode_pass() {
-                    Ok(decoded) => {
-                        black_box(decoded);
-                    }
-                    Err(error) => {
-                        failure = Some(error);
-                        break;
-                    }
+    let benchmark_id = benchmark.benchmark_id().to_string();
+    group.bench_function(benchmark_id, |bencher| {
+        bencher.iter_custom(
+            |iterations| match benchmark.measure_decode_iterations(iterations) {
+                Ok(duration) => {
+                    black_box(iterations);
+                    duration
                 }
-            }
-            start.elapsed()
-        });
+                Err(error) => {
+                    eprintln!("external-input decode failed during measurement: {error:#}");
+                    process::exit(1);
+                }
+            },
+        );
     });
     group.finish();
     criterion.final_summary();
-    if let Some(error) = failure {
-        bail!(error.context("external-input decode failed during measurement"));
-    }
     Ok(())
 }

--- a/tools/copybook-bench/src/external_input.rs
+++ b/tools/copybook-bench/src/external_input.rs
@@ -6,6 +6,7 @@ use std::fs;
 use std::io::Write;
 use std::ops::Range;
 use std::path::{Component, Path, PathBuf};
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail, ensure};
 use copybook_codec::{
@@ -219,6 +220,7 @@ pub struct ExternalInputDecodeBenchmark {
     options: DecodeOptions,
     scratch: ScratchBuffers,
     payload_bytes: usize,
+    benchmark_id: String,
 }
 
 impl ExternalInputDecodeBenchmark {
@@ -226,6 +228,12 @@ impl ExternalInputDecodeBenchmark {
     #[must_use]
     pub const fn payload_bytes(&self) -> usize {
         self.payload_bytes
+    }
+
+    /// Stable Criterion identity for this validated manifest and dataset.
+    #[must_use]
+    pub fn benchmark_id(&self) -> &str {
+        &self.benchmark_id
     }
 
     /// Decode every validated payload range exactly once.
@@ -236,6 +244,22 @@ impl ExternalInputDecodeBenchmark {
     /// checked record-count overflow.
     pub fn decode_pass(&mut self) -> Result<usize> {
         decode_loaded_pass(&self.loaded, &self.options, &mut self.scratch)
+    }
+
+    /// Time complete decode passes, returning no duration if any pass fails.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first contextual decode failure. Callers must not record a
+    /// Criterion sample unless this method returns `Ok`.
+    pub fn measure_decode_iterations(&mut self, iterations: u64) -> Result<Duration> {
+        let start = Instant::now();
+        for iteration in 0..iterations {
+            let _decoded = self
+                .decode_pass()
+                .with_context(|| format!("external-input decode iteration {iteration} failed"))?;
+        }
+        Ok(start.elapsed())
     }
 }
 
@@ -331,11 +355,13 @@ pub fn prepare_external_input_decode_benchmark(
     let loaded = load_external_input_bundle(manifest_path, None)?;
     let options = loaded.validated.decode_options();
     let payload_bytes = checked_payload_bytes(&loaded)?;
+    let benchmark_id = benchmark_identity(&loaded)?;
     let mut benchmark = ExternalInputDecodeBenchmark {
         loaded,
         options,
         scratch: ScratchBuffers::new(),
         payload_bytes,
+        benchmark_id,
     };
     let decoded_records = benchmark.decode_pass()?;
     ensure!(
@@ -343,6 +369,35 @@ pub fn prepare_external_input_decode_benchmark(
         "external-input initial decode count does not match validated payload ranges"
     );
     Ok(benchmark)
+}
+
+fn benchmark_identity(loaded: &LoadedExternalInput) -> Result<String> {
+    let manifest = &loaded.validated.manifest;
+    let format = match manifest.record_format {
+        ExternalRecordFormat::Fixed => "fixed",
+        ExternalRecordFormat::Rdw => "rdw",
+    };
+    let codepage = match manifest.codepage {
+        ExternalCodepage::Ascii => "ascii",
+        ExternalCodepage::Cp037 => "cp037",
+        ExternalCodepage::Cp273 => "cp273",
+        ExternalCodepage::Cp500 => "cp500",
+        ExternalCodepage::Cp1047 => "cp1047",
+        ExternalCodepage::Cp1140 => "cp1140",
+    };
+    let workload = match manifest.workload {
+        ExternalWorkload::DisplayHeavy => "display-heavy",
+        ExternalWorkload::Comp3Heavy => "comp3-heavy",
+        ExternalWorkload::Mixed => "mixed",
+    };
+    let digest = loaded
+        .manifest_sha256
+        .get(..12)
+        .context("validated manifest SHA-256 is shorter than 12 hexadecimal characters")?;
+    Ok(format!(
+        "{format}-{codepage}-{workload}-l{}-n{}-{digest}",
+        manifest.record_length, manifest.record_count
+    ))
 }
 
 fn checked_payload_bytes(loaded: &LoadedExternalInput) -> Result<usize> {
@@ -1062,6 +1117,7 @@ mod tests {
 
     #[test]
     fn external_input_benchmark_decodes_all_four_manifests() -> Result<()> {
+        let mut identities = Vec::new();
         for name in [
             "fixed-ascii.json",
             "fixed-cp037.json",
@@ -1070,9 +1126,17 @@ mod tests {
         ] {
             let mut benchmark = prepare_external_input_decode_benchmark(&fixtures().join(name))?;
             ensure!(benchmark.payload_bytes() == 5);
+            ensure!(benchmark.benchmark_id().len() <= 80);
+            identities.push(benchmark.benchmark_id().to_string());
             ensure!(benchmark.decode_pass()? == 1);
             ensure!(benchmark.decode_pass()? == 1);
         }
+        let mut distinct = identities.clone();
+        distinct.sort_unstable();
+        distinct.dedup();
+        ensure!(distinct.len() == identities.len());
+        let repeat = prepare_external_input_decode_benchmark(&fixtures().join("fixed-ascii.json"))?;
+        ensure!(repeat.benchmark_id() == identities[0]);
         Ok(())
     }
 
@@ -1094,6 +1158,37 @@ mod tests {
             error
                 .to_string()
                 .contains("failed to decode record 0 payload range 0..5")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn external_input_benchmark_returns_no_timing_after_decode_failure() -> Result<()> {
+        let (temp, manifest) = copy_fixture("fixed-ascii.json")?;
+        let numeric_copybook = b"       01 RECORD PIC 9(5).\n";
+        let valid_dataset = b"12345";
+        fs::write(temp.path().join("simple.cpy"), numeric_copybook)?;
+        fs::write(temp.path().join("fixed-ascii.bin"), valid_dataset)?;
+        edit_manifest(&manifest, |root| {
+            root.insert(
+                "copybook_sha256".to_string(),
+                json!(format!("{:x}", Sha256::digest(numeric_copybook))),
+            );
+            root.insert(
+                "dataset_sha256".to_string(),
+                json!(format!("{:x}", Sha256::digest(valid_dataset))),
+            );
+        })?;
+        let mut benchmark = prepare_external_input_decode_benchmark(&manifest)?;
+        benchmark.loaded.validated.dataset.copy_from_slice(b"ABCDE");
+        let error = benchmark
+            .measure_decode_iterations(2)
+            .err()
+            .context("decode failure unexpectedly returned a timing sample")?;
+        ensure!(
+            error
+                .to_string()
+                .contains("external-input decode iteration 0 failed")
         );
         Ok(())
     }

--- a/tools/copybook-bench/src/external_input.rs
+++ b/tools/copybook-bench/src/external_input.rs
@@ -1141,6 +1141,21 @@ mod tests {
     }
 
     #[test]
+    fn external_input_benchmark_target_is_explicitly_feature_gated() -> Result<()> {
+        let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let cargo_toml = fs::read_to_string(crate_root.join("Cargo.toml"))?;
+        ensure!(cargo_toml.contains("external-input = []"));
+        ensure!(cargo_toml.contains(
+            "name = \"external_input_decode\"\nharness = false\nrequired-features = [\"external-input\"]"
+        ));
+
+        let target = fs::read_to_string(crate_root.join("benches/external_input_decode.rs"))?;
+        ensure!(target.contains("COPYBOOK_EXTERNAL_INPUT_MANIFEST"));
+        ensure!(target.contains("must name one external-input manifest"));
+        Ok(())
+    }
+
+    #[test]
     fn external_input_benchmark_rejects_decode_invalid_payload() -> Result<()> {
         let (temp, manifest) = copy_fixture("fixed-ascii.json")?;
         let numeric_copybook = b"       01 RECORD PIC 9(5).\n";

--- a/tools/copybook-bench/src/external_input.rs
+++ b/tools/copybook-bench/src/external_input.rs
@@ -210,6 +210,35 @@ struct LoadedExternalInput {
     manifest_sha256: String,
 }
 
+/// Prepared state for the opt-in local external-input Criterion target.
+///
+/// This is public only because Cargo compiles benchmark targets as separate
+/// crates; `copybook-bench` itself is unpublished.
+pub struct ExternalInputDecodeBenchmark {
+    loaded: LoadedExternalInput,
+    options: DecodeOptions,
+    scratch: ScratchBuffers,
+    payload_bytes: usize,
+}
+
+impl ExternalInputDecodeBenchmark {
+    /// Sum of validated payload bytes processed by one decode pass.
+    #[must_use]
+    pub const fn payload_bytes(&self) -> usize {
+        self.payload_bytes
+    }
+
+    /// Decode every validated payload range exactly once.
+    ///
+    /// # Errors
+    ///
+    /// Returns contextual errors for an invalid range, decode failure, or
+    /// checked record-count overflow.
+    pub fn decode_pass(&mut self) -> Result<usize> {
+        decode_loaded_pass(&self.loaded, &self.options, &mut self.scratch)
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct ExternalInputPreflight {
     manifest_sha256: String,
@@ -288,6 +317,85 @@ impl ValidatedExternalInput {
 /// copybook layout disagreement, integrity mismatch, or invalid record framing.
 pub fn load_external_input(manifest_path: &Path) -> Result<ValidatedExternalInput> {
     Ok(load_external_input_bundle(manifest_path, None)?.validated)
+}
+
+/// Prepare one validated external-input dataset for local Criterion decoding.
+///
+/// # Errors
+///
+/// Returns an error when manifest loading or validation fails, when the
+/// payload-byte total overflows, or when the initial decode witness fails.
+pub fn prepare_external_input_decode_benchmark(
+    manifest_path: &Path,
+) -> Result<ExternalInputDecodeBenchmark> {
+    let loaded = load_external_input_bundle(manifest_path, None)?;
+    let options = loaded.validated.decode_options();
+    let payload_bytes = checked_payload_bytes(&loaded)?;
+    let mut benchmark = ExternalInputDecodeBenchmark {
+        loaded,
+        options,
+        scratch: ScratchBuffers::new(),
+        payload_bytes,
+    };
+    let decoded_records = benchmark.decode_pass()?;
+    ensure!(
+        decoded_records == benchmark.loaded.validated.payload_ranges.len(),
+        "external-input initial decode count does not match validated payload ranges"
+    );
+    Ok(benchmark)
+}
+
+fn checked_payload_bytes(loaded: &LoadedExternalInput) -> Result<usize> {
+    loaded
+        .validated
+        .payload_ranges
+        .iter()
+        .try_fold(0_usize, |total, range| {
+            let payload = loaded
+                .validated
+                .dataset
+                .get(range.clone())
+                .with_context(|| {
+                    format!(
+                        "payload range {}..{} is outside the validated dataset",
+                        range.start, range.end
+                    )
+                })?;
+            total
+                .checked_add(payload.len())
+                .context("external-input payload byte total overflows usize")
+        })
+}
+
+fn decode_loaded_pass(
+    loaded: &LoadedExternalInput,
+    options: &DecodeOptions,
+    scratch: &mut ScratchBuffers,
+) -> Result<usize> {
+    let mut decoded_records = 0_usize;
+    for (record_index, range) in loaded.validated.payload_ranges.iter().enumerate() {
+        let payload = loaded
+            .validated
+            .dataset
+            .get(range.clone())
+            .with_context(|| {
+                format!(
+                    "record {record_index} payload range {}..{} is outside the validated dataset",
+                    range.start, range.end
+                )
+            })?;
+        let _decoded = decode_record_with_scratch(&loaded.schema, payload, options, scratch)
+            .with_context(|| {
+                format!(
+                    "failed to decode record {record_index} payload range {}..{}",
+                    range.start, range.end
+                )
+            })?;
+        decoded_records = decoded_records
+            .checked_add(1)
+            .context("external-input decoded record count overflows usize")?;
+    }
+    Ok(decoded_records)
 }
 
 fn load_external_input_bundle(
@@ -396,34 +504,8 @@ fn run_external_input_preflight(
     let loaded = load_external_input_bundle(manifest_path, stale_output)?;
     let options = loaded.validated.decode_options();
     let mut scratch = ScratchBuffers::new();
-    let mut decoded_records = 0_usize;
-    let mut payload_bytes = 0_usize;
-
-    for (record_index, range) in loaded.validated.payload_ranges.iter().enumerate() {
-        let payload = loaded
-            .validated
-            .dataset
-            .get(range.clone())
-            .with_context(|| {
-                format!(
-                    "record {record_index} payload range {}..{} is outside the validated dataset",
-                    range.start, range.end
-                )
-            })?;
-        payload_bytes = payload_bytes
-            .checked_add(payload.len())
-            .context("external-input payload byte total overflows usize")?;
-        let _decoded = decode_record_with_scratch(&loaded.schema, payload, &options, &mut scratch)
-            .with_context(|| {
-                format!(
-                    "failed to decode record {record_index} payload range {}..{}",
-                    range.start, range.end
-                )
-            })?;
-        decoded_records = decoded_records
-            .checked_add(1)
-            .context("external-input decoded record count overflows usize")?;
-    }
+    let payload_bytes = checked_payload_bytes(&loaded)?;
+    let decoded_records = decode_loaded_pass(&loaded, &options, &mut scratch)?;
 
     let physical_bytes = loaded.validated.dataset.len();
     let framing_bytes = physical_bytes
@@ -831,9 +913,12 @@ mod tests {
     use super::{
         ExternalCodepage, ExternalRecordFormat, ExternalWorkload, IntegrityArtifact,
         ManifestIntegrityError, PreflightInputArtifact, PreflightOutputAliasError,
-        PreflightOutputLock, comparable_path, load_external_input,
+        PreflightOutputLock, load_external_input, prepare_external_input_decode_benchmark,
         publish_external_input_preflight, run_external_input_preflight, write_report_atomically,
     };
+
+    #[cfg(unix)]
+    use super::comparable_path;
 
     fn fixtures() -> PathBuf {
         Path::new(env!("CARGO_MANIFEST_DIR")).join("test_fixtures/external_input")
@@ -971,6 +1056,44 @@ mod tests {
         ensure!(
             run_external_input_preflight(&path, None)?
                 == run_external_input_preflight(&path, None)?
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn external_input_benchmark_decodes_all_four_manifests() -> Result<()> {
+        for name in [
+            "fixed-ascii.json",
+            "fixed-cp037.json",
+            "rdw-ascii.json",
+            "rdw-cp037.json",
+        ] {
+            let mut benchmark = prepare_external_input_decode_benchmark(&fixtures().join(name))?;
+            ensure!(benchmark.payload_bytes() == 5);
+            ensure!(benchmark.decode_pass()? == 1);
+            ensure!(benchmark.decode_pass()? == 1);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn external_input_benchmark_rejects_decode_invalid_payload() -> Result<()> {
+        let (temp, manifest) = copy_fixture("fixed-ascii.json")?;
+        let numeric_copybook = b"       01 RECORD PIC 9(5).\n";
+        fs::write(temp.path().join("simple.cpy"), numeric_copybook)?;
+        edit_manifest(&manifest, |root| {
+            root.insert(
+                "copybook_sha256".to_string(),
+                json!(format!("{:x}", Sha256::digest(numeric_copybook))),
+            );
+        })?;
+        let error = prepare_external_input_decode_benchmark(&manifest)
+            .err()
+            .context("decode-invalid input unexpectedly prepared a benchmark")?;
+        ensure!(
+            error
+                .to_string()
+                .contains("failed to decode record 0 payload range 0..5")
         );
         Ok(())
     }


### PR DESCRIPTION
<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
# Pull Request

## Summary

Adds one opt-in local Criterion target that decodes an explicitly selected, already-validated external-input manifest. Each input gets a stable bounded Criterion identity; decoding uses payload-byte throughput, one reused scratch buffer, checked totals, and fail-closed timed iterations.

## Type of Change

- [x] Performance (local benchmark tooling)
- [x] Tests

## COBOL/Mainframe Context

- **COBOL features affected**: fixed and RDW framing; ASCII and CP037 fixtures
- **Data processing impact**: local decode measurement only
- **Mainframe compatibility**: no codec or format contract change

## Workspace Crates Affected

- [x] copybook-bench

## Checklist

- [x] Tests added/updated
- [x] Tool README updated
- [x] Conventional commits used
- [ ] `cargo fmt --all` ? NOT_PROVEN: Windows OS error 206; scoped crate fmt passes
- [ ] all-target workspace Clippy ? NOT_PROVEN: five current-main test warnings outside this slice; changed lib+bench targets pass pedantic Clippy
- [ ] workspace tests ? NOT_RUN; scoped external-input tests and hosted matrices cover this change

## Testing Instructions

```text
PASS cargo test -p copybook-bench external_input --lib                 # 19/19 at current head
PASS cargo bench -p copybook-bench --no-run                            # target omitted without feature
PASS cargo bench -p copybook-bench --features external-input --bench external_input_decode --no-run
PASS explicit feature without COPYBOOK_EXTERNAL_INPUT_MANIFEST exits nonzero
PASS four explicit-feature Criterion --test runs: fixed/RDW x ASCII/CP037
PASS forced timed decode failure returns no Duration
PASS cargo clippy -p copybook-bench --lib --features external-input --bench external_input_decode -- -D warnings -W clippy::pedantic
PASS cargo fmt -p copybook-bench -- --check
PASS cargo test -p xtask docs_verify                                  # 61/61
PASS git diff --check
FAIL cargo run -p xtask -- docs verify-all: missing nextest JUnit prerequisite
```

## Performance Impact

- [x] No shipped-code performance impact expected

This creates an opt-in local measurement surface only. It does not establish a baseline, threshold, SLO, receipt, scheduled result, or hosted performance claim.

## Infrastructure/Tooling Changes

The `external-input` Cargo feature and `COPYBOOK_EXTERNAL_INPUT_MANIFEST` are both mandatory. `required-features` keeps ordinary canonical benchmark suites from launching this target. No CI workflow, receipt parser, SLO evaluation, generator, `perf.json`, schedule, or soak change is included.

**Adversarial Testing:**

- [x] Missing environment variable and unreadable manifest reject
- [x] Decode-invalid validated fixture rejects
- [x] Stable IDs repeat for one manifest and differ across all four fixtures
- [x] Timed errors cannot return a duration to Criterion
- [x] Generic no-feature benchmark inventory omits the target

## Breaking Changes

- [x] No breaking changes

## Related Issues

Closes #791
Relates to #776

## Additional Notes

Criterion IDs use `<format>-<codepage>-<workload>-l<record_length>-n<record_count>-<12hex manifest SHA>`. The checked-in datasets are tiny smoke fixtures, not representative performance workloads.


Governance repair proof: exact stability-registry workspace test 1/1, docs verifier tests 61/61, stable-errors, architecture check, record-pipeline digest, and JSON parse pass at head 225a4056.
Source truth: docs/stability/surface-registry.json registers external-input as internal-dev-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in benchmark for decoding validated external-input manifests.
  * Reports payload-byte throughput and Criterion measurement results.
  * Supports caller-selected manifests through an environment variable.

* **Documentation**
  * Added setup and usage instructions, including feature requirements and benchmark limitations.
  * Clarified that results are local measurements without performance guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->