### PR TITLE
test(security): pin receipt fixtures to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 *.sh text eol=lf
 tools/copybook-bench/test_fixtures/external_input/*.bin binary
 tools/copybook-bench/test_fixtures/external_input/*.cpy text eol=lf
+tests/fixtures/security-scanning/raw-audit/*.json text eol=lf

--- a/scripts/ci/test_generate_security_receipt.py
+++ b/scripts/ci/test_generate_security_receipt.py
@@ -105,34 +105,39 @@ class SecurityReceiptV2Tests(unittest.TestCase):
 
     def test_raw_audit_digest_preserves_canonical_lf_byte_identity(self) -> None:
         lf_bytes = (RAW_ROOT / "clean.json").read_bytes()
-        self.assertNotIn(b"\r\n", lf_bytes)
-        crlf_bytes = lf_bytes.replace(b"\n", b"\r\n")
+        self.assertNotIn(b"\r", lf_bytes)
+        variants = {
+            "crlf": lf_bytes.replace(b"\n", b"\r\n"),
+            "lone-cr": lf_bytes.replace(b"\n", b"\r"),
+        }
+        canonical = generate_case(CASES[0])
 
         with tempfile.TemporaryDirectory() as temporary:
-            crlf_path = Path(temporary) / "clean-crlf.json"
-            crlf_path.write_bytes(crlf_bytes)
-            canonical = generate_case(CASES[0])
-            crlf = generate_receipt(
-                crlf_path,
-                commit_sha="a" * 40,
-                scan_type="pr-gate",
-                workflow_run_id="1001",
-                cargo_audit_version="0.21.2",
-                audit_exit_code=0,
-            )
+            for name, content in variants.items():
+                with self.subTest(name=name):
+                    variant_path = Path(temporary) / f"clean-{name}.json"
+                    variant_path.write_bytes(content)
+                    variant = generate_receipt(
+                        variant_path,
+                        commit_sha="a" * 40,
+                        scan_type="pr-gate",
+                        workflow_run_id="1001",
+                        cargo_audit_version="0.21.2",
+                        audit_exit_code=0,
+                    )
+                    self.assertEqual(canonical["outcome"], variant["outcome"])
+                    self.assertEqual(
+                        variant["identity"]["raw_audit_sha256"],
+                        hashlib.sha256(content).hexdigest(),
+                    )
+                    self.assertNotEqual(
+                        canonical["identity"]["raw_audit_sha256"],
+                        variant["identity"]["raw_audit_sha256"],
+                    )
 
-        self.assertEqual(canonical["outcome"], crlf["outcome"])
         self.assertEqual(
             canonical["identity"]["raw_audit_sha256"],
             hashlib.sha256(lf_bytes).hexdigest(),
-        )
-        self.assertEqual(
-            crlf["identity"]["raw_audit_sha256"],
-            hashlib.sha256(crlf_bytes).hexdigest(),
-        )
-        self.assertNotEqual(
-            canonical["identity"]["raw_audit_sha256"],
-            crlf["identity"]["raw_audit_sha256"],
         )
 
     def test_classifier_and_generator_reject_noncanonical_json_encodings(self) -> None:

--- a/scripts/ci/test_generate_security_receipt.py
+++ b/scripts/ci/test_generate_security_receipt.py
@@ -103,6 +103,38 @@ class SecurityReceiptV2Tests(unittest.TestCase):
                 hashlib.sha256(findings_bytes).hexdigest(),
             )
 
+    def test_raw_audit_digest_preserves_canonical_lf_byte_identity(self) -> None:
+        lf_bytes = (RAW_ROOT / "clean.json").read_bytes()
+        self.assertNotIn(b"\r\n", lf_bytes)
+        crlf_bytes = lf_bytes.replace(b"\n", b"\r\n")
+
+        with tempfile.TemporaryDirectory() as temporary:
+            crlf_path = Path(temporary) / "clean-crlf.json"
+            crlf_path.write_bytes(crlf_bytes)
+            canonical = generate_case(CASES[0])
+            crlf = generate_receipt(
+                crlf_path,
+                commit_sha="a" * 40,
+                scan_type="pr-gate",
+                workflow_run_id="1001",
+                cargo_audit_version="0.21.2",
+                audit_exit_code=0,
+            )
+
+        self.assertEqual(canonical["outcome"], crlf["outcome"])
+        self.assertEqual(
+            canonical["identity"]["raw_audit_sha256"],
+            hashlib.sha256(lf_bytes).hexdigest(),
+        )
+        self.assertEqual(
+            crlf["identity"]["raw_audit_sha256"],
+            hashlib.sha256(crlf_bytes).hexdigest(),
+        )
+        self.assertNotEqual(
+            canonical["identity"]["raw_audit_sha256"],
+            crlf["identity"]["raw_audit_sha256"],
+        )
+
     def test_classifier_and_generator_reject_noncanonical_json_encodings(self) -> None:
         document = '{"vulnerabilities":{"count":0,"list":[]}}'
         variants = {


### PR DESCRIPTION
<!-- SPDX-License-Identifier: AGPL-3.0-or-later --> # Pull Request  ## Summary  Fix the Windows-only post-merge proof failure from #800 by pinning only normalized-receipt raw audit fixtures to LF. Add a focused exact-byte identity witness: the checked-in LF fixture reproduces committed receipt identities, while explicit CRLF and lone-CR inputs remain valid JSON and intentionally produce different `raw_audit_sha256` values.  No generator, schema, workflow, v1, or security-policy semantics change.  ## Type of Change  - [ ] Feature (new functionality) - [x] Bugfix (fixes an issue) - [ ] Refactor (code improvement without behavior change) - [ ] Performance (optimization) - [ ] Documentation - [x] Tests (test additions or improvements) - [ ] CI/CD - [ ] Chore  ## COBOL/Mainframe Context  - **COBOL features affected**: None - **Data processing impact**: None; test fixture byte identity only - **Mainframe compatibility**: Unchanged  ## Workspace Crates Affected  No shipped crate changes. The diff is limited to `.gitattributes` and the offline receipt v2 Python test module.  ## Checklist  - [x] Tests added/updated - [x] Documentation N/A (no public contract change) - [x] CHANGELOG.md N/A - [x] Python formatting and lint pass - [x] Existing v1 security integration remains green - [x] Follows conventional commit format - [x] MSRV compliance N/A  ## Testing Instructions  ```text PASS fresh Windows checkout git ls-files --eol: all raw receipt fixtures i/lf w/lf attr/text eol=lf PASS python -m unittest test_classify_security_audit.py test_generate_security_receipt.py -v (22/22) PASS ruff check and ruff format --check (classifier, generator, both test modules) PASS JSON parsing for the unchanged v2 schema PASS cargo test -p copybook-bench --test issue_35_security_scanning_integration (18 passed, 2 ignored) PASS cargo test -p xtask docs_verify (61/61) PASS cargo run -p xtask -- docs verify-record-pipeline (11 scenarios; digest f022c6852eaf8e4e26c477a75a703666df367db4057f178318143a9a589a9fa2) PASS git diff --check NOT RUN external draft-07 metaschema validation (unchanged schema; tool unavailable locally) ```  The new witness proves canonical LF checkout bytes and explicit CRLF/lone-CR inputs have equal parsed outcomes but distinct exact raw SHA-256 identities.  ## Performance Impact  - [x] No runtime performance impact  ## Infrastructure/Tooling Changes  **Areas modified:**  - [x] Fixture-specific Git EOL policy - [x] Offline receipt regression coverage  ## Breaking Changes  - [x] No breaking changes  ## Related Issues  Closes #801  Relates to #761  Follow-up to #800  ## Additional Notes  Claim boundary: this fixes deterministic test-fixture byte identity across Windows and Linux. It does not normalize user-provided raw audit evidence, change v2 receipt semantics, publish artifacts, alter v1/workflows, or address #763 lifecycle.  <!-- This is an auto-generated comment: release notes by coderabbit.ai -->  ## Summary by CodeRabbit  * **Bug Fixes**   * Improved consistency when processing security audit files with different line-ending formats.   * Ensured equivalent audit results produce consistent normalized receipts.  * **Tests**   * Added regression coverage verifying byte-level digest handling across LF and CRLF line endings.  <!-- end of auto-generated comment: release notes by coderabbit.ai -->