### PR TITLE
feat(security): add normalized receipt v2

### DIFF
--- a/docs/reference/security-receipt-schema-v2.json
+++ b/docs/reference/security-receipt-schema-v2.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://copybook-rs.effortlessmetrics.com/schemas/security-receipt-v2.0.json",
   "title": "copybook-rs Normalized Security Evidence v2",
-  "description": "Closed data contract for deterministic normalized cargo-audit evidence. Validation proves document shape and internal consistency only; it is not a security certification or regulatory-compliance determination.",
+  "description": "Closed shape contract for deterministic normalized cargo-audit evidence. JSON Schema validation alone does not prove aggregate parity; consumers must also run validate_receipt or an equivalent semantic validator. This is not a security certification or regulatory-compliance determination.",
   "type": "object",
   "required": [
     "schema_version",
@@ -19,7 +19,7 @@
     "receipt_id": {
       "type": "string",
       "pattern": "^sha256:[0-9a-f]{64}$",
-      "description": "Deterministic SHA-256 identity derived from the explicit identity and scanner objects."
+      "description": "Deterministic SHA-256 identifier for the explicit scan, raw-audit digest, and scanner tuple; it is not authentication or a digest of the normalized outcome and findings."
     },
     "identity": {
       "type": "object",

--- a/docs/reference/security-receipt-schema-v2.json
+++ b/docs/reference/security-receipt-schema-v2.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://copybook-rs.effortlessmetrics.com/schemas/security-receipt-v2.0.json",
+  "title": "copybook-rs Normalized Security Evidence v2",
+  "description": "Closed data contract for deterministic normalized cargo-audit evidence. Validation proves document shape and internal consistency only; it is not a security certification or regulatory-compliance determination.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "receipt_id",
+    "identity",
+    "scanner",
+    "outcome",
+    "findings"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "2.0"
+    },
+    "receipt_id": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "description": "Deterministic SHA-256 identity derived from the explicit identity and scanner objects."
+    },
+    "identity": {
+      "type": "object",
+      "required": [
+        "commit_sha",
+        "scan_type",
+        "workflow_run_id",
+        "raw_audit_sha256"
+      ],
+      "properties": {
+        "commit_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "scan_type": {
+          "type": "string",
+          "enum": ["pr-gate", "weekly-scan", "manual"]
+        },
+        "workflow_run_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "raw_audit_sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      },
+      "additionalProperties": false
+    },
+    "scanner": {
+      "type": "object",
+      "required": ["name", "version", "exit_code"],
+      "properties": {
+        "name": {
+          "const": "cargo-audit"
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "exit_code": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        }
+      },
+      "additionalProperties": false
+    },
+    "outcome": {
+      "type": "object",
+      "required": ["state", "finding_count", "by_severity"],
+      "properties": {
+        "state": {
+          "type": "string",
+          "enum": ["clean", "findings", "tool_error"]
+        },
+        "finding_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "by_severity": {
+          "type": "object",
+          "required": ["critical", "high", "medium", "low", "unknown"],
+          "properties": {
+            "critical": {"type": "integer", "minimum": 0},
+            "high": {"type": "integer", "minimum": 0},
+            "medium": {"type": "integer", "minimum": 0},
+            "low": {"type": "integer", "minimum": 0},
+            "unknown": {"type": "integer", "minimum": 0}
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "advisory_id",
+          "package",
+          "severity",
+          "patched_versions"
+        ],
+        "properties": {
+          "advisory_id": {
+            "type": "string",
+            "pattern": "^RUSTSEC-\\d{4}-\\d{4}$"
+          },
+          "package": {
+            "type": "object",
+            "required": ["name", "version"],
+            "properties": {
+              "name": {"type": "string", "minLength": 1},
+              "version": {"type": "string", "minLength": 1}
+            },
+            "additionalProperties": false
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["critical", "high", "medium", "low", "unknown"]
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "minLength": 1
+          },
+          "patched_versions": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1}
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/ci/classify_security_audit.py
+++ b/scripts/ci/classify_security_audit.py
@@ -12,7 +12,7 @@ from typing import Any, TextIO
 def parse_audit_report(raw_json: bytes) -> tuple[dict[str, Any], list[Any]]:
     """Parse cargo-audit JSON bytes and return the validated finding list."""
     try:
-        document = json.loads(raw_json)
+        document = json.loads(raw_json.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as error:
         raise ValueError(f"cargo-audit output is not valid JSON: {error}") from error
 

--- a/scripts/ci/classify_security_audit.py
+++ b/scripts/ci/classify_security_audit.py
@@ -9,13 +9,11 @@ from pathlib import Path
 from typing import Any, TextIO
 
 
-def load_audit_report(path: Path) -> tuple[dict[str, Any], list[Any]]:
-    """Load cargo-audit JSON and return the document and validated finding list."""
+def parse_audit_report(raw_json: bytes) -> tuple[dict[str, Any], list[Any]]:
+    """Parse cargo-audit JSON bytes and return the validated finding list."""
     try:
-        document = json.loads(path.read_text(encoding="utf-8"))
-    except FileNotFoundError as error:
-        raise ValueError(f"cargo-audit output is missing: {path}") from error
-    except json.JSONDecodeError as error:
+        document = json.loads(raw_json)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
         raise ValueError(f"cargo-audit output is not valid JSON: {error}") from error
 
     if not isinstance(document, dict):
@@ -37,6 +35,15 @@ def load_audit_report(path: Path) -> tuple[dict[str, Any], list[Any]]:
                 "cargo-audit vulnerabilities.count does not match vulnerabilities.list"
             )
     return document, findings
+
+
+def load_audit_report(path: Path) -> tuple[dict[str, Any], list[Any]]:
+    """Load cargo-audit JSON and return the document and validated finding list."""
+    try:
+        raw_json = path.read_bytes()
+    except FileNotFoundError as error:
+        raise ValueError(f"cargo-audit output is missing: {path}") from error
+    return parse_audit_report(raw_json)
 
 
 def classify(path: Path) -> tuple[str, int]:

--- a/scripts/ci/classify_security_audit.py
+++ b/scripts/ci/classify_security_audit.py
@@ -6,11 +6,11 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import TextIO
+from typing import Any, TextIO
 
 
-def classify(path: Path) -> tuple[str, int]:
-    """Return the issue decision and finding count for cargo-audit JSON."""
+def load_audit_report(path: Path) -> tuple[dict[str, Any], list[Any]]:
+    """Load cargo-audit JSON and return the document and validated finding list."""
     try:
         document = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError as error:
@@ -36,6 +36,13 @@ def classify(path: Path) -> tuple[str, int]:
             raise ValueError(
                 "cargo-audit vulnerabilities.count does not match vulnerabilities.list"
             )
+    return document, findings
+
+
+def classify(path: Path) -> tuple[str, int]:
+    """Return the issue decision and finding count for cargo-audit JSON."""
+    _document, findings = load_audit_report(path)
+    count = len(findings)
     return ("create_or_update" if count else "no_action", count)
 
 

--- a/scripts/ci/generate_security_receipt.py
+++ b/scripts/ci/generate_security_receipt.py
@@ -1,0 +1,400 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Generate and validate deterministic normalized cargo-audit evidence v2."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from classify_security_audit import load_audit_report
+
+SCHEMA_VERSION = "2.0"
+SCAN_TYPES = frozenset({"pr-gate", "weekly-scan", "manual"})
+STATES = frozenset({"clean", "findings", "tool_error"})
+SEVERITIES = ("critical", "high", "medium", "low", "unknown")
+SEVERITY_SET = frozenset(SEVERITIES)
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+ADVISORY_PATTERN = re.compile(r"^RUSTSEC-\d{4}-\d{4}$")
+
+
+def _require_object(value: object, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    return value
+
+
+def _require_string(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} must be a non-empty string")
+    return value
+
+
+def _require_integer(value: object, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or not 0 <= value <= 255:
+        raise ValueError(f"{label} must be an integer between 0 and 255")
+    return value
+
+
+def _require_exact_keys(
+    value: dict[str, Any], required: set[str], optional: set[str], label: str
+) -> None:
+    missing = sorted(required - value.keys())
+    unknown = sorted(value.keys() - required - optional)
+    if missing:
+        raise ValueError(f"{label} is missing required fields: {', '.join(missing)}")
+    if unknown:
+        raise ValueError(f"{label} contains unknown fields: {', '.join(unknown)}")
+
+
+def _normalize_finding(raw: object, index: int) -> dict[str, Any]:
+    finding = _require_object(raw, f"cargo-audit finding {index}")
+    advisory = _require_object(
+        finding.get("advisory"), f"cargo-audit finding {index}.advisory"
+    )
+    package = _require_object(
+        finding.get("package"), f"cargo-audit finding {index}.package"
+    )
+    versions_value = finding.get("versions", {})
+    versions = _require_object(versions_value, f"cargo-audit finding {index}.versions")
+
+    advisory_id = _require_string(
+        advisory.get("id"), f"cargo-audit finding {index}.advisory.id"
+    )
+    if ADVISORY_PATTERN.fullmatch(advisory_id) is None:
+        raise ValueError(f"cargo-audit finding {index}.advisory.id is invalid")
+
+    severity_value = advisory.get("severity")
+    if severity_value is None:
+        severity = "unknown"
+    elif isinstance(severity_value, str) and severity_value in SEVERITY_SET:
+        severity = severity_value
+    else:
+        raise ValueError(
+            f"cargo-audit finding {index}.advisory.severity is unsupported"
+        )
+
+    normalized: dict[str, Any] = {
+        "advisory_id": advisory_id,
+        "package": {
+            "name": _require_string(
+                package.get("name"), f"cargo-audit finding {index}.package.name"
+            ),
+            "version": _require_string(
+                package.get("version"),
+                f"cargo-audit finding {index}.package.version",
+            ),
+        },
+        "severity": severity,
+    }
+
+    for key in ("title", "url"):
+        if key in advisory:
+            normalized[key] = _require_string(
+                advisory[key], f"cargo-audit finding {index}.advisory.{key}"
+            )
+
+    patched = versions.get("patched", [])
+    if not isinstance(patched, list) or not all(
+        isinstance(version, str) and version for version in patched
+    ):
+        raise ValueError(
+            f"cargo-audit finding {index}.versions.patched must be an array of non-empty strings"
+        )
+    normalized["patched_versions"] = patched
+    return normalized
+
+
+def _canonical_digest(value: object) -> str:
+    canonical = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _receipt_identity(identity: dict[str, Any], scanner: dict[str, Any]) -> str:
+    material = {
+        "schema_version": SCHEMA_VERSION,
+        "identity": identity,
+        "scanner": scanner,
+    }
+    return f"sha256:{_canonical_digest(material)}"
+
+
+def generate_receipt(
+    audit_path: Path,
+    *,
+    commit_sha: str,
+    scan_type: str,
+    workflow_run_id: str,
+    cargo_audit_version: str,
+    audit_exit_code: int,
+) -> dict[str, Any]:
+    """Generate a deterministic normalized receipt from explicit scan identity."""
+    if COMMIT_PATTERN.fullmatch(commit_sha) is None:
+        raise ValueError(
+            "commit_sha must be exactly 40 lowercase hexadecimal characters"
+        )
+    if not isinstance(scan_type, str) or scan_type not in SCAN_TYPES:
+        raise ValueError(f"scan_type must be one of: {', '.join(sorted(SCAN_TYPES))}")
+    _require_string(workflow_run_id, "workflow_run_id")
+    _require_string(cargo_audit_version, "cargo_audit_version")
+    _require_integer(audit_exit_code, "audit_exit_code")
+
+    raw_bytes = audit_path.read_bytes()
+    _document, raw_findings = load_audit_report(audit_path)
+    findings = [
+        _normalize_finding(raw_finding, index)
+        for index, raw_finding in enumerate(raw_findings)
+    ]
+
+    by_severity = {severity: 0 for severity in SEVERITIES}
+    for finding in findings:
+        by_severity[finding["severity"]] += 1
+
+    if findings:
+        state = "findings"
+    elif audit_exit_code == 0:
+        state = "clean"
+    else:
+        state = "tool_error"
+
+    identity = {
+        "commit_sha": commit_sha,
+        "scan_type": scan_type,
+        "workflow_run_id": workflow_run_id,
+        "raw_audit_sha256": hashlib.sha256(raw_bytes).hexdigest(),
+    }
+    scanner = {
+        "name": "cargo-audit",
+        "version": cargo_audit_version,
+        "exit_code": audit_exit_code,
+    }
+    receipt = {
+        "schema_version": SCHEMA_VERSION,
+        "receipt_id": _receipt_identity(identity, scanner),
+        "identity": identity,
+        "scanner": scanner,
+        "outcome": {
+            "state": state,
+            "finding_count": len(findings),
+            "by_severity": by_severity,
+        },
+        "findings": findings,
+    }
+    validate_receipt(receipt)
+    return receipt
+
+
+def validate_receipt(receipt: object) -> None:
+    """Fail closed when a normalized v2 receipt violates its closed contract."""
+    root = _require_object(receipt, "receipt")
+    _require_exact_keys(
+        root,
+        {"schema_version", "receipt_id", "identity", "scanner", "outcome", "findings"},
+        set(),
+        "receipt",
+    )
+    if root["schema_version"] != SCHEMA_VERSION:
+        raise ValueError(f"unsupported schema_version: {root['schema_version']!r}")
+
+    identity = _require_object(root["identity"], "receipt.identity")
+    _require_exact_keys(
+        identity,
+        {"commit_sha", "scan_type", "workflow_run_id", "raw_audit_sha256"},
+        set(),
+        "receipt.identity",
+    )
+    commit_sha = _require_string(identity["commit_sha"], "receipt.identity.commit_sha")
+    if COMMIT_PATTERN.fullmatch(commit_sha) is None:
+        raise ValueError("receipt.identity.commit_sha is invalid")
+    if (
+        not isinstance(identity["scan_type"], str)
+        or identity["scan_type"] not in SCAN_TYPES
+    ):
+        raise ValueError("receipt.identity.scan_type is unsupported")
+    _require_string(identity["workflow_run_id"], "receipt.identity.workflow_run_id")
+    raw_digest = _require_string(
+        identity["raw_audit_sha256"], "receipt.identity.raw_audit_sha256"
+    )
+    if SHA256_PATTERN.fullmatch(raw_digest) is None:
+        raise ValueError("receipt.identity.raw_audit_sha256 is invalid")
+
+    scanner = _require_object(root["scanner"], "receipt.scanner")
+    _require_exact_keys(
+        scanner, {"name", "version", "exit_code"}, set(), "receipt.scanner"
+    )
+    if scanner["name"] != "cargo-audit":
+        raise ValueError("receipt.scanner.name must be cargo-audit")
+    _require_string(scanner["version"], "receipt.scanner.version")
+    exit_code = _require_integer(scanner["exit_code"], "receipt.scanner.exit_code")
+
+    receipt_id = _require_string(root["receipt_id"], "receipt.receipt_id")
+    if receipt_id != _receipt_identity(identity, scanner):
+        raise ValueError("receipt.receipt_id does not match its identity inputs")
+
+    findings_value = root["findings"]
+    if not isinstance(findings_value, list):
+        raise ValueError("receipt.findings must be an array")
+    findings = findings_value
+    computed_severity = {severity: 0 for severity in SEVERITIES}
+    for index, raw_finding in enumerate(findings):
+        finding = _require_object(raw_finding, f"receipt.findings[{index}]")
+        _require_exact_keys(
+            finding,
+            {"advisory_id", "package", "severity", "patched_versions"},
+            {"title", "url"},
+            f"receipt.findings[{index}]",
+        )
+        advisory_id = _require_string(
+            finding["advisory_id"], f"receipt.findings[{index}].advisory_id"
+        )
+        if ADVISORY_PATTERN.fullmatch(advisory_id) is None:
+            raise ValueError(f"receipt.findings[{index}].advisory_id is invalid")
+        package = _require_object(
+            finding["package"], f"receipt.findings[{index}].package"
+        )
+        _require_exact_keys(
+            package,
+            {"name", "version"},
+            set(),
+            f"receipt.findings[{index}].package",
+        )
+        _require_string(package["name"], f"receipt.findings[{index}].package.name")
+        _require_string(
+            package["version"], f"receipt.findings[{index}].package.version"
+        )
+        severity = finding["severity"]
+        if not isinstance(severity, str) or severity not in SEVERITY_SET:
+            raise ValueError(f"receipt.findings[{index}].severity is unsupported")
+        computed_severity[severity] += 1
+        patched = finding["patched_versions"]
+        if not isinstance(patched, list) or not all(
+            isinstance(version, str) and version for version in patched
+        ):
+            raise ValueError(
+                f"receipt.findings[{index}].patched_versions must be an array of non-empty strings"
+            )
+        for key in ("title", "url"):
+            if key in finding:
+                value = _require_string(
+                    finding[key], f"receipt.findings[{index}].{key}"
+                )
+                if key == "url":
+                    parsed = urlparse(value)
+                    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+                        raise ValueError(f"receipt.findings[{index}].url is invalid")
+
+    outcome = _require_object(root["outcome"], "receipt.outcome")
+    _require_exact_keys(
+        outcome,
+        {"state", "finding_count", "by_severity"},
+        set(),
+        "receipt.outcome",
+    )
+    state = outcome["state"]
+    if not isinstance(state, str) or state not in STATES:
+        raise ValueError("receipt.outcome.state is unsupported")
+    finding_count = outcome["finding_count"]
+    if not isinstance(finding_count, int) or isinstance(finding_count, bool):
+        raise ValueError("receipt.outcome.finding_count must be an integer")
+    if finding_count != len(findings):
+        raise ValueError(
+            "receipt.outcome.finding_count does not match receipt.findings"
+        )
+    by_severity = _require_object(outcome["by_severity"], "receipt.outcome.by_severity")
+    _require_exact_keys(
+        by_severity, set(SEVERITIES), set(), "receipt.outcome.by_severity"
+    )
+    for severity in SEVERITIES:
+        value = by_severity[severity]
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise ValueError(
+                f"receipt.outcome.by_severity.{severity} must be a non-negative integer"
+            )
+    if by_severity != computed_severity:
+        raise ValueError("receipt.outcome.by_severity does not match receipt.findings")
+
+    expected_state = (
+        "findings" if findings else ("clean" if exit_code == 0 else "tool_error")
+    )
+    if state != expected_state:
+        raise ValueError(
+            "receipt.outcome.state is inconsistent with findings and exit_code"
+        )
+
+
+def _write_atomic(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as output:
+            output.write(content)
+            output.flush()
+            os.fsync(output.fileno())
+        os.replace(temporary, path)
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def _read_receipt(path: Path) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as error:
+        raise ValueError(f"normalized receipt is missing: {path}") from error
+    except json.JSONDecodeError as error:
+        raise ValueError(f"normalized receipt is not valid JSON: {error}") from error
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    generate = subparsers.add_parser("generate")
+    generate.add_argument("audit_json", type=Path)
+    generate.add_argument("--commit-sha", required=True)
+    generate.add_argument("--scan-type", required=True)
+    generate.add_argument("--workflow-run-id", required=True)
+    generate.add_argument("--cargo-audit-version", required=True)
+    generate.add_argument("--audit-exit-code", required=True, type=int)
+    generate.add_argument("--output", type=Path)
+
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("receipt_json", type=Path)
+    args = parser.parse_args()
+
+    try:
+        if args.command == "validate":
+            validate_receipt(_read_receipt(args.receipt_json))
+            print("valid normalized security receipt v2")
+            return 0
+
+        receipt = generate_receipt(
+            args.audit_json,
+            commit_sha=args.commit_sha,
+            scan_type=args.scan_type,
+            workflow_run_id=args.workflow_run_id,
+            cargo_audit_version=args.cargo_audit_version,
+            audit_exit_code=args.audit_exit_code,
+        )
+        content = json.dumps(receipt, indent=2, sort_keys=True) + "\n"
+        if args.output is None:
+            print(content, end="")
+        else:
+            _write_atomic(args.output, content)
+    except (OSError, ValueError) as error:
+        parser.exit(1, f"error: {error}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/generate_security_receipt.py
+++ b/scripts/ci/generate_security_receipt.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
-from classify_security_audit import load_audit_report
+from classify_security_audit import parse_audit_report
 
 SCHEMA_VERSION = "2.0"
 SCAN_TYPES = frozenset({"pr-gate", "weekly-scan", "manual"})
@@ -147,7 +147,7 @@ def generate_receipt(
     _require_integer(audit_exit_code, "audit_exit_code")
 
     raw_bytes = audit_path.read_bytes()
-    _document, raw_findings = load_audit_report(audit_path)
+    _document, raw_findings = parse_audit_report(raw_bytes)
     findings = [
         _normalize_finding(raw_finding, index)
         for index, raw_finding in enumerate(raw_findings)

--- a/scripts/ci/generate_security_receipt.py
+++ b/scripts/ci/generate_security_receipt.py
@@ -346,6 +346,35 @@ def _write_atomic(path: Path, content: str) -> None:
         raise
 
 
+def _reject_output_alias(audit_path: Path, output_path: Path) -> None:
+    """Reject filesystem-semantic aliases before raw evidence can be replaced."""
+    try:
+        canonical_audit = audit_path.resolve(strict=True)
+    except (OSError, RuntimeError) as error:
+        raise ValueError(
+            f"cannot resolve cargo-audit input identity: {audit_path}: {error}"
+        ) from error
+    try:
+        canonical_output = output_path.resolve(strict=False)
+    except (OSError, RuntimeError) as error:
+        raise ValueError(
+            f"cannot resolve normalized receipt output identity: {output_path}: {error}"
+        ) from error
+
+    aliases = canonical_audit == canonical_output
+    if not aliases and output_path.exists():
+        try:
+            aliases = os.path.samefile(audit_path, output_path)
+        except OSError as error:
+            raise ValueError(
+                f"cannot compare cargo-audit input and receipt output identities: {error}"
+            ) from error
+    if aliases:
+        raise ValueError(
+            "normalized receipt output must not alias the raw cargo-audit input"
+        )
+
+
 def _read_receipt(path: Path) -> object:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
@@ -378,6 +407,8 @@ def main() -> int:
             print("valid normalized security receipt v2")
             return 0
 
+        if args.output is not None:
+            _reject_output_alias(args.audit_json, args.output)
         receipt = generate_receipt(
             args.audit_json,
             commit_sha=args.commit_sha,

--- a/scripts/ci/test_generate_security_receipt.py
+++ b/scripts/ci/test_generate_security_receipt.py
@@ -1,0 +1,277 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Regression tests for normalized security evidence v2."""
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from generate_security_receipt import generate_receipt, validate_receipt
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RAW_ROOT = REPO_ROOT / "tests/fixtures/security-scanning/raw-audit"
+RECEIPT_ROOT = REPO_ROOT / "tests/fixtures/security-scanning/receipts-v2"
+SCHEMA_PATH = REPO_ROOT / "docs/reference/security-receipt-schema-v2.json"
+GENERATOR_PATH = Path(__file__).with_name("generate_security_receipt.py")
+
+CASES = (
+    (
+        "clean",
+        "a" * 40,
+        "pr-gate",
+        "1001",
+        0,
+    ),
+    (
+        "findings",
+        "b" * 40,
+        "weekly-scan",
+        "1002",
+        1,
+    ),
+    (
+        "tool-error",
+        "c" * 40,
+        "manual",
+        "local-tool-error",
+        2,
+    ),
+)
+
+
+def generate_case(case: tuple[str, str, str, str, int]) -> dict[str, object]:
+    name, commit_sha, scan_type, run_id, exit_code = case
+    return generate_receipt(
+        RAW_ROOT / f"{name}.json",
+        commit_sha=commit_sha,
+        scan_type=scan_type,
+        workflow_run_id=run_id,
+        cargo_audit_version="0.21.2",
+        audit_exit_code=exit_code,
+    )
+
+
+class SecurityReceiptV2Tests(unittest.TestCase):
+    def test_generated_documents_match_committed_fixtures_and_repeat(self) -> None:
+        for case in CASES:
+            with self.subTest(case=case[0]):
+                generated = generate_case(case)
+                expected = json.loads(
+                    (RECEIPT_ROOT / f"{case[0]}.json").read_text(encoding="utf-8")
+                )
+                self.assertEqual(generated, expected)
+                self.assertEqual(generate_case(case), generated)
+                validate_receipt(generated)
+
+    def test_findings_preserve_explicit_severity_and_do_not_infer_missing(self) -> None:
+        receipt = generate_case(CASES[1])
+        findings = receipt["findings"]
+        self.assertEqual(
+            [finding["severity"] for finding in findings], ["high", "unknown"]
+        )
+        self.assertEqual(
+            receipt["outcome"]["by_severity"],
+            {"critical": 0, "high": 1, "medium": 0, "low": 0, "unknown": 1},
+        )
+
+    def test_raw_audit_malformed_missing_and_count_mismatch_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            for path, message in (
+                (root / "missing.json", "missing"),
+                (RAW_ROOT / "reject-malformed.json", "not valid JSON"),
+                (RAW_ROOT / "reject-count-mismatch.json", "count does not match"),
+            ):
+                with self.subTest(path=path.name):
+                    with self.assertRaisesRegex((OSError, ValueError), message):
+                        generate_receipt(
+                            path,
+                            commit_sha="d" * 40,
+                            scan_type="manual",
+                            workflow_run_id="reject",
+                            cargo_audit_version="0.21.2",
+                            audit_exit_code=2,
+                        )
+
+    def test_malformed_finding_and_unknown_severity_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "audit.json"
+            path.write_text(
+                json.dumps({"vulnerabilities": {"count": 1, "list": [None]}}),
+                encoding="utf-8",
+            )
+            for invalid_path in (path, RAW_ROOT / "reject-unknown-severity.json"):
+                with self.subTest(path=invalid_path.name):
+                    with self.assertRaises(ValueError):
+                        generate_receipt(
+                            invalid_path,
+                            commit_sha="d" * 40,
+                            scan_type="manual",
+                            workflow_run_id="reject",
+                            cargo_audit_version="0.21.2",
+                            audit_exit_code=1,
+                        )
+
+    def test_invalid_explicit_identity_inputs_fail_closed(self) -> None:
+        valid = {
+            "commit_sha": "d" * 40,
+            "scan_type": "manual",
+            "workflow_run_id": "local",
+            "cargo_audit_version": "0.21.2",
+            "audit_exit_code": 0,
+        }
+        invalid = (
+            {"commit_sha": "D" * 40},
+            {"scan_type": "scheduled"},
+            {"workflow_run_id": ""},
+            {"cargo_audit_version": ""},
+            {"audit_exit_code": -1},
+            {"audit_exit_code": 256},
+        )
+        for override in invalid:
+            with self.subTest(override=override):
+                arguments = valid | override
+                with self.assertRaises(ValueError):
+                    generate_receipt(RAW_ROOT / "clean.json", **arguments)
+
+    def test_validator_rejects_unknown_fields_counts_states_and_identity_drift(
+        self,
+    ) -> None:
+        receipt = generate_case(CASES[1])
+        mutations = []
+        unknown_root = json.loads(
+            (RECEIPT_ROOT / "reject-unknown-field.json").read_text(encoding="utf-8")
+        )
+        mutations.append((unknown_root, "unknown fields"))
+        unknown_nested = copy.deepcopy(receipt)
+        unknown_nested["scanner"]["channel"] = "stable"
+        mutations.append((unknown_nested, "unknown fields"))
+        count_mismatch = copy.deepcopy(receipt)
+        count_mismatch["outcome"]["finding_count"] = 1
+        mutations.append((count_mismatch, "finding_count does not match"))
+        severity_mismatch = copy.deepcopy(receipt)
+        severity_mismatch["outcome"]["by_severity"]["unknown"] = 0
+        mutations.append((severity_mismatch, "by_severity does not match"))
+        invalid_state = copy.deepcopy(receipt)
+        invalid_state["outcome"]["state"] = "success"
+        mutations.append((invalid_state, "state is unsupported"))
+        invalid_version = copy.deepcopy(receipt)
+        invalid_version["schema_version"] = "3.0"
+        mutations.append((invalid_version, "unsupported schema_version"))
+        identity_drift = copy.deepcopy(receipt)
+        identity_drift["identity"]["workflow_run_id"] = "changed"
+        mutations.append((identity_drift, "receipt_id does not match"))
+
+        for mutation, message in mutations:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ValueError, message):
+                    validate_receipt(mutation)
+
+    def test_schema_is_closed_and_matches_generator_enums(self) -> None:
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(schema["properties"]["schema_version"]["const"], "2.0")
+        self.assertFalse(schema["additionalProperties"])
+        self.assertFalse(schema["properties"]["identity"]["additionalProperties"])
+        self.assertFalse(schema["properties"]["scanner"]["additionalProperties"])
+        self.assertFalse(schema["properties"]["outcome"]["additionalProperties"])
+        self.assertFalse(
+            schema["properties"]["outcome"]["properties"]["by_severity"][
+                "additionalProperties"
+            ]
+        )
+        item_schema = schema["properties"]["findings"]["items"]
+        self.assertFalse(item_schema["additionalProperties"])
+        self.assertFalse(item_schema["properties"]["package"]["additionalProperties"])
+        self.assertEqual(
+            set(schema["properties"]["outcome"]["properties"]["state"]["enum"]),
+            {"clean", "findings", "tool_error"},
+        )
+        self.assertEqual(
+            set(item_schema["properties"]["severity"]["enum"]),
+            {"critical", "high", "medium", "low", "unknown"},
+        )
+
+    def test_cli_generates_and_validates_without_publishing(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "receipt.json"
+            generated = subprocess.run(
+                [
+                    sys.executable,
+                    str(GENERATOR_PATH),
+                    "generate",
+                    str(RAW_ROOT / "clean.json"),
+                    "--commit-sha",
+                    "a" * 40,
+                    "--scan-type",
+                    "pr-gate",
+                    "--workflow-run-id",
+                    "1001",
+                    "--cargo-audit-version",
+                    "0.21.2",
+                    "--audit-exit-code",
+                    "0",
+                    "--output",
+                    str(output),
+                ],
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+            self.assertEqual(generated.returncode, 0, generated.stderr)
+            self.assertEqual(
+                json.loads(output.read_text(encoding="utf-8")), generate_case(CASES[0])
+            )
+
+            validated = subprocess.run(
+                [sys.executable, str(GENERATOR_PATH), "validate", str(output)],
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+            self.assertEqual(validated.returncode, 0, validated.stderr)
+            self.assertEqual(
+                validated.stdout.strip(), "valid normalized security receipt v2"
+            )
+
+    def test_cli_failure_does_not_replace_existing_output(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            malformed = root / "malformed.json"
+            malformed.write_text("{not-json", encoding="utf-8")
+            output = root / "receipt.json"
+            output.write_text("existing evidence\n", encoding="utf-8")
+            generated = subprocess.run(
+                [
+                    sys.executable,
+                    str(GENERATOR_PATH),
+                    "generate",
+                    str(malformed),
+                    "--commit-sha",
+                    "d" * 40,
+                    "--scan-type",
+                    "manual",
+                    "--workflow-run-id",
+                    "reject",
+                    "--cargo-audit-version",
+                    "0.21.2",
+                    "--audit-exit-code",
+                    "2",
+                    "--output",
+                    str(output),
+                ],
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+            self.assertNotEqual(generated.returncode, 0)
+            self.assertIn("not valid JSON", generated.stderr)
+            self.assertEqual(output.read_text(encoding="utf-8"), "existing evidence\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test_generate_security_receipt.py
+++ b/scripts/ci/test_generate_security_receipt.py
@@ -4,12 +4,14 @@
 from __future__ import annotations
 
 import copy
+import hashlib
 import json
 import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from generate_security_receipt import generate_receipt, validate_receipt
 
@@ -67,6 +69,38 @@ class SecurityReceiptV2Tests(unittest.TestCase):
                 self.assertEqual(generated, expected)
                 self.assertEqual(generate_case(case), generated)
                 validate_receipt(generated)
+
+    def test_digest_and_findings_bind_the_same_single_read(self) -> None:
+        findings_bytes = (RAW_ROOT / "findings.json").read_bytes()
+        clean_bytes = (RAW_ROOT / "clean.json").read_bytes()
+        original_read_bytes = Path.read_bytes
+
+        with tempfile.TemporaryDirectory() as temporary:
+            audit_path = Path(temporary) / "audit.json"
+            audit_path.write_bytes(findings_bytes)
+
+            def read_then_replace(path: Path) -> bytes:
+                content = original_read_bytes(path)
+                path.write_bytes(clean_bytes)
+                return content
+
+            with patch.object(Path, "read_bytes", autospec=True) as read_bytes:
+                read_bytes.side_effect = read_then_replace
+                receipt = generate_receipt(
+                    audit_path,
+                    commit_sha="e" * 40,
+                    scan_type="manual",
+                    workflow_run_id="single-read",
+                    cargo_audit_version="0.21.2",
+                    audit_exit_code=1,
+                )
+
+            self.assertEqual(read_bytes.call_count, 1)
+            self.assertEqual(receipt["outcome"]["finding_count"], 2)
+            self.assertEqual(
+                receipt["identity"]["raw_audit_sha256"],
+                hashlib.sha256(findings_bytes).hexdigest(),
+            )
 
     def test_findings_preserve_explicit_severity_and_do_not_infer_missing(self) -> None:
         receipt = generate_case(CASES[1])

--- a/scripts/ci/test_generate_security_receipt.py
+++ b/scripts/ci/test_generate_security_receipt.py
@@ -13,6 +13,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+from classify_security_audit import classify
 from generate_security_receipt import generate_receipt, validate_receipt
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -101,6 +102,29 @@ class SecurityReceiptV2Tests(unittest.TestCase):
                 receipt["identity"]["raw_audit_sha256"],
                 hashlib.sha256(findings_bytes).hexdigest(),
             )
+
+    def test_classifier_and_generator_reject_noncanonical_json_encodings(self) -> None:
+        document = '{"vulnerabilities":{"count":0,"list":[]}}'
+        variants = {
+            "utf16": document.encode("utf-16"),
+            "utf8-bom": b"\xef\xbb\xbf" + document.encode("utf-8"),
+        }
+        with tempfile.TemporaryDirectory() as temporary:
+            audit_path = Path(temporary) / "audit.json"
+            for name, content in variants.items():
+                with self.subTest(name=name):
+                    audit_path.write_bytes(content)
+                    with self.assertRaisesRegex(ValueError, "not valid JSON"):
+                        classify(audit_path)
+                    with self.assertRaisesRegex(ValueError, "not valid JSON"):
+                        generate_receipt(
+                            audit_path,
+                            commit_sha="f" * 40,
+                            scan_type="manual",
+                            workflow_run_id="encoding-reject",
+                            cargo_audit_version="0.21.2",
+                            audit_exit_code=0,
+                        )
 
     def test_findings_preserve_explicit_severity_and_do_not_infer_missing(self) -> None:
         receipt = generate_case(CASES[1])

--- a/scripts/ci/test_generate_security_receipt.py
+++ b/scripts/ci/test_generate_security_receipt.py
@@ -272,6 +272,76 @@ class SecurityReceiptV2Tests(unittest.TestCase):
             self.assertIn("not valid JSON", generated.stderr)
             self.assertEqual(output.read_text(encoding="utf-8"), "existing evidence\n")
 
+    def test_cli_rejects_output_aliases_without_mutating_raw_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            raw = root / "audit.json"
+            raw.write_bytes((RAW_ROOT / "clean.json").read_bytes())
+            original = raw.read_bytes()
+            nested = root / "nested"
+            nested.mkdir()
+
+            aliases = (
+                raw,
+                Path("audit.json"),
+                nested / ".." / "audit.json",
+            )
+            for output in aliases:
+                with self.subTest(output=output):
+                    generated = self.run_cli_generate(raw, output, cwd=root)
+                    self.assertNotEqual(generated.returncode, 0)
+                    self.assertIn("must not alias", generated.stderr)
+                    self.assertEqual(raw.read_bytes(), original)
+
+    def test_cli_rejects_symlink_parent_alias_without_mutating_raw_evidence(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            raw = root / "audit.json"
+            raw.write_bytes((RAW_ROOT / "clean.json").read_bytes())
+            original = raw.read_bytes()
+            alias_parent = root / "alias"
+            try:
+                alias_parent.symlink_to(root, target_is_directory=True)
+            except OSError as error:
+                self.skipTest(f"directory symlinks unavailable: {error}")
+
+            generated = self.run_cli_generate(
+                raw, alias_parent / "audit.json", cwd=root
+            )
+            self.assertNotEqual(generated.returncode, 0)
+            self.assertIn("must not alias", generated.stderr)
+            self.assertEqual(raw.read_bytes(), original)
+
+    def run_cli_generate(
+        self, raw: Path, output: Path, *, cwd: Path
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(GENERATOR_PATH),
+                "generate",
+                str(raw),
+                "--commit-sha",
+                "d" * 40,
+                "--scan-type",
+                "manual",
+                "--workflow-run-id",
+                "alias-test",
+                "--cargo-audit-version",
+                "0.21.2",
+                "--audit-exit-code",
+                "0",
+                "--output",
+                str(output),
+            ],
+            capture_output=True,
+            check=False,
+            cwd=cwd,
+            text=True,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/fixtures/security-scanning/raw-audit/clean.json
+++ b/tests/fixtures/security-scanning/raw-audit/clean.json
@@ -1,0 +1,11 @@
+{
+  "database": {
+    "advisory-count": 812,
+    "last-commit": "1111111111111111111111111111111111111111"
+  },
+  "vulnerabilities": {
+    "count": 0,
+    "list": []
+  },
+  "warnings": {}
+}

--- a/tests/fixtures/security-scanning/raw-audit/findings.json
+++ b/tests/fixtures/security-scanning/raw-audit/findings.json
@@ -1,0 +1,45 @@
+{
+  "database": {
+    "advisory-count": 813,
+    "last-commit": "2222222222222222222222222222222222222222"
+  },
+  "vulnerabilities": {
+    "count": 2,
+    "list": [
+      {
+        "advisory": {
+          "id": "RUSTSEC-2025-0001",
+          "title": "Example explicitly classified advisory",
+          "url": "https://rustsec.org/advisories/RUSTSEC-2025-0001",
+          "severity": "high",
+          "cvss": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        },
+        "package": {
+          "name": "example-one",
+          "version": "1.2.3"
+        },
+        "versions": {
+          "patched": [">=1.2.4"]
+        }
+      },
+      {
+        "advisory": {
+          "id": "RUSTSEC-2025-0002",
+          "title": "Example advisory without supplied severity",
+          "url": "https://rustsec.org/advisories/RUSTSEC-2025-0002",
+          "cvss": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        },
+        "package": {
+          "name": "example-two",
+          "version": "4.5.6"
+        },
+        "versions": {
+          "patched": []
+        }
+      }
+    ]
+  },
+  "warnings": {
+    "unmaintained": []
+  }
+}

--- a/tests/fixtures/security-scanning/raw-audit/reject-count-mismatch.json
+++ b/tests/fixtures/security-scanning/raw-audit/reject-count-mismatch.json
@@ -1,0 +1,6 @@
+{
+  "vulnerabilities": {
+    "count": 1,
+    "list": []
+  }
+}

--- a/tests/fixtures/security-scanning/raw-audit/reject-malformed.json
+++ b/tests/fixtures/security-scanning/raw-audit/reject-malformed.json
@@ -1,0 +1,1 @@
+{not-json

--- a/tests/fixtures/security-scanning/raw-audit/reject-unknown-severity.json
+++ b/tests/fixtures/security-scanning/raw-audit/reject-unknown-severity.json
@@ -1,0 +1,17 @@
+{
+  "vulnerabilities": {
+    "count": 1,
+    "list": [
+      {
+        "advisory": {
+          "id": "RUSTSEC-2025-0003",
+          "severity": "urgent"
+        },
+        "package": {
+          "name": "bad-severity",
+          "version": "1.0.0"
+        }
+      }
+    ]
+  }
+}

--- a/tests/fixtures/security-scanning/raw-audit/tool-error.json
+++ b/tests/fixtures/security-scanning/raw-audit/tool-error.json
@@ -1,0 +1,13 @@
+{
+  "database": {
+    "advisory-count": 0,
+    "last-commit": "3333333333333333333333333333333333333333"
+  },
+  "vulnerabilities": {
+    "count": 0,
+    "list": []
+  },
+  "warnings": {
+    "scanner": "terminated before completing the advisory database query"
+  }
+}

--- a/tests/fixtures/security-scanning/receipts-v2/clean.json
+++ b/tests/fixtures/security-scanning/receipts-v2/clean.json
@@ -1,0 +1,27 @@
+{
+  "findings": [],
+  "identity": {
+    "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "raw_audit_sha256": "dbd75addd7942025af01c7e755b6262bcce33825cb8b5339083afe4f0a6ef79e",
+    "scan_type": "pr-gate",
+    "workflow_run_id": "1001"
+  },
+  "outcome": {
+    "by_severity": {
+      "critical": 0,
+      "high": 0,
+      "low": 0,
+      "medium": 0,
+      "unknown": 0
+    },
+    "finding_count": 0,
+    "state": "clean"
+  },
+  "receipt_id": "sha256:2cb95f62c81522664cfe90f19048dc3731824766bee342d53cb12fc5a847cd8d",
+  "scanner": {
+    "exit_code": 0,
+    "name": "cargo-audit",
+    "version": "0.21.2"
+  },
+  "schema_version": "2.0"
+}

--- a/tests/fixtures/security-scanning/receipts-v2/findings.json
+++ b/tests/fixtures/security-scanning/receipts-v2/findings.json
@@ -1,0 +1,52 @@
+{
+  "findings": [
+    {
+      "advisory_id": "RUSTSEC-2025-0001",
+      "package": {
+        "name": "example-one",
+        "version": "1.2.3"
+      },
+      "patched_versions": [
+        ">=1.2.4"
+      ],
+      "severity": "high",
+      "title": "Example explicitly classified advisory",
+      "url": "https://rustsec.org/advisories/RUSTSEC-2025-0001"
+    },
+    {
+      "advisory_id": "RUSTSEC-2025-0002",
+      "package": {
+        "name": "example-two",
+        "version": "4.5.6"
+      },
+      "patched_versions": [],
+      "severity": "unknown",
+      "title": "Example advisory without supplied severity",
+      "url": "https://rustsec.org/advisories/RUSTSEC-2025-0002"
+    }
+  ],
+  "identity": {
+    "commit_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "raw_audit_sha256": "18d14a9cac5d937bfe87a0184545b155a59603eb5bf5a2f5b0b14670096ee6f8",
+    "scan_type": "weekly-scan",
+    "workflow_run_id": "1002"
+  },
+  "outcome": {
+    "by_severity": {
+      "critical": 0,
+      "high": 1,
+      "low": 0,
+      "medium": 0,
+      "unknown": 1
+    },
+    "finding_count": 2,
+    "state": "findings"
+  },
+  "receipt_id": "sha256:bc374430d07493a058cdcc44695467d45e6f52bbcf6fa0977599c705d1d812fd",
+  "scanner": {
+    "exit_code": 1,
+    "name": "cargo-audit",
+    "version": "0.21.2"
+  },
+  "schema_version": "2.0"
+}

--- a/tests/fixtures/security-scanning/receipts-v2/reject-unknown-field.json
+++ b/tests/fixtures/security-scanning/receipts-v2/reject-unknown-field.json
@@ -1,0 +1,28 @@
+{
+  "certified": true,
+  "findings": [],
+  "identity": {
+    "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "raw_audit_sha256": "dbd75addd7942025af01c7e755b6262bcce33825cb8b5339083afe4f0a6ef79e",
+    "scan_type": "pr-gate",
+    "workflow_run_id": "1001"
+  },
+  "outcome": {
+    "by_severity": {
+      "critical": 0,
+      "high": 0,
+      "low": 0,
+      "medium": 0,
+      "unknown": 0
+    },
+    "finding_count": 0,
+    "state": "clean"
+  },
+  "receipt_id": "sha256:2cb95f62c81522664cfe90f19048dc3731824766bee342d53cb12fc5a847cd8d",
+  "scanner": {
+    "exit_code": 0,
+    "name": "cargo-audit",
+    "version": "0.21.2"
+  },
+  "schema_version": "2.0"
+}

--- a/tests/fixtures/security-scanning/receipts-v2/tool-error.json
+++ b/tests/fixtures/security-scanning/receipts-v2/tool-error.json
@@ -1,0 +1,27 @@
+{
+  "findings": [],
+  "identity": {
+    "commit_sha": "cccccccccccccccccccccccccccccccccccccccc",
+    "raw_audit_sha256": "fca1c20902c26a476327b72a1936d3287b72efef8c988af32969294eb31c1812",
+    "scan_type": "manual",
+    "workflow_run_id": "local-tool-error"
+  },
+  "outcome": {
+    "by_severity": {
+      "critical": 0,
+      "high": 0,
+      "low": 0,
+      "medium": 0,
+      "unknown": 0
+    },
+    "finding_count": 0,
+    "state": "tool_error"
+  },
+  "receipt_id": "sha256:62e99b0bf7410571321a2ec0bd729b4511363857001368a3a2df2441ba04ca1c",
+  "scanner": {
+    "exit_code": 2,
+    "name": "cargo-audit",
+    "version": "0.21.2"
+  },
+  "schema_version": "2.0"
+}


### PR DESCRIPTION
<!-- SPDX-License-Identifier: AGPL-3.0-or-later --> # Pull Request  ## Summary  Add the first bounded #761 implementation slice: a separate normalized security-evidence v2 contract plus an offline deterministic generator/validator. The generator reuses the weekly classifier's existing fail-closed cargo-audit parser, reads raw evidence once so the SHA-256 and normalized findings bind the same bytes, binds output to explicit scan identity, and never infers severity from CVSS when RustSec does not supply a named severity.  The existing v1 schema and all workflows remain unchanged.  ## Type of Change  - [x] Feature (new functionality) - [ ] Bugfix (fixes an issue) - [ ] Refactor (code improvement without behavior change) - [ ] Performance (optimization) - [x] Documentation (schema contract only) - [x] Tests (test additions or improvements) - [ ] CI/CD (workflow or tooling changes) - [ ] Chore (dependencies, formatting, etc.)  ## COBOL/Mainframe Context  - **COBOL features affected**: None - **Data processing impact**: None; offline dependency-scan evidence only - **Mainframe compatibility**: Unchanged  ## Workspace Crates Affected  No shipped or workspace crate is changed. This PR touches only the v2 JSON Schema, offline Python control-plane scripts, and security-scanning fixtures.  ## Checklist  - [x] Tests added/updated - [x] Documentation updated (new standalone v2 JSON Schema) - [x] CHANGELOG.md N/A (no shipped user-facing behavior) - [x] Python formatting and lint pass with Ruff - [x] Existing v1 security integration remains green - [x] Follows conventional commit format - [x] MSRV compliance N/A (no Rust/dependency change) - [x] Golden fixtures updated (new additive v2 accept/reject fixtures only)  ## Testing Instructions  ```text PASS python -m unittest test_classify_security_audit.py test_generate_security_receipt.py -v (21/21) PASS ruff check (classifier, generator, and both test modules) PASS ruff format --check (same four modules) PASS JSON parsing for the v2 schema and all three accepted receipt fixtures PASS cargo test -p copybook-bench --test issue_35_security_scanning_integration (18 passed, 2 ignored) PASS cargo test -p xtask docs_verify (61/61) PASS cargo run -p xtask -- docs verify-record-pipeline (11 scenarios; digest f022c6852eaf8e4e26c477a75a703666df367db4057f178318143a9a589a9fa2) PASS git diff --check NOT PROVEN cargo run -p xtask -- docs verify-all as a combined gate: isolated worktree has no target/nextest junit.xml; its stable-error and record-pipeline subchecks passed before that prerequisite failure was reported NOT RUN external draft-07 metaschema validation: check-jsonschema and Python jsonschema are unavailable locally; dependency-free tests assert schema closure/enums and generator-validator fixture parity NOT RUN hosted receipt generation or workflow publication (intentionally outside this PR) ```  Accept fixtures cover clean, findings, and structurally valid tool-error evidence. Reject fixtures/tests cover missing and malformed raw input, UTF-16 and UTF-8 BOM encodings rejected consistently by classifier and generator, declared-count mismatch, malformed findings, unsupported severity, invalid explicit identity, unknown normalized fields, count/severity/state drift, unsupported schema versions, receipt-ID drift, failure-safe output preservation, mutation after the single raw read without digest/finding divergence, and exact/relative/`..`/symlink-parent output aliases without raw-input mutation.  ## Performance Impact  - [x] No runtime performance impact expected  ## Infrastructure/Tooling Changes  **Areas modified:**  - [x] Additive offline security-evidence generator/validator - [x] Additive normalized receipt v2 schema and fixtures  The deterministic `receipt_id` identifies the explicit identity and scanner tuple. The identity includes exact commit, scan context, run identity, and raw cargo-audit SHA-256; it is not authentication or a digest of the normalized outcome/findings body. Schema validation establishes shape, while `validate_receipt` (or an equivalent semantic validator) is required for aggregate parity. Outcome states are closed to `clean`, `findings`, and `tool_error`; severity is closed to `critical`, `high`, `medium`, `low`, and `unknown`.  ## Breaking Changes  - [x] No breaking changes  ## Related Issues  Closes #799  Relates to #761  ## Additional Notes  Claim boundary: this PR defines and locally proves an offline normalized evidence format. It does not publish an artifact, change a gate or vulnerability-response policy, alter weekly issue lifecycle (#763), certify security or regulatory compliance, or migrate/remove v1 compatibility fields. Workflow adoption and hosted exact-head artifact proof remain future #761 slices. General concurrent symlink/path-swap TOCTOU hardening is outside this offline, non-privileged invocation; named severity is preserved only when explicitly present, and missing severity remains `unknown` without CVSS inference.   <!-- This is an auto-generated comment: release notes by coderabbit.ai -->  ## Summary by CodeRabbit  - **New Features**   - Added version 2.0 security receipts for normalized cargo-audit results.   - Receipts include scan metadata, deterministic identities, severity totals, outcomes, and structured vulnerability findings.   - Added commands to generate and validate receipts from audit reports.   - Added strict validation for malformed data, unsupported values, inconsistent counts, invalid URLs, and unexpected fields.   - Added atomic output handling to preserve existing receipt files when generation fails.  - **Bug Fixes**   - Audit finding counts are now derived from validated vulnerability data for more reliable results.  <!-- end of auto-generated comment: release notes by coderabbit.ai -->