### PR TITLE
fix(ci): anchor Criterion manifests to workspace

### DIFF
--- a/.github/workflows/external-input-criterion.yml
+++ b/.github/workflows/external-input-criterion.yml
@@ -38,7 +38,7 @@ jobs:
             tools/copybook-bench/test_fixtures/external_input/rdw-cp037.json
           )
           for manifest in "${manifests[@]}"; do
-            COPYBOOK_EXTERNAL_INPUT_MANIFEST="$manifest" \
+            COPYBOOK_EXTERNAL_INPUT_MANIFEST="$GITHUB_WORKSPACE/$manifest" \
               cargo bench -p copybook-bench --features external-input \
                 --bench external_input_decode -- \
                 --warm-up-time 1 --measurement-time 1 --sample-size 10

--- a/tools/copybook-bench/tests/external_input_preflight_cli.rs
+++ b/tools/copybook-bench/tests/external_input_preflight_cli.rs
@@ -113,6 +113,17 @@ fn shell_array_entries<'a>(text: &'a str, declaration: &str) -> Option<Vec<&'a s
     None
 }
 
+fn has_exact_workspace_manifest_binding(text: &str) -> bool {
+    const EXPECTED: &str = "COPYBOOK_EXTERNAL_INPUT_MANIFEST=\"$GITHUB_WORKSPACE/$manifest\" \\";
+    let mut bindings = text.lines().filter_map(|line| {
+        let trimmed = line.trim();
+        trimmed
+            .starts_with("COPYBOOK_EXTERNAL_INPUT_MANIFEST=")
+            .then_some(trimmed)
+    });
+    bindings.next() == Some(EXPECTED) && bindings.next().is_none()
+}
+
 #[test]
 fn adjacent_lines_are_eol_agnostic_but_layout_sensitive() -> Result<()> {
     let first = "permissions:";
@@ -428,7 +439,7 @@ fn criterion_workflow_is_manual_fixed_inventory_telemetry_only() -> Result<()> {
     ensure!(workflow.contains("persist-credentials: false"));
     ensure!(workflow.contains("set -euo pipefail"));
     ensure!(workflow.contains("--features external-input"));
-    ensure!(workflow.contains("COPYBOOK_EXTERNAL_INPUT_MANIFEST=\"$manifest\""));
+    ensure!(has_exact_workspace_manifest_binding(&workflow));
     ensure!(workflow.contains("--warm-up-time 1 --measurement-time 1 --sample-size 10"));
 
     let manifests = [
@@ -492,6 +503,20 @@ fn workflow_contract_helpers_reject_extra_triggers_and_manifests() -> Result<()>
         "manifests=(\n  fixed.json\n  rdw.json\n)\nmanifests=(\n  fixed.json\n  rdw.json\n)\n",
     ] {
         ensure!(shell_array_entries(rejected, "manifests=(") != Some(expected_manifests.to_vec()));
+    }
+
+    let binding = "COPYBOOK_EXTERNAL_INPUT_MANIFEST=\"$GITHUB_WORKSPACE/$manifest\" \\\n";
+    ensure!(has_exact_workspace_manifest_binding(binding));
+    ensure!(has_exact_workspace_manifest_binding(
+        &binding.replace('\n', "\r\n")
+    ));
+    for rejected in [
+        String::new(),
+        "COPYBOOK_EXTERNAL_INPUT_MANIFEST=\"$manifest\" \\\n".to_string(),
+        "COPYBOOK_EXTERNAL_INPUT_MANIFEST=\"$GITHUB_WORKSPACE$manifest\" \\\n".to_string(),
+        format!("{binding}{binding}"),
+    ] {
+        ensure!(!has_exact_workspace_manifest_binding(&rejected));
     }
     Ok(())
 }

--- a/tools/copybook-bench/tests/external_input_preflight_cli.rs
+++ b/tools/copybook-bench/tests/external_input_preflight_cli.rs
@@ -116,10 +116,10 @@ fn shell_array_entries<'a>(text: &'a str, declaration: &str) -> Option<Vec<&'a s
 fn has_exact_workspace_manifest_binding(text: &str) -> bool {
     const EXPECTED: &str = "COPYBOOK_EXTERNAL_INPUT_MANIFEST=\"$GITHUB_WORKSPACE/$manifest\" \\";
     let mut bindings = text.lines().filter_map(|line| {
-        let trimmed = line.trim();
-        trimmed
+        let normalized = line.trim_start().trim_end_matches('\r');
+        normalized
             .starts_with("COPYBOOK_EXTERNAL_INPUT_MANIFEST=")
-            .then_some(trimmed)
+            .then_some(normalized)
     });
     bindings.next() == Some(EXPECTED) && bindings.next().is_none()
 }
@@ -512,11 +512,16 @@ fn workflow_contract_helpers_reject_extra_triggers_and_manifests() -> Result<()>
     ));
     for rejected in [
         String::new(),
+        "COPYBOOK_EXTERNAL_INPUT_MANIFES=\"$GITHUB_WORKSPACE/$manifest\" \\\n".to_string(),
+        "COPYBOOK_EXTERNAL_INPUT_MANIFEST=\"$GITHUB_WORKSPACE/$manifest\" \\   \n".to_string(),
         "COPYBOOK_EXTERNAL_INPUT_MANIFEST=\"$manifest\" \\\n".to_string(),
         "COPYBOOK_EXTERNAL_INPUT_MANIFEST=\"$GITHUB_WORKSPACE$manifest\" \\\n".to_string(),
         format!("{binding}{binding}"),
     ] {
         ensure!(!has_exact_workspace_manifest_binding(&rejected));
+        ensure!(!has_exact_workspace_manifest_binding(
+            &rejected.replace('\n', "\r\n")
+        ));
     }
     Ok(())
 }


### PR DESCRIPTION
<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
# Pull Request

## Summary

Anchor the manual external-input Criterion workflow's fixed manifest paths to `$GITHUB_WORKSPACE`. The first hosted witness, [run 31867247195](https://github.com/EffortlessMetrics/copybook-rs/actions/runs/31867247195), failed because Cargo launched the benchmark from the package working directory while the workflow supplied repository-relative paths.

The existing workflow invariant now requires exactly one workspace-anchored manifest binding. Its line matcher preserves leading indentation handling and an optional CR while retaining shell-significant trailing whitespace, so it rejects whitespace after the continuation backslash. Missing, legacy unanchored, misspelled, malformed, or duplicate bindings reject under both LF and CRLF.

## Type of Change

- [ ] Feature (new functionality)
- [x] Bugfix (fixes an issue)
- [ ] Refactor (code improvement without behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (README, docs/, code comments)
- [x] Tests (test additions or improvements)
- [x] CI/CD (workflow or tooling changes)
- [ ] Chore (dependencies, formatting, etc.)

## COBOL/Mainframe Context

- **COBOL features affected**: None
- **Data processing impact**: None; workflow path resolution only
- **Mainframe compatibility**: Unchanged

## Workspace Crates Affected

- [x] copybook-bench (integration invariant only)

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (N/A; #776 and #797 carry the witness/source truth)
- [x] CHANGELOG.md updated (N/A; no user-facing runtime change)
- [ ] `cargo fmt --all` passes
- [ ] `cargo clippy --workspace -- -D warnings -W clippy::pedantic` passes
- [ ] `cargo test --workspace` passes
- [x] Follows conventional commit format
- [x] MSRV compliance N/A (no dependency or Rust production-code change)
- [x] Golden fixtures N/A

## Testing Instructions

```text
PASS focused workspace-binding helper (LF/CRLF accept; missing/legacy/misspelled/trailing-space/duplicate reject)
PASS focused actual Criterion workflow invariant
PASS cargo test -p copybook-bench --test external_input_preflight_cli (9/9)
PASS package-working-directory Criterion --test smoke over all four absolute manifests (4/4, prior workflow-diff proof)
PASS YAML parse
PASS cargo clippy -p copybook-bench --test external_input_preflight_cli -- -D warnings -W clippy::pedantic
PASS cargo fmt -p copybook-bench -- --check
PASS cargo test -p xtask docs_verify (61/61, prior workflow-diff proof)
PASS cargo run -p xtask -- docs verify-record-pipeline (prior workflow-diff proof)
PASS git diff --check
NOT RUN actionlint (unavailable locally)
```

The four package-CWD smoke identities were:

- `fixed-ascii-display-heavy-l5-n1-77f549fb5847`
- `fixed-cp037-display-heavy-l5-n1-92c9372e5d0a`
- `rdw-ascii-display-heavy-l5-n1-81fa446c2263`
- `rdw-cp037-display-heavy-l5-n1-20d47df5e34a`

## Performance Impact

- [x] No runtime performance impact expected

## Infrastructure/Tooling Changes

**Areas modified:**

- [x] Manual-only Criterion telemetry workflow path resolution
- [x] Existing workflow invariant test

The trigger remains dispatch-only with no inputs. The one Linux job, fixed ordered four-manifest allowlist, sequential execution, explicit feature/env contract, read-only permissions, bounded Criterion settings, and commit-keyed raw artifact are unchanged.

## Breaking Changes

- [x] No breaking changes

## Related Issues

Closes #797

Relates to #776

## Additional Notes

Hosted success and artifact contents remain **NOT_PROVEN** until this fix is reviewed, green, merged, and the manual workflow is dispatched again from fixed main. Run 31867247195 produced zero artifacts.

Even after a successful witness, the claim is limited to raw Criterion telemetry for four tiny checked-in fixtures. This PR does not establish an SLO, regression baseline, performance receipt, production representativeness, soak coverage, or `perf.json` result.
