### PR TITLE
ci(bench): add external-input Criterion telemetry

### DIFF
--- a/.github/workflows/external-input-criterion.yml
+++ b/.github/workflows/external-input-criterion.yml
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+name: External Input Criterion Telemetry
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: external-input-criterion-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  criterion-telemetry:
+    name: Measure checked-in external inputs
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Measure fixed external-input inventory
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf target/criterion/external_input_decode
+          manifests=(
+            tools/copybook-bench/test_fixtures/external_input/fixed-ascii.json
+            tools/copybook-bench/test_fixtures/external_input/fixed-cp037.json
+            tools/copybook-bench/test_fixtures/external_input/rdw-ascii.json
+            tools/copybook-bench/test_fixtures/external_input/rdw-cp037.json
+          )
+          for manifest in "${manifests[@]}"; do
+            COPYBOOK_EXTERNAL_INPUT_MANIFEST="$manifest" \
+              cargo bench -p copybook-bench --features external-input \
+                --bench external_input_decode -- \
+                --warm-up-time 1 --measurement-time 1 --sample-size 10
+          done
+
+      - name: Upload raw Criterion telemetry
+        uses: actions/upload-artifact@v7
+        with:
+          name: external-input-criterion-${{ github.sha }}
+          path: target/criterion/external_input_decode/**
+          retention-days: 30
+          if-no-files-found: error

--- a/docs/TESTING_COMMANDS.md
+++ b/docs/TESTING_COMMANDS.md
@@ -40,6 +40,7 @@ This document provides a canonical reference for all testing commands in copyboo
 | **Performance Benchmarks** | `BENCH_FILTER=slo_validation bash scripts/bench.sh` | Scheduled | 10-15 min | `target/perf.json` |
 | **Weekly Benchmark Gate** | `bash scripts/soak-dispatch.sh` | Weekly + manual | ~20 min | Sealed `scripts/bench/perf.json`, workflow job conclusion |
 | **External-input Decode Preflight** | `gh workflow run external-input-preflight.yml` | Manual only | Bounded | Four commit-keyed decode telemetry reports |
+| **External-input Criterion Telemetry** | `gh workflow run external-input-criterion.yml` | Manual only | Bounded | Commit-keyed raw Criterion output for four checked-in manifests |
 
 ---
 

--- a/docs/TEST_INFRASTRUCTURE_LANDSCAPE.md
+++ b/docs/TEST_INFRASTRUCTURE_LANDSCAPE.md
@@ -358,6 +358,16 @@ Tests use tags for categorization:
   input paths are distinct, stale output is removed before later validation
   and decode failures
 
+#### external-input-criterion.yml (Manual Criterion Telemetry)
+
+- Runs only through `workflow_dispatch` in one Ubuntu job
+- Measures the fixed four-manifest inventory sequentially through the opt-in
+  `external_input_decode` Criterion target
+- Publishes commit-keyed raw Criterion output only after all four runs succeed
+- Reports payload-byte timing telemetry for the tiny checked-in fixtures
+- Does not define a gate, threshold, receipt, schedule, baseline, or SLO, and
+  does not modify the canonical performance receipt or weekly soak owner
+
 #### security-scan.yml (Security Validation)
 - Security scanning integration
 - Dependency auditing

--- a/tools/copybook-bench/tests/external_input_preflight_cli.rs
+++ b/tools/copybook-bench/tests/external_input_preflight_cli.rs
@@ -339,3 +339,59 @@ fn workflow_is_manual_fixed_inventory_telemetry_only() -> Result<()> {
     }
     Ok(())
 }
+
+#[test]
+fn criterion_workflow_is_manual_fixed_inventory_telemetry_only() -> Result<()> {
+    let workflow = fs::read_to_string(
+        workspace_root().join(".github/workflows/external-input-criterion.yml"),
+    )?;
+    ensure!(workflow.contains("workflow_dispatch: {}"));
+    for forbidden in [
+        "schedule:",
+        "matrix:",
+        "inputs:",
+        "continue-on-error",
+        "threshold",
+        "SLO",
+        "perf.json",
+        "receipt",
+    ] {
+        ensure!(!workflow.contains(forbidden));
+    }
+    ensure!(has_adjacent_lines(
+        &workflow,
+        "permissions:",
+        "  contents: read"
+    ));
+    ensure!(workflow.contains("runs-on: ubuntu-latest"));
+    ensure!(workflow.contains("timeout-minutes: 20"));
+    ensure!(workflow.contains("persist-credentials: false"));
+    ensure!(workflow.contains("set -euo pipefail"));
+    ensure!(workflow.contains("--features external-input"));
+    ensure!(workflow.contains("COPYBOOK_EXTERNAL_INPUT_MANIFEST=\"$manifest\""));
+    ensure!(workflow.contains("--warm-up-time 1 --measurement-time 1 --sample-size 10"));
+
+    let manifests = [
+        "fixed-ascii.json",
+        "fixed-cp037.json",
+        "rdw-ascii.json",
+        "rdw-cp037.json",
+    ];
+    let mut prior = 0_usize;
+    for manifest in manifests {
+        ensure!(workflow.matches(manifest).count() == 1);
+        let position = workflow
+            .find(manifest)
+            .with_context(|| format!("Criterion workflow omits {manifest}"))?;
+        ensure!(position > prior);
+        prior = position;
+    }
+    let upload = workflow
+        .find("uses: actions/upload-artifact@v7")
+        .context("Criterion workflow omits artifact upload")?;
+    ensure!(upload > prior);
+    ensure!(workflow.contains("name: external-input-criterion-${{ github.sha }}"));
+    ensure!(workflow.contains("path: target/criterion/external_input_decode/**"));
+    ensure!(workflow.contains("if-no-files-found: error"));
+    Ok(())
+}

--- a/tools/copybook-bench/tests/external_input_preflight_cli.rs
+++ b/tools/copybook-bench/tests/external_input_preflight_cli.rs
@@ -57,6 +57,62 @@ fn has_adjacent_lines(text: &str, first: &str, second: &str) -> bool {
     false
 }
 
+fn has_exact_top_level_block(text: &str, header: &str, expected: &[&str]) -> bool {
+    if text.lines().filter(|line| *line == header).count() != 1 {
+        return false;
+    }
+    let mut block = Vec::new();
+    let mut collecting = false;
+    for line in text.lines() {
+        if line == header {
+            collecting = true;
+            continue;
+        }
+        if !collecting {
+            continue;
+        }
+        if line.is_empty() {
+            continue;
+        }
+        if !line.starts_with(' ') {
+            break;
+        }
+        block.push(line);
+    }
+    block == expected
+}
+
+fn shell_array_entries<'a>(text: &'a str, declaration: &str) -> Option<Vec<&'a str>> {
+    if text
+        .lines()
+        .filter(|line| line.trim() == declaration)
+        .count()
+        != 1
+    {
+        return None;
+    }
+    let mut entries = Vec::new();
+    let mut collecting = false;
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed == declaration {
+            collecting = true;
+            continue;
+        }
+        if !collecting {
+            continue;
+        }
+        if trimmed == ")" {
+            return Some(entries);
+        }
+        if trimmed.is_empty() || trimmed.contains(char::is_whitespace) {
+            return None;
+        }
+        entries.push(trimmed);
+    }
+    None
+}
+
 #[test]
 fn adjacent_lines_are_eol_agnostic_but_layout_sensitive() -> Result<()> {
     let first = "permissions:";
@@ -345,7 +401,11 @@ fn criterion_workflow_is_manual_fixed_inventory_telemetry_only() -> Result<()> {
     let workflow = fs::read_to_string(
         workspace_root().join(".github/workflows/external-input-criterion.yml"),
     )?;
-    ensure!(workflow.contains("workflow_dispatch: {}"));
+    ensure!(has_exact_top_level_block(
+        &workflow,
+        "on:",
+        &["  workflow_dispatch: {}"]
+    ));
     for forbidden in [
         "schedule:",
         "matrix:",
@@ -372,20 +432,15 @@ fn criterion_workflow_is_manual_fixed_inventory_telemetry_only() -> Result<()> {
     ensure!(workflow.contains("--warm-up-time 1 --measurement-time 1 --sample-size 10"));
 
     let manifests = [
-        "fixed-ascii.json",
-        "fixed-cp037.json",
-        "rdw-ascii.json",
-        "rdw-cp037.json",
+        "tools/copybook-bench/test_fixtures/external_input/fixed-ascii.json",
+        "tools/copybook-bench/test_fixtures/external_input/fixed-cp037.json",
+        "tools/copybook-bench/test_fixtures/external_input/rdw-ascii.json",
+        "tools/copybook-bench/test_fixtures/external_input/rdw-cp037.json",
     ];
-    let mut prior = 0_usize;
-    for manifest in manifests {
-        ensure!(workflow.matches(manifest).count() == 1);
-        let position = workflow
-            .find(manifest)
-            .with_context(|| format!("Criterion workflow omits {manifest}"))?;
-        ensure!(position > prior);
-        prior = position;
-    }
+    ensure!(shell_array_entries(&workflow, "manifests=(") == Some(manifests.to_vec()));
+    let prior = workflow
+        .find(manifests[3])
+        .context("Criterion workflow omits final canonical manifest")?;
     let upload = workflow
         .find("uses: actions/upload-artifact@v7")
         .context("Criterion workflow omits artifact upload")?;
@@ -393,5 +448,50 @@ fn criterion_workflow_is_manual_fixed_inventory_telemetry_only() -> Result<()> {
     ensure!(workflow.contains("name: external-input-criterion-${{ github.sha }}"));
     ensure!(workflow.contains("path: target/criterion/external_input_decode/**"));
     ensure!(workflow.contains("if-no-files-found: error"));
+    Ok(())
+}
+
+#[test]
+fn workflow_contract_helpers_reject_extra_triggers_and_manifests() -> Result<()> {
+    let expected_trigger = ["  workflow_dispatch: {}"];
+    for accepted in [
+        "on:\n  workflow_dispatch: {}\njobs:\n",
+        "on:\r\n  workflow_dispatch: {}\r\njobs:\r\n",
+    ] {
+        ensure!(has_exact_top_level_block(
+            accepted,
+            "on:",
+            &expected_trigger
+        ));
+    }
+    for rejected in [
+        "on:\n  workflow_dispatch: {}\n  push: {}\njobs:\n",
+        "on:\n  pull_request: {}\n  workflow_dispatch: {}\njobs:\n",
+        "on:\n  workflow_dispatch: {}\n  workflow_dispatch: {}\njobs:\n",
+    ] {
+        ensure!(!has_exact_top_level_block(
+            rejected,
+            "on:",
+            &expected_trigger
+        ));
+    }
+
+    let expected_manifests = ["fixed.json", "rdw.json"];
+    for accepted in [
+        "manifests=(\n  fixed.json\n  rdw.json\n)\n",
+        "manifests=(\r\n  fixed.json\r\n  rdw.json\r\n)\r\n",
+    ] {
+        ensure!(shell_array_entries(accepted, "manifests=(") == Some(expected_manifests.to_vec()));
+    }
+    for rejected in [
+        "manifests=(\n  fixed.json\n  rdw.json\n  extra.json\n)\n",
+        "manifests=(\n  rdw.json\n  fixed.json\n)\n",
+        "manifests=(\n  fixed.json\n)\n",
+        "manifests=(\n  fixed.json\n  fixed.json\n  rdw.json\n)\n",
+        "manifests=(\n  fixed.json\n  rdw.json\n",
+        "manifests=(\n  fixed.json\n  rdw.json\n)\nmanifests=(\n  fixed.json\n  rdw.json\n)\n",
+    ] {
+        ensure!(shell_array_entries(rejected, "manifests=(") != Some(expected_manifests.to_vec()));
+    }
     Ok(())
 }


### PR DESCRIPTION
<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
# Pull Request

## Summary

Adds a separate manual-only Linux workflow that runs the opt-in external-input Criterion target sequentially over the fixed four-manifest inventory and uploads commit-keyed raw Criterion telemetry.

## Type of Change

- [x] CI/CD
- [x] Tests
- [x] Documentation

## COBOL/Mainframe Context

- **COBOL features affected**: fixed/RDW framing and ASCII/CP037 fixture inventory
- **Data processing impact**: optional hosted timing telemetry only
- **Mainframe compatibility**: no codec or data-contract change

## Workspace Crates Affected

- [x] copybook-bench (workflow invariant test only)

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [x] Conventional commit format
- [x] Scoped fmt and pedantic Clippy pass
- [ ] actionlint ? NOT_RUN: unavailable locally; hosted workflow lint required
- [ ] Manual workflow dispatch ? NOT_PROVEN until run from merged workflow

## Testing Instructions

```text
PASS cargo test -p copybook-bench --test external_input_preflight_cli       # 9/9
PASS cargo clippy -p copybook-bench --test external_input_preflight_cli -- -D warnings -W clippy::pedantic
PASS cargo fmt -p copybook-bench -- --check
PASS Python YAML parse
PASS cargo test -p xtask docs_verify                                       # 61/61
PASS xtask stable-errors and record-pipeline verification
PASS git diff --check
NOT_PROVEN bounded local Criterion artifact smoke: two 64s compilation/contention timeouts, no semantic failure output
NOT_RUN actionlint: tool unavailable
```

## Performance Impact

- [x] No shipped-code performance impact expected

The workflow is telemetry-only. Tiny checked-in fixtures do not establish representative throughput, a baseline, threshold, SLO, receipt, gate result, or performance-policy claim.

## Infrastructure/Tooling Changes

- Manual `workflow_dispatch` only; no schedule, push, PR, matrix, or arbitrary input
- One Ubuntu job with `contents: read`, credential persistence disabled, bounded timeout, and fixed ordered allowlist
- Explicit `external-input` feature and manifest environment per run
- Raw Criterion artifact uploads only after all four commands succeed
- No `perf.json`, receipt, threshold, SLO, soak, or branch-protection change

## Breaking Changes

- [x] No breaking changes

## Related Issues

Closes #794
Relates to #776

## Additional Notes

The existing `external-input-preflight.yml` remains the deterministic decode-report owner. This workflow owns only optional raw Criterion telemetry. Issue #793 is untouched.


Adversarial inventory proof: exact top-level trigger block rejects push, pull_request, and duplicate dispatch entries; exact shell-array extraction accepts LF/CRLF and rejects extra, reordered, missing, duplicate, and unclosed manifest lists.