### PR TITLE
test(bench): make feature gate assertion CRLF safe

### DIFF
--- a/tools/copybook-bench/src/external_input.rs
+++ b/tools/copybook-bench/src/external_input.rs
@@ -1001,37 +1001,129 @@ mod tests {
         Ok(())
     }
 
-    fn has_adjacent_lines(source: &str, expected: &[&str]) -> bool {
+    #[derive(Clone, Copy)]
+    enum TomlMultilineString {
+        Basic,
+        Literal,
+    }
+
+    fn line_is_toml_structure(line: &str, multiline: &mut Option<TomlMultilineString>) -> bool {
+        let bytes = line.as_bytes();
+        let mut cursor = 0;
+        let mut basic_string = false;
+        let mut literal_string = false;
+        let mut escaped = false;
+        let mut touched_multiline = multiline.is_some();
+
+        while cursor < bytes.len() {
+            if let Some(delimiter) = *multiline {
+                let marker = match delimiter {
+                    TomlMultilineString::Basic => b"\"\"\"".as_slice(),
+                    TomlMultilineString::Literal => b"'''".as_slice(),
+                };
+                if bytes
+                    .get(cursor..)
+                    .is_some_and(|tail| tail.starts_with(marker))
+                    && (!matches!(delimiter, TomlMultilineString::Basic) || !escaped)
+                {
+                    *multiline = None;
+                    cursor += marker.len();
+                    escaped = false;
+                    continue;
+                }
+                escaped = matches!(delimiter, TomlMultilineString::Basic)
+                    && bytes.get(cursor) == Some(&b'\\')
+                    && !escaped;
+                cursor += 1;
+                continue;
+            }
+
+            if !basic_string
+                && !literal_string
+                && bytes
+                    .get(cursor..)
+                    .is_some_and(|tail| tail.starts_with(b"\"\"\""))
+            {
+                *multiline = Some(TomlMultilineString::Basic);
+                touched_multiline = true;
+                cursor += 3;
+                continue;
+            }
+            if !basic_string
+                && !literal_string
+                && bytes
+                    .get(cursor..)
+                    .is_some_and(|tail| tail.starts_with(b"'''"))
+            {
+                *multiline = Some(TomlMultilineString::Literal);
+                touched_multiline = true;
+                cursor += 3;
+                continue;
+            }
+
+            match bytes.get(cursor) {
+                Some(b'#') if !basic_string && !literal_string => break,
+                Some(b'\"') if !literal_string && !escaped => basic_string = !basic_string,
+                Some(b'\'') if !basic_string => literal_string = !literal_string,
+                _ => {}
+            }
+            escaped = basic_string && bytes.get(cursor) == Some(&b'\\') && !escaped;
+            cursor += 1;
+        }
+
+        !touched_multiline
+    }
+
+    fn has_adjacent_toml_lines(source: &str, expected: &[&str]) -> bool {
         let Some((first, tail)) = expected.split_first() else {
             return false;
         };
-        let mut lines = source.lines();
-        while let Some(line) = lines.next() {
-            if line == *first {
-                let mut candidate = lines.clone();
-                if tail
-                    .iter()
-                    .all(|expected| candidate.next() == Some(*expected))
+        let mut multiline = None;
+        let mut matched_tail: Option<&[&str]> = None;
+        for line in source.lines() {
+            if !line_is_toml_structure(line, &mut multiline) {
+                matched_tail = None;
+                continue;
+            }
+            if let Some(expected_tail) = matched_tail.as_mut() {
+                if expected_tail
+                    .first()
+                    .is_some_and(|expected| line == *expected)
                 {
+                    *expected_tail = expected_tail.get(1..).unwrap_or_default();
+                    if expected_tail.is_empty() {
+                        return true;
+                    }
+                    continue;
+                }
+                matched_tail = None;
+            }
+            if line == *first {
+                if tail.is_empty() {
                     return true;
                 }
+                matched_tail = Some(tail);
             }
         }
         false
     }
 
     fn cargo_manifest_admits_external_input_benchmark(source: &str) -> bool {
-        let feature_declared = source
-            .lines()
-            .scan(false, |in_features, line| {
-                if line.starts_with('[') {
-                    *in_features = line == "[features]";
-                }
-                Some(*in_features && line == "external-input = []")
-            })
-            .any(|matches| matches);
+        let mut multiline = None;
+        let mut in_features = false;
+        let mut feature_declared = false;
+        for line in source.lines() {
+            if !line_is_toml_structure(line, &mut multiline) {
+                continue;
+            }
+            if line.starts_with('[') {
+                in_features = line == "[features]";
+            } else if in_features && line == "external-input = []" {
+                feature_declared = true;
+            }
+        }
         feature_declared
-            && has_adjacent_lines(
+            && has_adjacent_toml_lines(
                 source,
                 &[
                     "[[bench]]",
@@ -1200,6 +1292,13 @@ mod tests {
         ensure!(cargo_manifest_admits_external_input_benchmark(
             &valid.replace('\n', "\r\n")
         ));
+
+        for delimiter in ["\"\"\"", "'''"] {
+            let fake = format!(
+                "[package]\nname = \"copybook-bench\"\n\n[package.metadata]\ntext = {delimiter}\n[features]\nexternal-input = []\n\n[[bench]]\nname = \"external_input_decode\"\nharness = false\nrequired-features = [\"external-input\"]\n{delimiter}\n"
+            );
+            ensure!(!cargo_manifest_admits_external_input_benchmark(&fake));
+        }
 
         for rejected in [
             valid.replace("external-input = []\n", ""),

--- a/tools/copybook-bench/src/external_input.rs
+++ b/tools/copybook-bench/src/external_input.rs
@@ -1001,6 +1001,47 @@ mod tests {
         Ok(())
     }
 
+    fn has_adjacent_lines(source: &str, expected: &[&str]) -> bool {
+        let Some((first, tail)) = expected.split_first() else {
+            return false;
+        };
+        let mut lines = source.lines();
+        while let Some(line) = lines.next() {
+            if line == *first {
+                let mut candidate = lines.clone();
+                if tail
+                    .iter()
+                    .all(|expected| candidate.next() == Some(*expected))
+                {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    fn cargo_manifest_admits_external_input_benchmark(source: &str) -> bool {
+        let feature_declared = source
+            .lines()
+            .scan(false, |in_features, line| {
+                if line.starts_with('[') {
+                    *in_features = line == "[features]";
+                }
+                Some(*in_features && line == "external-input = []")
+            })
+            .any(|matches| matches);
+        feature_declared
+            && has_adjacent_lines(
+                source,
+                &[
+                    "[[bench]]",
+                    "name = \"external_input_decode\"",
+                    "harness = false",
+                    "required-features = [\"external-input\"]",
+                ],
+            )
+    }
+
     #[test]
     fn external_input_accepts_fixed_rdw_ascii_cp037_matrix() -> Result<()> {
         let cases = [
@@ -1144,14 +1185,45 @@ mod tests {
     fn external_input_benchmark_target_is_explicitly_feature_gated() -> Result<()> {
         let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
         let cargo_toml = fs::read_to_string(crate_root.join("Cargo.toml"))?;
-        ensure!(cargo_toml.contains("external-input = []"));
-        ensure!(cargo_toml.contains(
-            "name = \"external_input_decode\"\nharness = false\nrequired-features = [\"external-input\"]"
-        ));
+        ensure!(cargo_manifest_admits_external_input_benchmark(&cargo_toml));
 
         let target = fs::read_to_string(crate_root.join("benches/external_input_decode.rs"))?;
         ensure!(target.contains("COPYBOOK_EXTERNAL_INPUT_MANIFEST"));
         ensure!(target.contains("must name one external-input manifest"));
+        Ok(())
+    }
+
+    #[test]
+    fn external_input_benchmark_admission_is_crlf_safe_and_fail_closed() -> Result<()> {
+        let valid = "[package]\nname = \"copybook-bench\"\n\n[[bench]]\nname = \"external_input_decode\"\nharness = false\nrequired-features = [\"external-input\"]\n\n[features]\ndefault = []\nexternal-input = []\n";
+        ensure!(cargo_manifest_admits_external_input_benchmark(valid));
+        ensure!(cargo_manifest_admits_external_input_benchmark(
+            &valid.replace('\n', "\r\n")
+        ));
+
+        for rejected in [
+            valid.replace("external-input = []\n", ""),
+            valid.replace("[features]\n", "[package.metadata]\n"),
+            valid.replace("required-features = [\"external-input\"]\n", ""),
+            valid.replace(
+                "required-features = [\"external-input\"]",
+                "required-features = [\"diagnostics\"]",
+            ),
+            valid.replace(
+                "harness = false\nrequired-features = [\"external-input\"]",
+                "required-features = [\"external-input\"]\nharness = false",
+            ),
+            valid.replace(
+                "harness = false\nrequired-features = [\"external-input\"]",
+                "harness = false\n\n[[bench]]\nname = \"detached\"\nharness = false\nrequired-features = [\"external-input\"]",
+            ),
+            valid.replace(
+                "name = \"external_input_decode\"",
+                "name = \"decode_performance\"",
+            ),
+        ] {
+            ensure!(!cargo_manifest_admits_external_input_benchmark(&rejected));
+        }
         Ok(())
     }
 


### PR DESCRIPTION
<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
# Pull Request

## Summary

Make the `copybook-bench` Cargo feature/benchmark admission assertion independent of LF versus CRLF bytes. The test-only matcher verifies the exact adjacent `[[bench]]`, target name, `harness = false`, and `required-features = ["external-input"]` lines plus the feature declaration inside `[features]`.

The matcher is bounded but TOML string-aware: basic and literal multiline-string content is excluded and forms an adjacency barrier, so declaration-shaped text inside a string cannot satisfy the inventory assertion.

This fixes the Windows checkout failure found after #792 without changing benchmark behavior, Cargo metadata, workflows, docs, schemas, or registries.

## Type of Change

- [ ] Feature (new functionality)
- [ ] Bugfix (fixes an issue)
- [ ] Refactor (code improvement without behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (README, docs/, code comments)
- [x] Tests (test additions or improvements)
- [ ] CI/CD (workflow or tooling changes)
- [ ] Chore (dependencies, formatting, etc.)

## COBOL/Mainframe Context

- **COBOL features affected**: None
- **Data processing impact**: None; test inventory only
- **Mainframe compatibility**: Unchanged

## Workspace Crates Affected

- [x] copybook-bench (test-only assertion)

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (N/A; no contract or behavior changed)
- [x] CHANGELOG.md updated (N/A; no user-facing change)
- [ ] `cargo fmt --all` passes
- [ ] `cargo clippy --workspace -- -D warnings -W clippy::pedantic` passes
- [ ] `cargo test --workspace` passes
- [x] Follows conventional commit format
- [x] MSRV compliance N/A (no dependency or production-code change)
- [x] Golden fixtures N/A

## Testing Instructions

```text
PASS cargo test -p copybook-bench external_input_benchmark_admission_is_crlf_safe_and_fail_closed --lib (1/1)
PASS cargo test -p copybook-bench external_input (20/20 across 19 suites)
PASS cargo metadata --no-deps --format-version 1 assertion for feature and bench required-features
PASS cargo fmt -p copybook-bench -- --check
PASS cargo clippy -p copybook-bench --lib -- -D warnings -W clippy::pedantic
PASS git diff --check
```

The hostile fixture test accepts LF and CRLF and rejects missing/detached feature declarations, missing/wrong/reordered/detached required-feature blocks, the wrong target, and complete fake declarations inside TOML basic or literal multiline strings.

`cargo clippy -p copybook-bench --lib --tests -- -D warnings -W clippy::pedantic` is NOT_PROVEN because five pre-existing warnings outside the changed file remain (float comparison, map/unwrap-or, two single-character patterns, and a lossless cast). No diagnostic points at `external_input.rs`.

The manual external-input Criterion workflow dispatch/artifact remains NOT_PROVEN and is not exercised or changed here. Actionlint was not run because this PR changes no workflow.

## Performance Impact

- [x] No performance impact expected

## Infrastructure/Tooling Changes

None. Cargo metadata, benchmark implementation, workflows, receipts, thresholds, and SLOs are unchanged.

## Breaking Changes

- [x] No breaking changes

## Related Issues

Closes #793

## Additional Notes

Claim boundary: this proves the checked-in test recognizes equivalent LF/CRLF Cargo manifests while failing closed on the enumerated admission drift and multiline-string false positives. It does not change or newly prove runtime benchmark behavior.
